### PR TITLE
After correcting a copied callsign, TU is now sent

### DIFF
--- a/Main.pas
+++ b/Main.pas
@@ -1428,17 +1428,15 @@ end;
 
 {
   called whenever callsign field (Edit1) changes. Any callsign edit will
-  invalidate the callsign and NR (Exchange) field(s) already sent, so clear
-  the CallSent and NrSent values.
+  invalidate the callsign already sent by clearing the CallSent value.
+  If the Callsign is empty, also crear the NrSent value.
 }
 procedure TMainForm.Edit1Change(Sender: TObject);
 begin
     if Edit1.Text = '' then
         NrSent := false;
-    if not Tst.Me.UpdateCallInMessage(Edit1.Text) then begin
+    if not Tst.Me.UpdateCallInMessage(Edit1.Text) then
         CallSent := false;
-        NrSent := false;
-    end;
 end;
 
 


### PR DESCRIPTION
Previously, after correcting a copied callsign, MR would send the corrected callsign along with the full exchange. Now MR will send the corrected callsign followed by 'TU'. This fixes #177.

This bug was inserted while building ARRL FD and has been mostly backed out.