### PR TITLE
ARRL DX: allow ENN to be sent as short-form 5NN RST

### DIFF
--- a/CqWW.pas
+++ b/CqWW.pas
@@ -260,15 +260,16 @@ end;
 
 procedure TCqWw.GetExchange(id : integer; out station : TDxStation);
 begin
+  station.Exch1 := getExch1(station.Operid);  // RST
   station.Exch2 := getExch2(station.Operid);
-  station.NR := StrToInt(getExch2(station.Operid));
+  station.NR := StrToInt(station.Exch2);
 end;
 
 
 
-function TCqWw.getExch1(id:integer): string;    // returns RST (e.g. 5NN)
+function TCqWw.getExch1(id:integer): string;    // returns RST (e.g. 599)
 begin
-  result := '5NN';
+  result := '599';
 end;
 
 

--- a/Log.pas
+++ b/Log.pas
@@ -647,12 +647,12 @@ begin
     scCQWW:
       ScoreTableInsert(FormatDateTime('hh:nn:ss', t), Call
         , format('%.3d %4d', [Rst, NR])
-        , format('%.3d %4d', [Tst.Me.Rst, Tst.Me.NR])
+        , format('%.3s %4d', [Tst.Me.Exch1, Tst.Me.NR])     // log my sent RST
         , Pfx, Err, format('%.3d', [TrueWpm]));
     scArrlDx:
       ScoreTableInsert(FormatDateTime('hh:nn:ss', t), Call
         , format('%.3d %4s', [Rst, Exch2])
-        , format('%.3d %4s', [Tst.Me.Rst, Tst.Me.Exch2])
+        , format('%.3s %4s', [Tst.Me.Exch1, Tst.Me.Exch2])  // log my sent RST
         , Pfx, Err, format('%.2d', [TrueWpm]));
     else
       assert(false, 'missing case');

--- a/Main.pas
+++ b/Main.pas
@@ -46,7 +46,7 @@ const
   // Adding a contest: define contest-specific field types
   // Exchange Field 1 settings/rules
   Exchange1Settings: array[TExchange1Type] of TFieldDefinition = (
-    (C: 'RST';   R: '5[9N][9N]';        L: 3;  T:Ord(etRST)),
+    (C: 'RST';   R: '[5E][9N][9N]';     L: 3;  T:Ord(etRST)),
     (C: 'Name';  R: '[A-Z][A-Z]*';      L: 10; T:Ord(etOpName)),
     (C: 'Class'; R: '[1-9][0-9]*[A-F]'; L: 3;  T:Ord(etFdClass))
   );
@@ -546,9 +546,10 @@ begin
       begin
         if RunMode <> rmHst then
         begin
-          // for RST field, map (A,N) to (1,9)
+          // for RST field, map (A,E,N) to (1,5,9)
           case Key of
             'a', 'A': Key := '1';
+            'e', 'E': Key := '5';
             'n', 'N': Key := '9';
           end;
         end;
@@ -1127,7 +1128,8 @@ begin
       begin
         // Format('invalid RST (%s)', [AValue]));
         Ini.UserExchange1[SimContest] := Avalue;
-        Tst.Me.RST := StrToInt(Avalue.Replace('N', '9', [rfReplaceAll]));
+        Tst.Me.RST := StrToInt(Avalue.Replace('E', '5', [rfReplaceAll])
+                                     .Replace('N', '9', [rfReplaceAll]));
         Tst.Me.Exch1 := Avalue;
         if BDebugExchSettings then Edit2.Text := Avalue; // testing only
       end;

--- a/Station.pas
+++ b/Station.pas
@@ -274,6 +274,10 @@ end;
 
 
                                                 
+{
+  This function formats the exchange string to be sent by this station
+  by combining exchange fields 1 and 2.
+}
 function TStation.NrAsText: string;
 var
   Idx: integer;
@@ -281,7 +285,7 @@ begin
   // Adding a contest: TStation.NrAsText(), converts <#> to exchange (usually '<exch1> <exch2>'). Inject LID errors.
   case SimContest of
     scCQWW:
-      Result := Format('%d %d', [RST, NR]);
+      Result := Format('%s %d', [Exch1, NR]);     // <RST> <serial#>
     scCwt:
       Result := Format('%s  %.d', [OpName, NR]);
     scFieldDay:
@@ -308,9 +312,13 @@ begin
     end;
 
   if SentExchTypes.Exch1 = etRST then
+     begin
+     if (Ini.RunMode <> rmHST) and (Random < 0.05) then
+       Result := StringReplace(Result, '599', 'ENN', [rfReplaceAll]);
      Result := StringReplace(Result, '599', '5NN', [rfReplaceAll]);
+     end;
   if (Ini.RunMode <> rmHst) and (SentExchTypes.Exch2 in
-    [etSerialNr, etCqZone, etItuZone, etAge, etPower, etStateProv]) then
+    [etSerialNr, etCqZone, etItuZone, etAge, etPower]) then
     begin
     Result := StringReplace(Result, '000', 'TTT', [rfReplaceAll]);
     Result := StringReplace(Result, '00', 'TT', [rfReplaceAll]);


### PR DESCRIPTION
- ENN can now be specified in Sent Exchange and sent by user
- ENN is randomly sent 5% of the time from Dx Stations.
- fixes #154 