### PR TITLE
rework user callsign handling, load call history file at runtime

### DIFF
--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -96,8 +96,6 @@ begin
       end;
     end;
 
-    // retain user's callsign after successful load
-    SetUserCallsign(AUserCallsign);
     Result := True;
 
   finally

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -80,8 +80,6 @@ begin
             end;
         end;
 
-        // retain user's callsign after successful load
-        SetUserCallsign(AUserCallsign);
         Result := True;
 
     finally

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -88,8 +88,6 @@ begin
       end;
     end;
 
-    // retain user's callsign after successful load
-    SetUserCallsign(AUserCallsign);
     Result := True;
 
   finally

--- a/CqWpx.pas
+++ b/CqWpx.pas
@@ -47,8 +47,6 @@ begin
 
   CallLst.LoadCallList;
 
-  // retain user's callsign after successful load
-  SetUserCallsign(AUserCallsign);
   Result := True;
 end;
 

--- a/Ini.pas
+++ b/Ini.pas
@@ -49,6 +49,9 @@ type
   PContestDefinition = ^TContestDefinition;
 
 const
+  UndefExchType1 : TExchange1Type = TExchange1Type(-1);
+  UndefExchType2 : TExchange2Type = TExchange2Type(-1);
+
   {
     Each contest is declared here. Long-term, this will be a generalized
     table-driven implementation allowing new contests to be configured

--- a/Main.dfm
+++ b/Main.dfm
@@ -786,6 +786,7 @@ object MainForm: TMainForm
         TabOrder = 0
         Text = 'VE3NEA'
         OnChange = Edit4Change
+        OnExit = Edit4Exit
       end
       object SpinEdit1: TSpinEdit
         Left = 91

--- a/MyStn.pas
+++ b/MyStn.pas
@@ -59,8 +59,8 @@ begin
   Wpm := Ini.Wpm;
   Amplitude := 300000;
 
-  // My sent exchange types depends on my callsign
-  SentExchTypes:= Tst.GetSentExchTypes(skMyStation, MyCall);
+  // invalidate SentExchTypes. Will be set by Tst.OnSetMyCall().
+  SentExchTypes := ExchTypesUndef;
 
   // Adding a contest: Initialize Exch1 and Exch2
   // (try to use the generalized Exch1 and Exch2 fields for new contests.)

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -91,8 +91,6 @@ begin
       end;
     end;
 
-    // retain user's callsign after successful load
-    SetUserCallsign(AUserCallsign);
     Result := True;
 
   finally

--- a/Station.pas
+++ b/Station.pas
@@ -93,6 +93,12 @@ type
     property Bfo: Single read GetBfo;
   end;
 
+const
+  ExchTypesUndef : TExchTypes = (
+    Exch1: TExchange1Type(-1);
+    Exch2: TExchange2Type(-1);
+  );
+
 implementation
 
 uses
@@ -113,8 +119,7 @@ constructor TStation.CreateStation;
 begin
   inherited Create(nil);
 
-  SentExchTypes.Exch1:= TExchange1Type(-1);
-  SentExchTypes.Exch2:= TExchange2Type(-1);
+  SentExchTypes:= ExchTypesUndef;
 end;
 
 


### PR DESCRIPTION
This refactor step is necessary to prepare for dual exchange contests, including ARRL DX Contest (part of issue #62). Previous refactoring steps are covered in PR #132 and PR #125.

Changes in this PR include:
- after user callsign edits, SetMyCall is called.
- SetMyCall calls Tst.OnSetMyCall which will extract any contest-specific information (e.g. in ARRL DX Contest, US/CA stations work only DX and DX works only US/CA stations).
- call history file is now loaded after the user starts the contest using the RUN button. This simplified the reload logic in case the user callsign had changed.
- move logic from each derived call history reader into the base class TContest.OnContestPrepareToStart function.