### PR TITLE
Issue #60 - Restore missing Help About dialog (Coded by W7SST)

### DIFF
--- a/Main.dfm
+++ b/Main.dfm
@@ -1495,14 +1495,14 @@ object MainForm: TMainForm
         OnClick = WebPage1Click
       end
       object Readme1: TMenuItem
-        Caption = 'Readme...'
+        Caption = 'Readme'
         OnClick = Readme1Click
       end
       object N2: TMenuItem
         Caption = '-'
       end
       object About1: TMenuItem
-        Caption = 'About...'
+        Caption = 'About Morse Runner'
         OnClick = About1Click
       end
     end

--- a/Main.pas
+++ b/Main.pas
@@ -1243,13 +1243,16 @@ end;
 
 procedure TMainForm.About1Click(Sender: TObject);
 const
-    Msg= 'CW CONTEST SIMULATOR'#13#13 +
-        'Copyright ©2004-2016 Alex Shovkoplyas, VE3NEA'#13#13 +
-        've3nea@dxatlas.com'#13#13 +
-        'Rebuild by BG4FQD. bg4fqd@gmail.com 20160712';
+    Msg= //'Morse Runner - Community Edition'#13 +
+        'CW CONTEST SIMULATOR'#13#13 +
+        'Version %s'#13#13 +
+        'Copyright ©2004-2016 Alex Shovkoplyas, VE3NEA'#13 +
+        'Copyright ©2022 Morse Runner Community Edition Contributors'#13#13 +
+        'https://www.github.com/w7sst/MorseRunner';
 begin
-    //Application.MessageBox(Msg, 'Morse Runner', MB_OK or MB_ICONINFORMATION);
-    PopupScoreWpx;
+    Application.MessageBox(PChar(Format(Msg, [sVersion])),
+      'About Morse Runner - Community Edition',
+      MB_OK or MB_ICONINFORMATION);
 end;          
 
 


### PR DESCRIPTION
The Help About dialog has been restored.
- restores missing Help About dialog
- rename menu item from "Help | About..." to "Help | About Morse Runner"
- rename menu item from "Help | Readme..." to "Help | Readme"