### PR TITLE
add contest-specific scoring

### DIFF
--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -7,7 +7,7 @@ unit ARRLFD;
 interface
 
 uses
-  Generics.Defaults, Generics.Collections, Contest, DxStn;
+  Generics.Defaults, Generics.Collections, Contest, DxStn, Log;
 
 type
   TFdCallRec = class
@@ -43,13 +43,14 @@ public
   //function IsNum(Num: String): Boolean;
   function FindCallRec(out fdrec: TFdCallRec; const ACall: string): Boolean;
   function GetStationInfo(const ACallsign: string) : string; override;
+  function ExtractMultiplier(Qso: PQso) : string; override;
 end;
 
 
 implementation
 
 uses
-  SysUtils, Classes, Log, PerlRegEx, pcre, ARRL;
+  SysUtils, Classes, PerlRegEx, pcre, ARRL;
 
 function TArrlFieldDay.LoadCallHistory(const AUserCallsign : string) : boolean;
 const
@@ -190,6 +191,17 @@ begin
     if dxEntity <> '' then
       result:= result + ' - ' + dxEntity;
     end;
+end;
+
+
+{
+  Field Day doesn't have an expliclit multiplier; return a non-empty string.
+  Also sets contest-specific Qso.Points for this QSO.
+}
+function TArrlFieldDay.ExtractMultiplier(Qso: PQso) : string;
+begin
+  Qso^.Points := 2;
+  Result:= '1';
 end;
 
 

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -3,7 +3,7 @@ unit CWOPS;
 interface
 
 uses
-  Classes, Contest, Contnrs, DxStn;
+  Classes, Contest, Contnrs, DxStn, Log;
 
 type
     TCWOPSRec= class
@@ -27,6 +27,7 @@ type
     procedure DropStation(id : integer); override;
     function GetCall(id : integer): string; override;
     procedure GetExchange(id : integer; out station : TDxStation); override;
+    function ExtractMultiplier(Qso: PQso) : string; override;
 
     function getcwopsname(id:integer): string;
     function getcwopsnum(id:integer): integer;
@@ -38,7 +39,7 @@ type
 implementation
 
 uses
-    SysUtils, Log;
+    SysUtils;
 
 function TCWOPS.LoadCallHistory(const AUserCallsign : string) : boolean;
 var
@@ -126,6 +127,17 @@ procedure TCWOPS.GetExchange(id : integer; out station : TDxStation);
 begin
   station.OpName := getcwopsname(id);
   station.NR :=  getcwopsnum(id);
+end;
+
+
+{
+  CWOPS CWT contest uses number of unique callsigns worked as the multiplier.
+  Also sets contest-specific Qso.Points for this QSO.
+}
+function TCWOPS.ExtractMultiplier(Qso: PQso) : string;
+begin
+  Qso^.Points := 1;
+  Result:= Qso^.Call;
 end;
 
 

--- a/CqWpx.pas
+++ b/CqWpx.pas
@@ -7,7 +7,7 @@ unit CQWPX;
 interface
 
 uses
-  Contest, CallLst, DxStn;
+  Contest, CallLst, DxStn, Log;
 
 type
 TCqWpx = class(TContest)
@@ -31,12 +31,13 @@ public
   function FindCallRec(out fdrec: TCqWpxCallRec; const ACall: string): Boolean;
   }
   function GetStationInfo(const ACallsign: string) : string; override;
+  function ExtractMultiplier(Qso: PQso) : string; override;
 end;
 
 implementation
 
 uses
-  SysUtils, Classes, log, ARRL;
+  SysUtils, Classes, ARRL;
 
 function TCqWpx.LoadCallHistory(const AUserCallsign : string) : boolean;
 begin
@@ -91,6 +92,18 @@ begin
   // find caller's Continent/Entity
   if gDXCCList.FindRec(dxrec, ACallsign) then
     Result := Format('%s - %s/%s', [ACallsign, dxRec.Continent, dxRec.Entity]);
+end;
+
+
+{
+  For CQ Wpx, the multiplier is the sum of unique Wpx prefixes worked.
+  Also sets contest-specific Qso.Points for this QSO.
+}
+function TCqWpx.ExtractMultiplier(Qso: PQso) : string;
+begin
+  Qso.Points := 1;
+  // assumes Log.ExtractPrefix() has already been called.
+  Result := Qso.Pfx;
 end;
 
 

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -3,7 +3,7 @@ unit NAQP;
 interface
 
 uses
-  Generics.Defaults, Generics.Collections, Contest, DxStn;
+  Generics.Defaults, Generics.Collections, Contest, DxStn, Log;
 
 type
   TNaQpCallRec = class
@@ -30,6 +30,7 @@ public
   procedure DropStation(id : integer); override;
   function GetCall(id : integer): string; override; // returns station callsign
   procedure GetExchange(id : integer; out station : TDxStation); override;
+  function ExtractMultiplier(Qso: PQso) : string; override;
 
   function getExch1(id:integer): string;    // returns station info (e.g. MIKE)
   function getExch2(id:integer): string;    // returns section info (e.g. OR)
@@ -45,7 +46,7 @@ implementation
 
 uses
   StrUtils, SysUtils, Classes, Contnrs, PerlRegEx, pcre,
-  log, ARRL;
+  ARRL;
 
 function TNcjNaQp.LoadCallHistory(const AUserCallsign : string) : boolean;
 const
@@ -184,6 +185,22 @@ begin
 end;
 
 
+{
+  Extract multiplier string for a given contest.
+  Also sets contest-specific Qso.Points for this QSO.
+
+  For NCJ NAQP Contest, the State/Prov value is returned;
+
+  Return the multiplier string used by this contest. This string is accumlated
+  in the Log.RawMultList and Log.VerifiedMultList to count the multiplier value.
+}
+function TNcjNaQp.ExtractMultiplier(Qso: PQso) : string;
+begin
+  Qso^.Points := 1;
+  Result := Qso^.Exch2;
+end;
+
+
 function TNcjNaQp.GetCall(id : integer): string;     // returns station callsign
 begin
   result := NaQpCallList.Items[id].Call;
@@ -197,6 +214,7 @@ begin
   station.Exch2 := getExch2(station.Operid);
   station.UserText := getUserText(station.Operid);
 end;
+
 
 function TNcjNaQp.getExch1(id:integer): string;    // returns station info (e.g. MIKE)
 begin


### PR DESCRIPTION
Fixes #139 - adds Contest-specific scoring to MRCE.

Please see #137 discussion for more information.