### PR TITLE
Introduce class hierarchy to support common Contest behaviors

### DIFF
--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -31,6 +31,7 @@ public
   procedure LoadCallHistory(const AUserCallsign : string); override;
 
   function PickStation(): integer; override;
+  procedure DropStation(id : integer); override;
   function GetCall(id : integer): string; override; // returns station callsign
   procedure GetExchange(id : integer; out station : TDxStation); override;
 
@@ -115,6 +116,13 @@ end;
 function TArrlFieldDay.PickStation(): integer;
 begin
      result := random(FdCallList.Count);
+end;
+
+
+procedure TArrlFieldDay.DropStation(id : integer);
+begin
+  assert(id < FdCallList.Count);
+  FdCallList.Delete(id);
 end;
 
 

--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -28,7 +28,7 @@ private
 public
   constructor Create;
   destructor Destroy; override;
-  procedure LoadCallHistory(const AUserCallsign : string); override;
+  function LoadCallHistory(const AUserCallsign : string) : boolean; override;
 
   function PickStation(): integer; override;
   procedure DropStation(id : integer); override;
@@ -51,7 +51,7 @@ implementation
 uses
   SysUtils, Classes, Log, PerlRegEx, pcre, ARRL;
 
-procedure TArrlFieldDay.LoadCallHistory(const AUserCallsign : string);
+function TArrlFieldDay.LoadCallHistory(const AUserCallsign : string) : boolean;
 const
   DelimitChar: char = ',';
 var
@@ -59,6 +59,11 @@ var
   i: integer;
   rec: TFdCallRec;
 begin
+  // reload call history iff user's callsign has changed.
+  Result := not HasUserCallsignChanged(AUserCallsign);
+  if Result then
+    Exit;
+
   slst:= TStringList.Create;
   tl:= TStringList.Create;
   tl.Delimiter := DelimitChar;
@@ -90,6 +95,10 @@ begin
           FdCallList.Add(rec);
       end;
     end;
+
+    // retain user's callsign after successful load
+    SetUserCallsign(AUserCallsign);
+    Result := True;
 
   finally
     slst.Free;

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -24,6 +24,7 @@ type
     procedure LoadCallHistory(const AUserCallsign : string); override;
 
     function PickStation(): integer; override;
+    procedure DropStation(id : integer); override;
     function GetCall(id : integer): string; override;
     procedure GetExchange(id : integer; out station : TDxStation); override;
 
@@ -96,6 +97,13 @@ end;
 function TCWOPS.PickStation(): integer;
 begin
      result := random(CWOPSList.Count);
+end;
+
+
+procedure TCWOPS.DropStation(id : integer);
+begin
+  assert(id < CWOPSList.Count);
+  CWOPSList.Delete(id);
 end;
 
 

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -21,7 +21,7 @@ type
   public
     constructor Create;
     destructor Destroy; override;
-    procedure LoadCallHistory(const AUserCallsign : string); override;
+    function LoadCallHistory(const AUserCallsign : string) : boolean; override;
 
     function PickStation(): integer; override;
     procedure DropStation(id : integer); override;
@@ -40,16 +40,23 @@ implementation
 uses
     SysUtils, Log;
 
-procedure TCWOPS.LoadCallHistory(const AUserCallsign : string);
+function TCWOPS.LoadCallHistory(const AUserCallsign : string) : boolean;
 var
     slst, tl: TStringList;
     i: integer;
     CWO: TCWOPSRec;
 begin
+    // reload call history iff user's callsign has changed.
+    Result := not HasUserCallsignChanged(AUserCallsign);
+    if Result then
+      Exit;
+
     slst:= TStringList.Create;
     tl:= TStringList.Create;
+
     try
         CWOPSList.Clear;
+
         slst.LoadFromFile(ParamStr(1) + 'CWOPS.LIST');
         slst.Sort;
 
@@ -72,6 +79,10 @@ begin
 
             end;
         end;
+
+        // retain user's callsign after successful load
+        SetUserCallsign(AUserCallsign);
+        Result := True;
 
     finally
         slst.Free;

--- a/CallLst.pas
+++ b/CallLst.pas
@@ -8,22 +8,34 @@ unit CallLst;
 interface
 
 uses
-  SysUtils, Classes, Ini;
+  Classes;
 
-procedure LoadCallList;
-function PickCall: string;
+type
+  // simple calllist. contains a TStringList of callsigns.
+  TCallList = class
+  protected
+    Calls: TStringList;
 
-var
-  Calls: TStringList;
+  public
+    constructor Create;
+    destructor Destroy;
+    procedure LoadCallList;
+    function PickCall : string;
+  end;
+
 
 implementation
+
+uses
+  SysUtils, Ini;
 
 function CompareCalls(Item1, Item2: Pointer): Integer;
 begin
   Result := StrComp(PChar(Item1), PChar(Item2));
 end;
 
-procedure LoadCallList;
+// reads callsigns from Master.dta file
+procedure TCallList.LoadCallList;
 const
   Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/';
   CHRCOUNT = Length(Chars);
@@ -89,7 +101,8 @@ begin
 end;
 
 
-function PickCall: string;
+// returns a single callsign
+function TCallList.PickCall : string;
 var
   Idx: integer;
 begin
@@ -106,11 +119,16 @@ begin
 end;
 
 
-initialization
+constructor TCallList.Create;
+begin
   Calls := TStringList.Create;
+end;
 
-finalization
+destructor TCallList.Destroy;
+begin
   Calls.Free;
+end;
+
 
 end.
 

--- a/CallLst.pas
+++ b/CallLst.pas
@@ -20,6 +20,7 @@ type
     constructor Create;
     destructor Destroy; override;
     procedure LoadCallList;
+    procedure Clear();
     function PickCall : string;
   end;
 
@@ -101,6 +102,12 @@ begin
 end;
 
 
+procedure TCallList.Clear();
+begin
+  Calls.Clear;
+end;
+
+
 // returns a single callsign
 function TCallList.PickCall : string;
 var
@@ -126,6 +133,7 @@ end;
 
 destructor TCallList.Destroy;
 begin
+  Calls.Clear;
   Calls.Free;
 end;
 

--- a/CallLst.pas
+++ b/CallLst.pas
@@ -18,7 +18,7 @@ type
 
   public
     constructor Create;
-    destructor Destroy;
+    destructor Destroy; override;
     procedure LoadCallList;
     function PickCall : string;
   end;

--- a/Contest.pas
+++ b/Contest.pas
@@ -14,10 +14,16 @@ uses
 type
   TContest = class
   private
+    UserCallsign : String;  // used by LoadCallHistory() to minimize reloads
+
     function DxCount: integer;
     procedure SwapFilters;
+
   protected
     constructor Create;
+    function HasUserCallsignChanged(const AUserCallsign : String) : boolean;
+    procedure SetUserCallsign(const AUserCallsign : String);
+
   public
     BlockNumber: integer;
     Me: TMyStation;
@@ -30,7 +36,7 @@ type
 
     destructor Destroy; override;
     procedure Init;
-    procedure LoadCallHistory(const AUserCallsign : string); virtual; abstract;
+    function LoadCallHistory(const AHomeCallsign : string) : boolean; virtual; abstract;
 
     function PickStation : integer; virtual; abstract;
     procedure DropStation(id : integer); virtual; abstract;
@@ -90,6 +96,7 @@ begin
   Agc.HoldSamples := 155;
   Agc.AgcEnabled := true;
   NoActivityCnt :=0;
+  UserCallsign := '';
 
   Init;
 end;
@@ -112,6 +119,21 @@ begin
   Me.Init;
   Stations.Clear;
   BlockNumber := 0;
+  UserCallsign := '';
+end;
+
+
+{ return whether to call history file is valid based on user's callsign. }
+function TContest.HasUserCallsignChanged(const AUserCallsign : string) : boolean;
+begin
+  // user's home callsign is required to load this contest.
+  Result := (not AUserCallsign.IsEmpty) and (UserCallsign <> AUserCallsign);
+end;
+
+
+procedure TContest.SetUserCallsign(const AUserCallsign : String);
+begin
+  UserCallsign := AUserCallsign;
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -33,6 +33,7 @@ type
     procedure LoadCallHistory(const AUserCallsign : string); virtual;
 
     function PickStation : integer; virtual;
+    procedure DropStation(id : integer); virtual;
     function GetCall(id : integer) : string; virtual;
     procedure GetExchange(id : integer; out station : TDxStation); virtual;
     function GetStationInfo(const ACallsign : string) : string; virtual;
@@ -123,6 +124,11 @@ function TContest.PickStation : integer;
 begin
   assert(false, 'PickStation should be overriden');
   Result := -1;
+end;
+
+
+procedure TContest.DropStation(id : integer);
+begin
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -30,12 +30,12 @@ type
 
     destructor Destroy; override;
     procedure Init;
-    procedure LoadCallHistory(const AUserCallsign : string); virtual;
+    procedure LoadCallHistory(const AUserCallsign : string); virtual; abstract;
 
-    function PickStation : integer; virtual;
-    procedure DropStation(id : integer); virtual;
-    function GetCall(id : integer) : string; virtual;
-    procedure GetExchange(id : integer; out station : TDxStation); virtual;
+    function PickStation : integer; virtual; abstract;
+    procedure DropStation(id : integer); virtual; abstract;
+    function GetCall(id : integer) : string; virtual; abstract;
+    procedure GetExchange(id : integer; out station : TDxStation); virtual; abstract;
     function GetStationInfo(const ACallsign : string) : string; virtual;
     function PickCallOnly : string;
 
@@ -112,36 +112,6 @@ begin
   Me.Init;
   Stations.Clear;
   BlockNumber := 0;
-end;
-
-
-procedure TContest.LoadCallHistory(const AUserCallsign : string);
-begin
-end;
-
-
-function TContest.PickStation : integer;
-begin
-  assert(false, 'PickStation should be overriden');
-  Result := -1;
-end;
-
-
-procedure TContest.DropStation(id : integer);
-begin
-end;
-
-
-function TContest.GetCall(id : integer) : string;
-begin
-  assert(false, 'GetCall should be overriden');
-  Result := '';
-end;
-
-
-procedure TContest.GetExchange(id : integer; out station : TDxStation);
-begin
-  assert(false, 'PickStation should be overriden');
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -16,6 +16,8 @@ type
   private
     function DxCount: integer;
     procedure SwapFilters;
+  protected
+    constructor Create;
   public
     BlockNumber: integer;
     Me: TMyStation;
@@ -26,7 +28,6 @@ type
     RitPhase: Single;
     FStopPressed: boolean;
 
-    constructor Create;
     destructor Destroy; override;
     procedure Init;
     procedure LoadCallHistory(const AUserCallsign : string); virtual;
@@ -35,6 +36,7 @@ type
     function GetCall(id : integer) : string; virtual;
     procedure GetExchange(id : integer; out station : TDxStation); virtual;
     function GetStationInfo(const ACallsign : string) : string; virtual;
+    function PickCallOnly : string;
 
     function GetSentExchTypes(
       const AStationKind : TStationKind;
@@ -114,30 +116,26 @@ end;
 
 procedure TContest.LoadCallHistory(const AUserCallsign : string);
 begin
-  assert(SimContest in [scWpx, scHst]);
-  if SimContest in [scWPX, scHst] then
-    CallLst.LoadCallList;   // loads Master.dta (p/o CQ WPX Contest)
 end;
 
 
 function TContest.PickStation : integer;
 begin
-  assert(SimContest in [scWpx, scHst], 'PickStation should be overriden');
+  assert(false, 'PickStation should be overriden');
   Result := -1;
 end;
 
 
 function TContest.GetCall(id : integer) : string;
 begin
-  assert(SimContest in [scWpx, scHst]);
-  Result := CallLst.PickCall;
+  assert(false, 'GetCall should be overriden');
+  Result := '';
 end;
 
 
 procedure TContest.GetExchange(id : integer; out station : TDxStation);
 begin
-  assert(SimContest in [scWpx, scHst]);
-  station.NR := station.Oper.GetNR;
+  assert(false, 'PickStation should be overriden');
 end;
 
 
@@ -150,6 +148,16 @@ end;
 function TContest.GetStationInfo(const ACallsign : string) : string;
 begin
   Result := gDXCCList.Search(ACallsign);
+end;
+
+
+// helper function to return only a callsign (used by QrnStation)
+function TContest.PickCallOnly : string;
+var
+  id : integer;
+begin
+  id := PickStation;
+  Result := GetCall(id);
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -29,6 +29,13 @@ type
     constructor Create;
     destructor Destroy; override;
     procedure Init;
+    procedure LoadCallHistory(const AUserCallsign : string); virtual;
+
+    function PickStation : integer; virtual;
+    function GetCall(id : integer) : string; virtual;
+    procedure GetExchange(id : integer; out station : TDxStation); virtual;
+    function GetStationInfo(const ACallsign : string) : string; virtual;
+
     function GetSentExchTypes(
       const AStationKind : TStationKind;
       const AMyCallsign : string) : TExchTypes;
@@ -49,7 +56,7 @@ var
 implementation
 
 uses
-  Main;
+  Main, CallLst, ARRL;
 
 { TContest }
 
@@ -102,6 +109,47 @@ begin
   Me.Init;
   Stations.Clear;
   BlockNumber := 0;
+end;
+
+
+procedure TContest.LoadCallHistory(const AUserCallsign : string);
+begin
+  assert(SimContest in [scWpx, scHst]);
+  if SimContest in [scWPX, scHst] then
+    CallLst.LoadCallList;   // loads Master.dta (p/o CQ WPX Contest)
+end;
+
+
+function TContest.PickStation : integer;
+begin
+  assert(SimContest in [scWpx, scHst], 'PickStation should be overriden');
+  Result := -1;
+end;
+
+
+function TContest.GetCall(id : integer) : string;
+begin
+  assert(SimContest in [scWpx, scHst]);
+  Result := CallLst.PickCall;
+end;
+
+
+procedure TContest.GetExchange(id : integer; out station : TDxStation);
+begin
+  assert(SimContest in [scWpx, scHst]);
+  station.NR := station.Oper.GetNR;
+end;
+
+
+{
+  GetStationInfo() returns station's DXCC information.
+
+  Adding a contest: UpdateSbar - update status bar with station info (e.g. FD shows UserText)
+  Override as needed for each contest.
+}
+function TContest.GetStationInfo(const ACallsign : string) : string;
+begin
+  Result := gDXCCList.Search(ACallsign);
 end;
 
 

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -30,6 +30,7 @@ public
   procedure LoadCallHistory(const AUserCallsign : string); override;
 
   function PickStation(): integer; override;
+  procedure DropStation(id : integer); override;
   function GetCall(id:integer): string; override;     // returns station callsign
   procedure GetExchange(id : integer; out station : TDxStation); override;
 
@@ -107,6 +108,13 @@ end;
 function TCqWw.PickStation(): integer;
 begin
      result := random(CqWwCallList.Count);
+end;
+
+
+procedure TCqWw.DropStation(id : integer);
+begin
+  assert(id < CqWwCallList.Count);
+  CqWwCallList.Delete(id);
 end;
 
 

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -27,7 +27,7 @@ private
 public
   constructor Create;
   destructor Destroy; override;
-  procedure LoadCallHistory(const AUserCallsign : string); override;
+  function LoadCallHistory(const AUserCallsign : string) : Boolean; override;
 
   function PickStation(): integer; override;
   procedure DropStation(id : integer); override;
@@ -47,7 +47,7 @@ implementation
 uses
   SysUtils, Classes, log, ARRL;
 
-procedure TCqWw.LoadCallHistory(const AUserCallsign : string);
+function TCqWw.LoadCallHistory(const AUserCallsign : string) : boolean;
 const
   DelimitChar: char = ',';
 var
@@ -55,6 +55,11 @@ var
   i: integer;
   rec: TCqWwCallRec;
 begin
+  // reload call history iff user's callsign has changed.
+  Result := not HasUserCallsignChanged(AUserCallsign);
+  if Result then
+    Exit;
+
   slst:= TStringList.Create;
   tl:= TStringList.Create;
   tl.Delimiter := DelimitChar;
@@ -82,6 +87,10 @@ begin
           CqWwCallList.Add(rec);
       end;
     end;
+
+    // retain user's callsign after successful load
+    SetUserCallsign(AUserCallsign);
+    Result := True;
 
   finally
     slst.Free;

--- a/CqWpx.pas
+++ b/CqWpx.pas
@@ -18,7 +18,7 @@ private
 public
   constructor Create;
   destructor Destroy; override;
-  procedure LoadCallHistory(const AUserCallsign : string); override;
+  function LoadCallHistory(const AUserCallsign : string) : boolean; override;
 
   function PickStation(): integer; override;
   procedure DropStation(id : integer); override;
@@ -38,9 +38,18 @@ implementation
 uses
   SysUtils, Classes, log, ARRL;
 
-procedure TCqWpx.LoadCallHistory(const AUserCallsign : string);
+function TCqWpx.LoadCallHistory(const AUserCallsign : string) : boolean;
 begin
+  // reload call history iff user's callsign has changed.
+  Result := not HasUserCallsignChanged(AUserCallsign);
+  if Result then
+    Exit;
+
   CallLst.LoadCallList;
+
+  // retain user's callsign after successful load
+  SetUserCallsign(AUserCallsign);
+  Result := True;
 end;
 
 

--- a/CqWpx.pas
+++ b/CqWpx.pas
@@ -1,0 +1,112 @@
+unit CQWPX;
+
+{$ifdef FPC}
+{$MODE Delphi}
+{$endif}
+
+interface
+
+uses
+  Contest, CallLst, DxStn;
+
+type
+TCqWpx = class(TContest)
+private
+  // CQ Wpx Contest uses the global Calls variable (see CallLst.pas)
+  CallLst : TCallList;
+
+public
+  constructor Create;
+  destructor Destroy; override;
+  procedure LoadCallHistory(const AUserCallsign : string); override;
+
+  function PickStation(): integer; override;
+  function GetCall(id:integer): string; override;     // returns station callsign
+  procedure GetExchange(id : integer; out station : TDxStation); override;
+
+  function getExch1(id:integer): string;    // returns RST (e.g. 5NN)
+  function getExch2(id:integer): string;    // returns section info (e.g. 3)
+  {function getZone(id:integer): string;     // returns CQZone (e.g. 3)
+  function FindCallRec(out fdrec: TCqWpxCallRec; const ACall: string): Boolean;
+  }
+  function GetStationInfo(const ACallsign: string) : string; override;
+end;
+
+implementation
+
+uses
+  SysUtils, Classes, log, ARRL;
+
+procedure TCqWpx.LoadCallHistory(const AUserCallsign : string);
+begin
+  CallLst.LoadCallList;
+end;
+
+
+constructor TCqWpx.Create;
+begin
+  inherited Create;
+  CallLst := TCallList.Create;
+end;
+
+
+destructor TCqWpx.Destroy;
+begin
+  CallLst.Free;
+  inherited;
+end;
+
+
+function TCqWpx.PickStation(): integer;
+begin
+  Result := -1;
+end;
+
+
+// return status bar information string from DXCC data file.
+// the callsign, Entity and Continent are returned.
+// this string is used in MainForm.sbar.Caption (status bar).
+// Format:  '<call> - Entity/Continent'
+function TCqWpx.GetStationInfo(const ACallsign: string) : string;
+var
+  dxrec : TDXCCRec;
+begin
+  dxrec := nil;
+  Result := '';
+
+  // find caller's Continent/Entity
+  if gDXCCList.FindRec(dxrec, ACallsign) then
+    Result := Format('%s - %s/%s', [ACallsign, dxRec.Continent, dxRec.Entity]);
+end;
+
+
+function TCqWpx.GetCall(id : integer): string;     // returns station callsign
+begin
+  Result := CallLst.PickCall;
+end;
+
+
+procedure TCqWpx.GetExchange(id : integer; out station : TDxStation);
+begin
+  station.Exch1 := getExch1(station.Operid);  // RST
+  station.NR := station.Oper.GetNR;           // serial number
+end;
+
+
+
+function TCqWpx.getExch1(id:integer): string;    // returns RST (e.g. 5NN)
+begin
+  result := '599';
+end;
+
+
+function TCqWpx.getExch2(id:integer): string;    // returns serial number (e.g. 3)
+begin
+  Result := '1';
+end;
+
+
+end.
+
+
+

--- a/CqWpx.pas
+++ b/CqWpx.pas
@@ -21,6 +21,7 @@ public
   procedure LoadCallHistory(const AUserCallsign : string); override;
 
   function PickStation(): integer; override;
+  procedure DropStation(id : integer); override;
   function GetCall(id:integer): string; override;     // returns station callsign
   procedure GetExchange(id : integer; out station : TDxStation); override;
 
@@ -60,6 +61,12 @@ end;
 function TCqWpx.PickStation(): integer;
 begin
   Result := -1;
+end;
+
+
+procedure TCqWpx.DropStation(id : integer);
+begin
+  // already deleted by GetCall
 end;
 
 

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -74,6 +74,12 @@ begin
   Amplitude := 9000 + 18000 * (1 + RndUShaped);
   Pitch := Round(RndGaussLim(0, 300));
 
+  if Ini.RunMode = rmHst then
+    begin
+      Tst.DropStation(Operid);
+      Operid := -1;
+    end;
+
   //the MeSent event will follow immediately
   TimeOut := NEVER;
   State := stCopying;

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -8,9 +8,7 @@ unit DxStn;
 interface
 
 uses
-  SysUtils, Classes, Station, RndFunc, Dialogs, Ini, ARRLFD, NAQP, CWOPS,
-  CQWW,
-  CallLst, Qsb, DxOper, Log, SndTypes;
+  Station, Qsb, DxOper, SndTypes;
 
 type
   TDxStation = class(TStation)
@@ -32,7 +30,8 @@ type
 implementation
 
 uses
-  Contest;
+  SysUtils, Classes, RndFunc, Dialogs,
+  CallLst, Log, Ini, Contest;
 
 { TDxStation }
 
@@ -41,27 +40,10 @@ begin
   inherited Create(nil);
 
   HisCall := Ini.Call;
-  // Adding a contest: DxStation.CreateStation - load a random callsign
-  case SimContest of
-    scCwt: begin
-       Operid := CWOPSCWT.getcwopsid();
-       MyCall :=  CWOPSCWT.getcwopscall(Operid);
-    end;
-    scFieldDay: begin
-       Operid := gARRLFD.pickStation();
-       MyCall := gARRLFD.getCall(Operid);
-    end;
-    scNaQp: begin
-       Operid := gNAQP.pickStation();
-       MyCall := gNAQP.getCall(Operid);
-    end;
-    scCQWW: begin
-       Operid := gCQWW.pickStation();
-       MyCall := gCQWW.getCall(Operid);
-    end
-    else
-       MyCall := PickCall;     // Pick one Callsign from Calllist
-  end;
+
+  // Pick one Callsign from call history file
+  Operid := Tst.PickStation;
+  MyCall := Tst.GetCall(Operid);
 
   Oper := TDxOperator.Create;
   Oper.Call := MyCall;
@@ -75,30 +57,8 @@ begin
   SentExchTypes := Tst.GetSentExchTypes(skDxStation, MyCall);
 
   // Adding a contest: DxStation.CreateStation - get Exch1 (e.g. Name), Exch2 (e.g. NR), and optional UserText
-  case SimContest of
-    scCwt: begin
-      OpName := CWOPSCWT.getcwopsname(Operid);
-      NR :=  CWOPSCWT.getcwopsnum(Operid);
-    end;
-    scFieldDay: begin
-      Exch1 := gARRLFD.getExch1(Operid);
-      Exch2 := gARRLFD.getExch2(Operid);
-      UserText := gARRLFD.getUserText(Operid);
-    end;
-    scNaQp: begin
-      Exch1 := gNAQP.getExch1(Operid);
-      OpName := Exch1; // TODO - refactor etOpName to use Exch1
-      Exch2 := gNAQP.getExch2(Operid);
-      UserText := gNAQP.getUserText(Operid);
-    end;
-    scCQWW: begin
-      Exch2 := gCQWW.getExch2(Operid);
-      NR := StrToInt(gCQWW.getExch2(Operid));
-    end
-    else
-      NR := Oper.GetNR;
-  end;
-  //showmessage(MyCall);
+  // load dynamic exchange field information into this DxStation.
+  Tst.GetExchange(Operid, Self);
 
   if Ini.Lids and (Random < 0.03) then
     RST := 559 + 10 * Random(4)

--- a/Ini.pas
+++ b/Ini.pas
@@ -243,7 +243,6 @@ begin
         begin V := 3; WriteInteger(SEC_SYS, 'BufSize', V); end;
       V := Max(1, Min(5, V));
       BufSize := 64 shl V;
-      // Tst.Filt{,2}.SamplesInInput: set in TContest.Create & TMainForm.SetContest
 
       V := ReadInteger(SEC_STN, 'SelfMonVolume', 0);
       MainForm.VolumeSlider1.Value := V / 80 + 0.75;

--- a/Ini.pas
+++ b/Ini.pas
@@ -199,9 +199,11 @@ begin
       ArrlClass := ReadString(SEC_STN, 'ArrlClass', '3A');
       ArrlSection := ReadString(SEC_STN, 'ArrlSection', 'OR');
 
-      MainForm.SetMyCall(ReadString(SEC_STN, 'Call', Call));
-      MainForm.SetPitch(ReadInteger(SEC_STN, 'Pitch', 3));
-      MainForm.SetBw(ReadInteger(SEC_STN, 'BandWidth', 9));
+      // load station settings...
+      // Calls to SetMyCall, SetPitch, SetBw, etc., moved to MainForm.SetContest
+      Call := ReadString(SEC_STN, 'Call', Call);
+      MainForm.ComboBox1.ItemIndex := ReadInteger(SEC_STN, 'Pitch', 3);
+      MainForm.ComboBox2.ItemIndex := ReadInteger(SEC_STN, 'BandWidth', 9);
 
       HamName := ReadString(SEC_STN, 'Name', '');
       CWOPSNum :=  ReadString(SEC_STN, 'cwopsnum', CWOPSNum);
@@ -210,8 +212,8 @@ begin
       MainForm.UpdCWMinRxSpeed(ReadInteger(SEC_STN, 'CWMinRxSpeed', MinRxWpm));
       MainForm.UpdNRDigits(ReadInteger(SEC_STN, 'NRDigits', NRDigits));
 
-      MainForm.SetWpm(ReadInteger(SEC_STN, 'Wpm', Wpm));
-      MainForm.SetQsk(ReadBool(SEC_STN, 'Qsk', Qsk));
+      Wpm := ReadInteger(SEC_STN, 'Wpm', Wpm);
+      Qsk := ReadBool(SEC_STN, 'Qsk', Qsk);
       CallsFromKeyer := ReadBool(SEC_STN, 'CallsFromKeyer', CallsFromKeyer);
       GetWpmUsesGaussian := ReadBool(SEC_STN, 'GetWpmUsesGaussian', GetWpmUsesGaussian);
 
@@ -241,8 +243,7 @@ begin
         begin V := 3; WriteInteger(SEC_SYS, 'BufSize', V); end;
       V := Max(1, Min(5, V));
       BufSize := 64 shl V;
-      Tst.Filt.SamplesInInput := BufSize;
-      Tst.Filt2.SamplesInInput := BufSize;
+      // Tst.Filt{,2}.SamplesInInput: set in TContest.Create & TMainForm.SetContest
 
       V := ReadInteger(SEC_STN, 'SelfMonVolume', 0);
       MainForm.VolumeSlider1.Value := V / 80 + 0.75;

--- a/Log.pas
+++ b/Log.pas
@@ -8,9 +8,7 @@ unit Log;
 interface
 
 uses
-  Windows, SysUtils, Classes, Graphics, RndFunc, Math, Controls,
-  StdCtrls, ExtCtrls, ARRL, ARRLFD, NAQP, PerlRegEx, pcre;
-
+  Classes, Controls, ExtCtrls;
 
 procedure SaveQso;
 procedure LastQsoToScreen;
@@ -68,6 +66,8 @@ var
 implementation
 
 uses
+  Windows, SysUtils, Graphics, RndFunc, Math,
+  StdCtrls, PerlRegEx, pcre,
   Contest, Main, DxStn, DxOper, Ini, MorseKey;
 
 
@@ -145,14 +145,7 @@ var
   s: string;
 begin
   // Adding a contest: UpdateSbar - update status bar with station info (e.g. FD shows UserText)
-  case Ini.SimContest of
-  scFieldDay:
-    s := gArrlFd.GetStationInfo(ACallsign);
-  scNaQp:
-    s := gNAQP.GetStationInfo(ACallsign);
-  else
-    s := gDXCCList.Search(ACallsign);
-  end;
+  s := Tst.GetStationInfo(ACallsign);
 
   // '&' are suppressed in this control; replace with '&&'
   s:= StringReplace(s, '&', '&&', [rfReplaceAll]);

--- a/Main.pas
+++ b/Main.pas
@@ -16,7 +16,7 @@ uses
   Buttons, SndCustm, SndOut, Contest, Ini, MorseKey, CallLst,
   VolmSldr, VolumCtl, StdCtrls, Station, Menus, ExtCtrls, MAth,
   ComCtrls, Spin, SndTypes, ShellApi, jpeg, ToolWin, ImgList, Crc32,
-  WavFile, IniFiles, Idhttp, ARRL, ARRLFD, NAQP, CWOPS, CQWW,
+  WavFile, IniFiles, Idhttp,
   System.ImageList;
 
 const
@@ -410,7 +410,10 @@ var
   MainForm: TMainForm;
 
 implementation
-uses TypInfo, ScoreDlg, Log, PerlRegEx;
+
+uses
+  ARRL, ARRLFD, NAQP, CWOPS, CQWW, CQWPX,
+  TypInfo, ScoreDlg, Log, PerlRegEx;
 
 {$R *.DFM}
 
@@ -480,7 +483,7 @@ begin
   // Adding a contest: implement a new contest-specific call history .pas file.
   Result := nil;
   case AContestId of
-  scWpx, scHst: Result := TContest.Create;
+  scWpx, scHst: Result := TCqWpx.Create;
   scCwt:        Result := TCWOPS.Create;
   scFieldDay:   Result := TArrlFieldDay.Create;
   scNaQp:       Result := TNcjNaQp.Create;

--- a/Main.pas
+++ b/Main.pas
@@ -446,8 +446,8 @@ begin
   ListView2.Visible:= False;
   ListView2.Clear;
 
-  Tst := TContest.Create;
-  LoadCallList;
+  //Tst := TContest.Create;
+  //LoadCallList;
 
   // Adding a contest: implement a new contest-specific call history .pas file.
   // Adding a contest: load call history file (be sure to delete it below).
@@ -871,6 +871,11 @@ begin
 
   assert(ContestDefinitions[AContestNum].T = AContestNum,
     'Contest definitions are out of order');
+
+  // drop prior contest
+  if Assigned(Tst) then
+    FreeAndNil(Tst);
+
   Ini.SimContest := AContestNum;
   Ini.ActiveContest := @ContestDefinitions[AContestNum];
   SimContestCombo.ItemIndex := Ord(AContestNum);
@@ -881,8 +886,29 @@ begin
   sbar.Font.Color := clDefault;
   sbar.Visible := mnuShowCallsignInfo.Checked;
 
-  // update my sent exchange types
-  Tst.Me.SentExchTypes := Tst.GetSentExchTypes(skMyStation, Ini.Call);
+  // create new contest
+  // how to turn this into a factory
+  //Tst := CreateContest(AContestNum, Ini.Call);
+  Tst := TContest.Create;
+  CallLst.LoadCallList;   // loads Master.dta
+  // Tst.LoadCallHistory; // virtual function
+
+  // the following will initialize simulation-specific data owned by contest.
+  // (this used to reside in Ini.FromIni and called while reading .INI file)
+  begin
+    SetMyCall(Ini.Call);
+    SetPitch(ComboBox1.ItemIndex);
+    SetBw(ComboBox2.ItemIndex);
+    SetWpm(Ini.Wpm);
+    SetQsk(Ini.Qsk);
+
+    // buffer size
+    Tst.Filt.SamplesInInput := Ini.BufSize;
+    Tst.Filt2.SamplesInInput := Ini.BufSize;
+
+    // update my sent exchange types (must be called after loading call lists?)
+    Tst.Me.SentExchTypes:= Tst.GetSentExchTypes(skMyStation, Ini.Call);
+  end;
 
   // update Exchange field labels and length settings (e.g. RST, Nr.)
   ConfigureExchangeFields(ActiveContest.ExchType1, ActiveContest.ExchType2);

--- a/Main.pas
+++ b/Main.pas
@@ -913,7 +913,8 @@ begin
     assert(Tst.Filt2.SamplesInInput = Ini.BufSize);
 
     // load contest-specific call history file
-    Tst.LoadCallHistory(Ini.Call);
+    if not Tst.LoadCallHistory(Ini.Call) then
+      Exit;
 
     // update my sent exchange types (must be called after loading call lists?)
     Tst.Me.SentExchTypes:= Tst.GetSentExchTypes(skMyStation, Ini.Call);

--- a/MorseRunner.dpr
+++ b/MorseRunner.dpr
@@ -37,7 +37,8 @@ uses
   ArrlFd in 'ArrlFd.pas',
   NaQp in 'NaQp.pas',
   CWOPS in 'CWOPS.pas',
-  CqWW in 'CqWW.pas';
+  CqWW in 'CqWW.pas',
+  CqWpx in 'CqWpx.pas';
 
 {$R *.RES}
 

--- a/MorseRunner.dproj
+++ b/MorseRunner.dproj
@@ -155,6 +155,7 @@
         <DCCReference Include="NaQp.pas"/>
         <DCCReference Include="CWOPS.pas"/>
         <DCCReference Include="CqWW.pas"/>
+        <DCCReference Include="CqWpx.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/MyStn.pas
+++ b/MyStn.pas
@@ -8,7 +8,7 @@ unit MyStn;
 interface
 
 uses
-  SysUtils, Classes, Station, RndFunc, Ini, SndTypes, MorseKey;
+  Station, Classes, SndTypes;
 
 type
   TMyStation = class(TStation)
@@ -31,7 +31,7 @@ type
 implementation
 
 uses
-  Contest, Main;
+  SysUtils, RndFunc, Ini, MorseKey, Contest, Main;
 
 { TMyStation }
 

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -27,6 +27,7 @@ public
   procedure LoadCallHistory(const AUserCallsign : string); override;
 
   function PickStation(): integer; override;
+  procedure DropStation(id : integer); override;
   function GetCall(id : integer): string; override; // returns station callsign
   procedure GetExchange(id : integer; out station : TDxStation); override;
 
@@ -110,6 +111,13 @@ end;
 function TNcjNaQp.PickStation(): integer;
 begin
      result := random(NaQpCallList.Count);
+end;
+
+
+procedure TNcjNaQp.DropStation(id : integer);
+begin
+  assert(id < NaQpCallList.Count);
+  NaQpCallList.Delete(id);
 end;
 
 

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -24,7 +24,7 @@ private
 public
   constructor Create;
   destructor Destroy; override;
-  procedure LoadCallHistory(const AUserCallsign : string); override;
+  function LoadCallHistory(const AUserCallsign : string) : boolean; override;
 
   function PickStation(): integer; override;
   procedure DropStation(id : integer); override;
@@ -47,7 +47,7 @@ uses
   StrUtils, SysUtils, Classes, Contnrs, PerlRegEx, pcre,
   log, ARRL;
 
-procedure TNcjNaQp.LoadCallHistory(const AUserCallsign : string);
+function TNcjNaQp.LoadCallHistory(const AUserCallsign : string) : boolean;
 const
   DelimitChar: char = ',';
 var
@@ -55,6 +55,11 @@ var
   i: integer;
   rec: TNaQpCallRec;
 begin
+  // reload call history iff user's callsign has changed.
+  Result := not HasUserCallsignChanged(AUserCallsign);
+  if Result then
+    Exit;
+
   slst:= TStringList.Create;
   tl:= TStringList.Create;
   tl.Delimiter := DelimitChar;
@@ -85,6 +90,10 @@ begin
           NaQpCallList.Add(rec);
       end;
     end;
+
+    // retain user's callsign after successful load
+    SetUserCallsign(AUserCallsign);
+    Result := True;
 
   finally
     slst.Free;

--- a/QrmStn.pas
+++ b/QrmStn.pas
@@ -8,7 +8,7 @@ unit QrmStn;
 interface
 
 uses
-  SysUtils, Classes, Station, RndFunc, Ini, CallLst;
+  Station;
 
 type
   TQrmStation = class(TStation)
@@ -22,6 +22,7 @@ type
 implementation
 
 uses
+  SysUtils, Classes, RndFunc, Ini, CallLst,
   Contest;
 
 constructor TQrmStation.CreateStation;

--- a/QrmStn.pas
+++ b/QrmStn.pas
@@ -30,7 +30,7 @@ begin
   inherited Create(nil);
 
   Patience := 1 + Random(5);
-  MyCall := PickCall;
+  MyCall := Tst.PickCallOnly;
   HisCall := Ini.Call;
   Amplitude := 5000 + 25000 * Random;
   Pitch := Round(RndGaussLim(0, 300));

--- a/QrnStn.pas
+++ b/QrnStn.pas
@@ -8,8 +8,7 @@ unit QrnStn;
 interface
 
 uses
-  SysUtils, Classes, Station, RndFunc, Ini, CallLst,
-  Math;
+  Station;
 
 type
   TQrnStation = class(TStation)
@@ -19,6 +18,9 @@ type
   end;
 
 implementation
+
+uses
+  Ini, RndFunc, Math;
 
 constructor TQrnStation.CreateStation;
 var

--- a/Qsb.pas
+++ b/Qsb.pas
@@ -8,7 +8,7 @@ unit Qsb;
 interface
 
 uses
-  SysUtils, QuickAvg, SndTypes, RndFunc, Math, Ini;
+  QuickAvg, SndTypes;
 
 type
   TQsb = class
@@ -28,6 +28,9 @@ type
 
 
 implementation
+
+uses
+  SysUtils, RndFunc, Math, Ini;
 
 
 constructor TQsb.Create;

--- a/Station.pas
+++ b/Station.pas
@@ -8,7 +8,7 @@ unit Station;
 interface
 
 uses
-  SysUtils, Classes, Math, SndTypes, Ini, MorseKey;
+  Classes, SndTypes, Ini;
 
 const
   NEVER = MAXINT;
@@ -96,7 +96,7 @@ type
 implementation
 
 uses
-  Contest;
+  SysUtils, Math, MorseKey, Contest;
 
 
 { TExchTypes }


### PR DESCRIPTION
Implements a common class hierarchy to support contests. contest-specific behaviors will be implemented in the various derived contests. See Issue #124 for a UML Class Diagram showing this hierarchy. This refactoring introduces the base TContest class along with 5 derived subclasses.