### PR TITLE
restore Dx Station timeout used while copying initial callsign

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -127,7 +127,7 @@ procedure TDxOperator.SetState(AState: TOperatorState);
 begin
   State := AState;
   if AState = osNeedQso
-    then Patience := Round(RndRayleigh(4)) + 99 // mikeb debug
+    then Patience := Round(RndRayleigh(4))
     else Patience := FULL_PATIENCE;
 
   if (AState = osNeedQso) and (not (RunMode in [rmSingle, RmHst])) and (Random < 0.1)


### PR DESCRIPTION
Fixes #180. Removes debug code added during ARRL Field Day prototype development. Restores original behavior of a timeout after the user tries to copy the callers callsign 2-8 times. This restores usual contest behavior.