### PR TITLE
refactor - introduce contest-specific message handling

### DIFF
--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -7,7 +7,7 @@ unit ARRLFD;
 interface
 
 uses
-  Generics.Defaults, Generics.Collections, Contest, DxStn, Log;
+  Generics.Defaults, Generics.Collections, Contest, Station, DxStn, Log;
 
 type
   TFdCallRec = class
@@ -42,6 +42,7 @@ public
   function getUserText(id:integer): string; // returns optional club name
   //function IsNum(Num: String): Boolean;
   function FindCallRec(out fdrec: TFdCallRec; const ACall: string): Boolean;
+  procedure SendMsg(const AStn: TStation; const AMsg: TStationMessage); override;
   function GetStationInfo(const ACallsign: string) : string; override;
   function ExtractMultiplier(Qso: PQso) : string; override;
 end;
@@ -153,6 +154,29 @@ begin
     rec.Free;
   end;
   Result:= fdrec <> nil;
+end;
+
+
+{
+  Overrides TContest.SendMsg() to send contest-specific messages.
+
+  Adding a contest: TContest.SendMsg(AMsg): send contest-specfic messages
+}
+procedure TArrlFieldDay.SendMsg(const AStn: TStation; const AMsg: TStationMessage);
+begin
+  case AMsg of
+    msgCQ: SendText(AStn, 'CQ FD <my>');
+    msgNrQm:
+      case Random(5) of
+        0,1: SendText(AStn, 'NR?');
+        2: SendText(AStn, 'SECT?');
+        3: SendText(AStn, 'CLASS?');
+        4: SendText(AStn, 'CL?');
+      end;
+    msgLongCQ: SendText(AStn, 'CQ CQ FD <my> <my> FD');  // QrmStation only
+    else
+      inherited SendMsg(AStn, AMsg);
+  end;
 end;
 
 

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -3,7 +3,8 @@ unit CWOPS;
 interface
 
 uses
-  Classes, Generics.Defaults, Generics.Collections, Contest, Contnrs, DxStn, Log;
+  Classes, Generics.Defaults, Generics.Collections, Contest, Contnrs,
+  Station, DxStn, Log;
 
 type
     TCWOPSRec= class
@@ -33,6 +34,7 @@ type
     function GetCall(id : integer): string; override;
     function FindCallRec(out outrec: TCWOPSRec; const ACall: string): Boolean;
     procedure GetExchange(id : integer; out station : TDxStation); override;
+    procedure SendMsg(const AStn: TStation; const AMsg: TStationMessage); override;
     function GetStationInfo(const ACallsign: string) : string; override;
     function ExtractMultiplier(Qso: PQso) : string; override;
   end;
@@ -165,6 +167,30 @@ begin
   station.OpName := CWOPSList.Items[id].Exch1;
   station.Exch1 := CWOPSList.Items[id].Exch1;
   station.Exch2 := CWOPSList.Items[id].Exch2;
+end;
+
+
+{
+  Overrides TContest.SendMsg() to send contest-specific messages.
+
+  Adding a contest: TContest.SendMsg(AMsg): send contest-specfic messages
+}
+procedure TCWOPS.SendMsg(const AStn: TStation; const AMsg: TStationMessage);
+begin
+  case AMsg of
+    msgCQ: SendText(AStn, 'CQ CWT <my>');
+    msgR_NR:
+      if (random < 0.9)
+        then SendText(AStn, '<#>')
+        else SendText(AStn, 'R <#>');
+    msgR_NR2:
+      if (random < 0.9)
+        then SendText(AStn, '<#> <#>')
+        else SendText(AStn, 'R <#> <#>');
+    msgLongCQ: SendText(AStn, 'CQ CQ CWT <my> <my>');  // QrmStation only
+    else
+      inherited SendMsg(AStn, AMsg);
+  end;
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -59,6 +59,8 @@ type
       const AStationKind : TStationKind;
       const ARequestedMsgType : TRequestedMsgType;
       const ADxCallsign : string) : TExchTypes; virtual;
+    procedure SendMsg(const AStn: TStation; const AMsg: TStationMessage); virtual;
+    procedure SendText(const AStn: TStation; const AMsg: string); virtual;
     function ExtractMultiplier(Qso: PQso) : string; virtual;
     function Minute: Single;
     function GetAudio: TSingleArray;
@@ -200,7 +202,7 @@ end;
   function.
 
   Current behavior is to load the call history file. This action has been
-  defferred until now since some contests use the user's callsign to determine
+  deferred until now since some contests use the user's callsign to determine
   which stations can work other stations in the contest. For example, in the
   ARRL DX Contest, US/CA Stations work DX (non-US/CA) stations.
 
@@ -258,6 +260,53 @@ function TContest.GetExchangeTypes(
 begin
   Result.Exch1 := ActiveContest.ExchType1;
   Result.Exch2 := ActiveContest.ExchType2;
+end;
+
+
+{
+  This virtual procedure allows contest-specific messages to be implemented
+  in derived Contest classes.
+
+  When overridden by derived classes, if a message is not handled then this
+  base-class procedure should be called.
+  Please see ARRLFD.SendMsg for an example.
+}
+procedure TContest.SendMsg(const AStn: TStation; const AMsg: TStationMessage);
+begin
+  case AMsg of
+    msgCQ: SendText(AStn, 'CQ <my> TEST');
+    msgNR: SendText(AStn, '<#>');
+    msgTU: SendText(AStn, 'TU');
+    msgMyCall: SendText(AStn, '<my>');
+    msgHisCall: SendText(AStn, '<his>');
+    msgB4: SendText(AStn, 'QSO B4');
+    msgQm: SendText(AStn, '?');
+    msgNil: SendText(AStn, 'NIL');
+    msgR_NR: SendText(AStn, 'R <#>');
+    msgR_NR2: SendText(AStn, 'R <#> <#>');
+    msgDeMyCall1: SendText(AStn, 'DE <my>');
+    msgDeMyCall2: SendText(AStn, 'DE <my> <my>');
+    msgDeMyCallNr1: SendText(AStn, 'DE <my> <#>');
+    msgDeMyCallNr2: SendText(AStn, 'DE <my> <my> <#>');
+    msgMyCallNr2: SendText(AStn, '<my> <my> <#>');
+    msgNrQm: SendText(AStn, 'NR?');
+    msgLongCQ: SendText(AStn, 'CQ CQ TEST <my> <my> TEST');  // QrmStation only
+    msgQrl: SendText(AStn, 'QRL?');
+    msgQrl2: SendText(AStn, 'QRL?   QRL?');
+    msqQsy: SendText(AStn, '<his>  QSY QSY');
+    msgAgn: SendText(AStn, 'AGN');
+  end;
+end;
+
+
+{
+  This virtual procedure is provided to allow a derived contest the ability
+  to perform additional processing on the message, including token replacement,
+  before being passed to the Encoder and Keyer.
+}
+procedure TContest.SendText(const AStn: TStation; const AMsg: string);
+begin
+  AStn.SendText(AMsg);  // virtual
 end;
 
 

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -19,7 +19,6 @@ type
     constructor CreateStation;
     destructor Destroy; override;
     procedure ProcessEvent(AEvent: TStationEvent); override;
-    procedure SendMsg(AMsg: TStationMessage); override;
     procedure DataToLastQso;
     function GetBlock: TSingleArray; override;
   var
@@ -166,25 +165,6 @@ begin
         TimeOut := NEVER;
       end;
     end;
-end;
-
-
-// override SendMsg to allow Dx Stations to send alternate field day messages
-// (SECT?, CLASS?, CL?) whenever a 'NR?' message (msgNrQm) is sent.
-procedure TDxStation.SendMsg(AMsg: TStationMessage);
-begin
-  if (SimContest = scFieldDay) and
-    (AMsg = msgNrQm) then
-    begin
-      case Random(5) of
-        0,1: SendText('NR?');
-        2: SendText('SECT?');
-        3: SendText('CLASS?');
-        4: SendText('CL?');
-      end;
-    end
-  else
-    inherited SendMsg(AMsg);
 end;
 
 


### PR DESCRIPTION
Added new virtual method to TContest.SendMsg(). This is derived by those contests with contest-specific messaging. Codes was moved from its old location into the new methods. No functionality was changed - only code movement. This fixes #184.

I like this change. It removes lots of case statements. Here is an example from ARRL Field Day...
```
{
  Overrides TContest.SendMsg() to send contest-specific messages.

  Adding a contest: TContest.SendMsg(AMsg): send contest-specfic messages
}
procedure TArrlFieldDay.SendMsg(const AStn: TStation; const AMsg: TStationMessage);
begin
  case AMsg of
    msgCQ: SendText(AStn, 'CQ FD <my>');
    msgNrQm:
      case Random(5) of
        0,1: SendText(AStn, 'NR?');
        2: SendText(AStn, 'SECT?');
        3: SendText(AStn, 'CLASS?');
        4: SendText(AStn, 'CL?');
      end;
    msgLongCQ: SendText(AStn, 'CQ CQ FD <my> <my> FD');  // QrmStation only
    else
      inherited SendMsg(AStn, AMsg);
  end;
end;
```

Note - I added many people to this review to keep people informed of the design change. My next step is to integrate the SST Contest.