### PR TITLE
Fix #44 - fix bad CWOPS CWT Exchange message when starting without .i…

### DIFF
--- a/Main.pas
+++ b/Main.pas
@@ -912,6 +912,8 @@ begin
         sbar.Align:= alBottom;
         sbar.Visible:= true;
         sbar.Font.Color := clRed;
+        ExchangeEdit.Text := AExchange;
+        exit;
       end
     else
       begin
@@ -1002,7 +1004,8 @@ begin
   ExchangeField2Type := AExchType2;
 
   // Set my exchange value (from INI file)
-  SetMyExchange(Ini.UserExchangeTbl[SimContest]);
+  // UI assumes uppercase only, so convert .ini files to uppercase.
+  SetMyExchange(UpperCase(Ini.UserExchangeTbl[SimContest]));
 end;
 
 procedure TMainForm.SetMyExch1(const AExchType: TExchange1Type;


### PR DESCRIPTION
…ni file.
The problem occurs when lowercase letters end up in the `MorseRunner.ini` file due to manual editing or by adding an Operator name in the `Settings > HST/CWOPS Operator` menu pick. This string is passed to the UI which is expecting uppercase letters only. Now these strings are converted to uppercase before being passed to the UI for validation.