### PR TITLE
reading call history files only needs to occur one time

### DIFF
--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -59,8 +59,8 @@ var
   i: integer;
   rec: TFdCallRec;
 begin
-  // reload call history iff user's callsign has changed.
-  Result := not HasUserCallsignChanged(AUserCallsign);
+  // reload call history if empty
+  Result := FdCallList.Count <> 0;
   if Result then
     Exit;
 

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -46,8 +46,8 @@ var
     i: integer;
     CWO: TCWOPSRec;
 begin
-    // reload call history iff user's callsign has changed.
-    Result := not HasUserCallsignChanged(AUserCallsign);
+    // reload call history if empty
+    Result := CWOPSList.Count <> 0;
     if Result then
       Exit;
 

--- a/CallLst.pas
+++ b/CallLst.pas
@@ -20,6 +20,7 @@ type
     constructor Create;
     destructor Destroy; override;
     procedure LoadCallList;
+    function IsEmpty : Boolean;
     procedure Clear();
     function PickCall : string;
   end;
@@ -99,6 +100,12 @@ begin
   finally
     L.Free;
   end;
+end;
+
+
+function TCallList.IsEmpty : Boolean;
+begin
+  Result := Calls.Count = 0;
 end;
 
 

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -55,8 +55,8 @@ var
   i: integer;
   rec: TCqWwCallRec;
 begin
-  // reload call history iff user's callsign has changed.
-  Result := not HasUserCallsignChanged(AUserCallsign);
+  // reload call history if empty
+  Result := CqWwCallList.Count <> 0;
   if Result then
     Exit;
 

--- a/CqWpx.pas
+++ b/CqWpx.pas
@@ -40,8 +40,8 @@ uses
 
 function TCqWpx.LoadCallHistory(const AUserCallsign : string) : boolean;
 begin
-  // reload call history iff user's callsign has changed.
-  Result := not HasUserCallsignChanged(AUserCallsign);
+  // reload call history if empty
+  Result := not CallLst.IsEmpty();
   if Result then
     Exit;
 

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -55,8 +55,8 @@ var
   i: integer;
   rec: TNaQpCallRec;
 begin
-  // reload call history iff user's callsign has changed.
-  Result := not HasUserCallsignChanged(AUserCallsign);
+  // reload call history if empty
+  Result := NaQpCallList.Count <> 0;
   if Result then
     Exit;
 


### PR DESCRIPTION
When fixing #124, call history files were loaded multiple times. This is not necessary. They are now loaded one time only.