### PR TITLE
refactor - rename Wpm to WpmS (sending wpm speed); add TStation.SetWpm

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -8,7 +8,7 @@ unit DxOper;
 interface
 
 uses
-  SysUtils, RndFunc, Station, Ini, Math, Log;
+  Station;
 
 const
   FULL_PATIENCE = 5;
@@ -44,7 +44,7 @@ type
 implementation
 
 uses
-  Contest;
+  SysUtils, Ini, Math, RndFunc, Contest, Log;
 
 { TDxOperator }
 
@@ -60,7 +60,7 @@ begin
   if State = osNeedPrevEnd then
     Result := NEVER
   else if RunMode = rmHst then
-    Result := SecondsToBlocks(0.05 + 0.5*Random * 10/Wpm)
+    Result := SecondsToBlocks(0.05 + 0.5*Random * 10/Ini.Wpm)
   else
     Result := SecondsToBlocks(0.1 + 0.5*Random);
 end;
@@ -106,7 +106,7 @@ end;
 function TDxOperator.GetReplyTimeout: integer;
 begin
   if RunMode = rmHst then
-    Result := SecondsToBlocks(60/Wpm)
+    Result := SecondsToBlocks(60/Ini.Wpm)
   else
     Result := SecondsToBlocks(6-Skills);
   Result := Round(RndGaussLim(Result, Result/2));

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -56,7 +56,7 @@ begin
   Oper.SetState(osNeedPrevEnd);
   NrWithError := Ini.Lids and (Random < 0.1);
 
-  Wpm := Oper.GetWpm;
+  WpmS := Oper.GetWpm;
 
   // DX's sent exchange types depends on kind-of-station and their callsign
   SentExchTypes := Tst.GetSentExchTypes(skDxStation, MyCall);

--- a/Main.pas
+++ b/Main.pas
@@ -2007,7 +2007,7 @@ procedure TMainForm.SetWpm(AWpm : integer);
 begin
   Wpm := Max(10, Min(120, AWpm));
   SpinEdit1.Value := Wpm;
-  Tst.Me.Wpm := Wpm;
+  Tst.Me.SetWpm(Wpm);
 end;
 
 

--- a/MyStn.pas
+++ b/MyStn.pas
@@ -20,6 +20,7 @@ type
     constructor CreateStation;
     destructor Destroy; override;
     procedure Init;
+    procedure SetWpm(const AWpmS : integer);
     procedure ProcessEvent(AEvent: TStationEvent); override;
     procedure AbortSend;
     procedure SendText(AMsg: string); override;
@@ -58,7 +59,7 @@ begin
   NR := 1;
   RST := 599;
   Pitch := Ini.Pitch;
-  Wpm := Ini.Wpm;
+  WpmS := Ini.Wpm;
   Amplitude := 300000;
 
   // invalidate SentExchTypes. Will be set by Tst.OnSetMyCall().
@@ -69,6 +70,15 @@ begin
   OpName := HamName;
   Exch1 := '3A';
   Exch2 := 'OR';
+end;
+
+
+{
+  Called by TMainForm.SetWpm whenever Wpm is updated via UI.
+}
+procedure TMyStation.SetWpm(const AWpmS : integer);
+begin
+  WpmS := AWpmS;   // set via UI
 end;
 
 
@@ -176,7 +186,7 @@ begin
   if Result then
     begin
     //create new envelope
-    Keyer.Wpm := Wpm;
+    Keyer.WpmS := Wpm;
     Keyer.MorseMsg := Keyer.Encode(ACall);
     NewEnvelope := Keyer.Envelope;
     for i:=0 to High(NewEnvelope) do

--- a/QrmStn.pas
+++ b/QrmStn.pas
@@ -35,7 +35,7 @@ begin
   HisCall := Ini.Call;
   Amplitude := 5000 + 25000 * Random;
   Pitch := Round(RndGaussLim(0, 300));
-  Wpm := 30 + Random(20);
+  WpmS := 30 + Random(20);
 
   // DX's sent exchange types depends on kind-of-station and their callsign
   SentExchTypes:= Tst.GetSentExchTypes(skDxStation, MyCall);

--- a/Station.pas
+++ b/Station.pas
@@ -54,7 +54,7 @@ type
     function NrAsText: string;
   public
     Amplitude: Single;
-    Wpm: integer;
+    WpmS: integer;          // Words per minute, sending speed (set by UI)
     Envelope: TSingleArray; // this station's digitized Envelope being sent
     State: TStationState;
 
@@ -245,8 +245,8 @@ begin
     SendPos := 0;
     FBfo := 0;
     end;
-    
-  Keyer.Wpm := Wpm;
+
+  Keyer.WpmS := WpmS;
   Keyer.MorseMsg := AMorse;
   Envelope := Keyer.Envelope;
   for i:=0 to High(Envelope) do

--- a/VCL/MorseKey.pas
+++ b/VCL/MorseKey.pas
@@ -26,7 +26,7 @@ type
     function BlackmanHarrisStepResponse(Len: integer): TSingleArray;
     procedure SetRiseTime(const Value: Single);
   public
-    Wpm: integer;
+    WpmS: integer;      // sending speed - Ts    (set by UI)
     BufSize: integer;
     Rate: integer;
     MorseMsg: string;
@@ -192,7 +192,7 @@ begin
       end;
 
   //calc buffer size
-  SamplesInUnit := Round(0.1 * Rate * 12 / Wpm);
+  SamplesInUnit := Round(0.1 * Rate * 12 / WpmS);
   TrueEnvelopeLen := UnitCnt * SamplesInUnit + RampLen;
   Len := BufSize * Ceil(TrueEnvelopeLen / BufSize);
   Result := nil;


### PR DESCRIPTION
Renames existing Wpm variable to WpmS and adds TStation.SetWpm() method.

This is done in preparation for adding Farnsworth support in #188. Fixes #189.