### PR TITLE
Fix #59 - The 'Help > Web Page' now directs to the GitHub home page

### DIFF
--- a/Main.pas
+++ b/Main.pas
@@ -1713,7 +1713,7 @@ end;
 
 procedure TMainForm.WebPage1Click(Sender: TObject);
 begin
-  OpenWebPage('http://www.dxatlas.com/MorseRunner');
+  OpenWebPage('https://www.github.com/w7sst/MorseRunner#readme');
 end;
 
 


### PR DESCRIPTION
The menu pick `Help > Web Page` now redirects to our GitHub Morse Runner Runner Community Edition home page.