### PR TITLE
CWT Contest - 'R' is now sent only 10% of the time

### DIFF
--- a/Station.pas
+++ b/Station.pas
@@ -166,7 +166,10 @@ begin
     msgR_NR: begin
       // Adding a contest: TStation.SendMsg(msgR_NR): send 'R <#>' message, where # is exch (e.g. 3A OR)
       case SimContest of
-        scCwt: SendText('R <#>');
+        scCwt:
+          if (random < 0.9)
+            then SendText('<#>')
+            else SendText('R <#>');
       else
         SendText('R <#>');
       end;
@@ -174,7 +177,10 @@ begin
     msgR_NR2: begin
       // Adding a contest: TStation.SendMsg(msgR_NR2): send 'R <#> <#>' message, where # is exch (e.g. 3A OR)
       case SimContest of
-        scCwt: SendText('R <#> <#>');
+        scCwt:
+          if (random < 0.9)
+            then SendText('<#> <#>')
+            else SendText('R <#> <#>');
       else
         SendText('R <#> <#>');
       end;


### PR DESCRIPTION
Usual contest behavior is to send NAME/NR without a leading acknowledgement.
After additional discussion, we want to preserve original behavior. Now, the 'R' acknowledgement is only sent 10% of the time.
Fixes #175.