### PR TITLE
Quarterly project Roadmap update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ but not in a coordinated manner.
 
 In this project, Morse Runner will be enhanced to support multiple contests along with combining
 features and bug fixes from various independent development efforts.
-Initial contests will include ARRL Field Day, CQ WW, CWOPS CWT, NCJ NAQP, etc.
+Initial contests will include ARRL Field Day, CQ WPX, CWOPS CWT, NCJ NAQP, etc.
 Any contest with a corresponding call history file could be implemented.
 
 ## Goals
@@ -39,16 +39,7 @@ Please refer to [CONTRIBUTING.md](.github/CONTRIBUTING.md) for more information.
 ## Roadmap
 Below is a high-level overview of project activities over the next year.
 
-Now (active) | Next (planned, this fall) | Later (future, next year)
--------------|----------------|---------------
-**Community...**<br>Launch Community Repository | Foster Community Growth | Investigate using GitHub project boards for this roadmap
-Develop Community Guidelines | Trial team-based contest development model | Promote team-based contest development model
-**Development...**:<br>Standardize git setup | Multi-contest design | Multi-contest implementation
-Invite prior authors;<br>Solicit early feedback | Merge selected features and bug fixes [from prior authors](#morse-runner-release-history) | Maintain existing integration with N1MM and DxLog
-**Contests...**<br>FD, CWT, WPX, NAQP, HST | CQWW, Sweepstakes?, others... | Perhaps IARU/HF, All Asia, IOTA, ...<br>(based on community input/suggestions)
-**Releases...**<br>FD prototype (v1.80) | v1.8x (based on FD prototype) | v2.0 (based on new design)
-
-### Roadmap - Additional details
+### Roadmap - Completed
 
 ***Complete - Spring 2022 (Apr-June)***
 - [x] **Develop FD prototype** - Build a FD prototype building upon work from
@@ -59,7 +50,7 @@ Contests include CQ WPX, CWOPS CWT, ARRL FD, NCJ NAQP, and HST.
 Contest is selected using a drop-down list.
 This prototype was shared with a few individuals in early June.
 
-***Now - Summer 2022 (July-Sept)***
+***Complete - Summer 2022 (July-Sept)***
 Projects we are currently working on...
 - [x] **Develop Community Guidelines** - Discuss and adopt community guidelines
 for contributing to this project, including roles, code of conduct, best practices, guidelines,
@@ -70,21 +61,21 @@ most major development projects/branches by various MR authors.
 Over time portions these projects, including individual features and bug fixes,
 can be independently extracted and merged into a common development branch.
 
-- [ ] **Invite prior authors** - Invite all known MR authors to join and contribute
+- [x] **Invite prior authors** - Invite all known MR authors to join and contribute
 to this effort.
 Encourage them to at least connect as a "Watcher" of this project and share any
 personal knowledge they may have with this project.
 
-- [ ] **Standardize git setup** - Resolve git setup issues with CRLF caused by different git
-setups on individual computers and git setups. Document recommended setup for future work.
+- [x] **Standardize git setup** - Resolve git setup issues with CRLF caused by different git
+setups on individual computers and git setups. Perform git database normalization so all files across all projects are handled in a consistent manner.
 Document this issue so other developers can understand avoid this issue.
 
-- [ ] **N1MM Integration Design Discussions** - Work with Steve, N2IC, to discuss extensions to N1MM-to-MorseRunner protocol to support additional contests (e.g. Arrl Field Day). This is a feasibility study only and will not be released until early spring 2023.
-
-- [ ] **Release FD prototype (v1.80)** - Release the FD prototype to allow others to see the
+- [x] **Release FD prototype (v1.80)** - Release the FD prototype to allow others to see the
 general direction of the project and solicit early feedback. Release expected late September 2022.
 
-***Next - Fall 2022 (Oct-Dec)***
+### Roadmap - Now, Next, and Future
+
+***Now - Fall 2022 (Oct-Dec)***
 Projects we will work on next...
 
 - [ ] **Solicit early feedback** - Invite users to try the FD prototype and provide
@@ -98,26 +89,35 @@ community documentation, including README.md, CONTRIBUTING.md, etc., files.
 Once complete, we will reach out to various user communities
 (e.g. N1MM forums, and perhaps specific clubs).
 
+- [ ] **Document git setup** - Document a recommended git setup to avoid issues with CRLF caused by different git
+setups on individual computers and git setups.
+Document this issue so other developers can understand avoid this issue.
+
+- [ ] **N1MM Integration Design Discussions** - Work with Steve, N2IC, to discuss extensions to N1MM-to-MorseRunner protocol to support additional contests (e.g. Arrl Field Day). This is a feasibility study only and will not be released until early spring 2023.
+
 - [ ] **Multi-contest design** - Discuss the design approach for supporting multiple
 contests within Morse Runner based on FD prototype.
 Look for patterns across multiple contests and propose interface(s) to be used
 to generalize an individual contest.
 
-- [ ] **Add a few more contests** -
-Implement one or two more popular contests.
-Consider adding ARRL Sweepstakes; however this one might be a little harder since
+- [ ] **Add CQ WW Contest** - simple contest with RST and CQ-Zone.
+
+- [ ] **Add ARRL Sweepstakes** - Consider adding ARRL Sweepstakes; however this one might be a little harder since
 it has a complex exchange.
 
-***Later - 1st Half 2023 (Jan-June)***
-
-Projects that we'll work on later...
-- [ ] **Merge selected features and bug fixes** - Identify and integrate features from
-[other MR branches](#morse-runner-release-history) into the main release branch.
-
+***Next - Winter 2023 (Jan-Mar)***
 - [ ] **Team-based (developer/advocate) contest development model** - promote the notion of a small contest development team consisting of a developer and one or more user/advocates.
 This team will develop and test an individual contest before it is released for general use.
 Please review Issues pages for contest recommendations and add a comment to your favorite contests. Also mention if you're interested in either an advocate or developer role for this contest. As a point of reference, adding the NAQP contest to the FD prototype codebase was completed in one afternoon.
 
+- [ ] **Add a few more contests** - Implement one or two more popular contests based on community input.
+
+- [ ] **Merge selected features and bug fixes** - Identify and integrate features from
+[other MR branches](#morse-runner-release-history) into the main release branch.
+
+***Later - 1st Half 2023 (Apr-June)***
+
+Projects that we'll work on later...
 - [ ] **Multi-contest implementation** - finish the initial implementation of the
 multi-contest codebase. Major interfaces are developed and running. Contests are
 added by extending these interfaces only. Most switch states in code have been removed.

--- a/README.md
+++ b/README.md
@@ -39,43 +39,9 @@ Please refer to [CONTRIBUTING.md](.github/CONTRIBUTING.md) for more information.
 ## Roadmap
 Below is a high-level overview of project activities over the next year.
 
-### Roadmap - Completed
-
-***Complete - Spring 2022 (Apr-June)***
-- [x] **Develop FD prototype** - Build a FD prototype building upon work from
-[prior authors](#morse-runner-release-history).
-The approach taken introduces a table-driven
-design along with the notion of generalized exchange fields (e.g Exch1=3A, Exch2=OR).
-Contests include CQ WPX, CWOPS CWT, ARRL FD, NCJ NAQP, and HST.
-Contest is selected using a drop-down list.
-This prototype was shared with a few individuals in early June.
-
-***Complete - Summer 2022 (July-Sept)***
-Projects we are currently working on...
-- [x] **Develop Community Guidelines** - Discuss and adopt community guidelines
-for contributing to this project, including roles, code of conduct, best practices, guidelines,
-expectations, adherence to standards, etc.
-
-- [x] **Launch Community Repository** - Create a single repository containing
-most major development projects/branches by various MR authors.
-Over time portions these projects, including individual features and bug fixes,
-can be independently extracted and merged into a common development branch.
-
-- [x] **Invite prior authors** - Invite all known MR authors to join and contribute
-to this effort.
-Encourage them to at least connect as a "Watcher" of this project and share any
-personal knowledge they may have with this project.
-
-- [x] **Standardize git setup** - Resolve git setup issues with CRLF caused by different git
-setups on individual computers and git setups. Perform git database normalization so all files across all projects are handled in a consistent manner.
-Document this issue so other developers can understand avoid this issue.
-
-- [x] **Release FD prototype (v1.80)** - Release the FD prototype to allow others to see the
-general direction of the project and solicit early feedback. Release expected late September 2022.
-
 ### Roadmap - Now, Next, and Future
 
-***Now - Fall 2022 (Oct-Dec)***
+#### Now - Fall 2022 (Oct-Dec)
 Projects we will work on next...
 
 - [ ] **Solicit early feedback** - Invite users to try the FD prototype and provide
@@ -105,7 +71,7 @@ to generalize an individual contest.
 - [ ] **Add ARRL Sweepstakes** - Consider adding ARRL Sweepstakes; however this one might be a little harder since
 it has a complex exchange.
 
-***Next - Winter 2023 (Jan-Mar)***
+#### Next - Winter 2023 (Jan-Mar)
 - [ ] **Team-based (developer/advocate) contest development model** - promote the notion of a small contest development team consisting of a developer and one or more user/advocates.
 This team will develop and test an individual contest before it is released for general use.
 Please review Issues pages for contest recommendations and add a comment to your favorite contests. Also mention if you're interested in either an advocate or developer role for this contest. As a point of reference, adding the NAQP contest to the FD prototype codebase was completed in one afternoon.
@@ -115,7 +81,7 @@ Please review Issues pages for contest recommendations and add a comment to your
 - [ ] **Merge selected features and bug fixes** - Identify and integrate features from
 [other MR branches](#morse-runner-release-history) into the main release branch.
 
-***Later - 1st Half 2023 (Apr-June)***
+#### Later - 1st Half 2023 (Apr-June)
 
 Projects that we'll work on later...
 - [ ] **Multi-contest implementation** - finish the initial implementation of the
@@ -131,7 +97,7 @@ popular logging programs.
 Perhaps adding a contest will need two people, a contest developer and a contest advocate.
 This team can develop and test a contest before releasing to general use.
 
-***Future***
+#### Future
 - [ ] **Project Wiki** - Explore idea of developing a project wiki containing additional
 project details, including recommended setups (both developer and user),
 design discussions, compile instructions, coding standards, release criteria, etc.
@@ -139,6 +105,40 @@ This will also include details on adding a new contest to Morse Runner.
 Is this implemented within github or elsewhere?
 
 - [ ] **User-defined contests** - Explore notion of user-defined contests using a contest configuration file. Perhaps a yaml file? Can this be similar to N1MM contest definition file?
+
+### Roadmap - Completed
+
+#### Complete - Spring 2022 (Apr-June)
+- [x] **Develop FD prototype** - Build a FD prototype building upon work from
+[prior authors](#morse-runner-release-history).
+The approach taken introduces a table-driven
+design along with the notion of generalized exchange fields (e.g Exch1=3A, Exch2=OR).
+Contests include CQ WPX, CWOPS CWT, ARRL FD, NCJ NAQP, and HST.
+Contest is selected using a drop-down list.
+This prototype was shared with a few individuals in early June.
+
+#### Complete - Summer 2022 (July-Sept)
+Projects we are currently working on...
+- [x] **Develop Community Guidelines** - Discuss and adopt community guidelines
+for contributing to this project, including roles, code of conduct, best practices, guidelines,
+expectations, adherence to standards, etc.
+
+- [x] **Launch Community Repository** - Create a single repository containing
+most major development projects/branches by various MR authors.
+Over time portions these projects, including individual features and bug fixes,
+can be independently extracted and merged into a common development branch.
+
+- [x] **Invite prior authors** - Invite all known MR authors to join and contribute
+to this effort.
+Encourage them to at least connect as a "Watcher" of this project and share any
+personal knowledge they may have with this project.
+
+- [x] **Standardize git setup** - Resolve git setup issues with CRLF caused by different git
+setups on individual computers and git setups. Perform git database normalization so all files across all projects are handled in a consistent manner.
+Document this issue so other developers can understand avoid this issue.
+
+- [x] **Release FD prototype (v1.80)** - Release the FD prototype to allow others to see the
+general direction of the project and solicit early feedback. Release expected late September 2022.
 
 # History
 TODO - add a paragraph or two regarding the history of MR.


### PR DESCRIPTION
- Update the quarterly Roadmap before sending out the invite to prior authors.
- remove the Roadmap table. This was too difficult to maintain.