### PR TITLE
Fix #175 - CWT contest - DxStation now sends 'R' after receiving report.

### DIFF
--- a/Station.pas
+++ b/Station.pas
@@ -166,7 +166,7 @@ begin
     msgR_NR: begin
       // Adding a contest: TStation.SendMsg(msgR_NR): send 'R <#>' message, where # is exch (e.g. 3A OR)
       case SimContest of
-        scCwt: SendText('<#>')
+        scCwt: SendText('R <#>');
       else
         SendText('R <#>');
       end;
@@ -174,7 +174,7 @@ begin
     msgR_NR2: begin
       // Adding a contest: TStation.SendMsg(msgR_NR2): send 'R <#> <#>' message, where # is exch (e.g. 3A OR)
       case SimContest of
-        scCwt: SendText('<#>')
+        scCwt: SendText('R <#> <#>');
       else
         SendText('R <#> <#>');
       end;
@@ -188,7 +188,8 @@ begin
     msgLongCQ:
       begin
         case SimContest of
-          scFieldDay: SendText('CQ CQ FD <my> <my>')
+          scFieldDay: SendText('CQ CQ FD <my> <my>');
+          scCwt: SendText('CQ CQ CWT <my>');
         else
           SendText('CQ CQ TEST <my> <my> TEST');
         end;


### PR DESCRIPTION
Fixes #175. 'R' is now sent by DxStation after receiving user's callsign and name/MR to indicate message was received. This follows standard contest behaviors.