### PR TITLE
188 add farnsworth timing to sst contest

### DIFF
--- a/CWSST.pas
+++ b/CWSST.pas
@@ -117,6 +117,8 @@ begin
     inherited Create;
     CWSSTList:= TObjectList<TCWSSTRec>.Create;
     Comparer := TComparer<TCWSSTRec>.Construct(TCWSSTRec.compareCall);
+
+    BFarnsworthEnabled := true;
 end;
 
 destructor TCWSST.Destroy;

--- a/Contest.pas
+++ b/Contest.pas
@@ -20,6 +20,8 @@ type
     procedure SwapFilters;
 
   protected
+    BFarnsworthEnabled : Boolean; // enables Farnsworth timing (e.g. SST Contest)
+
     constructor Create;
     function IsReloadRequired(const AUserCallsign : String) : boolean;
     procedure SetLastLoadCallsign(const AUserCallsign : String);
@@ -48,6 +50,7 @@ type
     function OnSetMyCall(const AUserCallsign : string; out err : string) : boolean; virtual;
     function OnContestPrepareToStart(const AUserCallsign: string;
       const ASentExchange : string) : Boolean; virtual;
+    function IsFarnsworthAllowed : Boolean;
     function GetSentExchTypes(
       const AStationKind : TStationKind;
       const AMyCallsign : string) : TExchTypes;
@@ -108,6 +111,7 @@ begin
   Agc.AgcEnabled := true;
   NoActivityCnt :=0;
   LastLoadCallsign := '';
+  BFarnsworthEnabled := false;
 
   Init;
 end;
@@ -131,6 +135,7 @@ begin
   Stations.Clear;
   BlockNumber := 0;
   LastLoadCallsign := '';
+  BFarnsworthEnabled := false;
 end;
 
 
@@ -151,6 +156,18 @@ procedure TContest.SetLastLoadCallsign(const AUserCallsign : String);
 begin
   LastLoadCallsign := AUserCallsign;
 end;
+
+
+{
+  Farnsworth timing is supported by certain contests only (initially the
+  K1USN SST Contest). Derived contests will set BFarnworthEnabled in their
+  TContest.Create() method.
+}
+function TContest.IsFarnsworthAllowed : Boolean;
+begin
+  Result := BFarnsworthEnabled;
+end;
+
 
 
 {

--- a/DxOper.pas
+++ b/DxOper.pas
@@ -32,7 +32,7 @@ type
     State: TOperatorState;
     function GetSendDelay: integer;
     function GetReplyTimeout: integer;
-    function GetWpm: integer;
+    function GetWpm(out AWpmC : integer) : integer;
     function GetNR: integer;
     function GetName: string;
     procedure MsgReceived(AMsg: TStationMessages);
@@ -65,7 +65,7 @@ begin
     Result := SecondsToBlocks(0.1 + 0.5*Random);
 end;
 
-function TDxOperator.GetWpm: integer;
+function TDxOperator.GetWpm(out AWpmC : integer): integer;
 var
   mean, limit: Single;
 begin
@@ -81,6 +81,16 @@ begin
     end
   else                      { use Random value, [Wpm-Min,Wpm+Max] }
     Result := Round(Ini.Wpm - MinRxWpm + (MinRxWpm + MaxRxWpm) * Random);
+
+  // optionally force all stations to use same speed (debugging and timing)
+  if Ini.AllStationsWpmS > 10 then
+    Result := Ini.AllStationsWpmS;
+
+  // Allow Farnsworth timing for certain contests
+  if Tst.IsFarnsworthAllowed() and (Result < Ini.MinFarnsworthWpmC) then
+    AWpmC := Ini.MinFarnsworthWpmC
+  else
+    AWpmC := Result;
 end;
 
 function TDxOperator.GetNR: integer;

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -56,7 +56,8 @@ begin
   Oper.SetState(osNeedPrevEnd);
   NrWithError := Ini.Lids and (Random < 0.1);
 
-  WpmS := Oper.GetWpm;
+  // DX's speed, {WpmS,WpmC}, is set once at creation time
+  WpmS := Oper.GetWpm(WpmC);
 
   // DX's sent exchange types depends on kind-of-station and their callsign
   SentExchTypes := Tst.GetSentExchTypes(skDxStation, MyCall);

--- a/Ini.pas
+++ b/Ini.pas
@@ -184,7 +184,7 @@ var
   CompDuration: integer = 60;
 
   SaveWav: boolean = false;
-  MinFarnsworthWpmC: integer = 0;
+  MinFarnsworthWpmC: integer = 25;
   AllStationsWpmS: integer = 0;      // force all stations to this Wpm
   CallsFromKeyer: boolean = false;
   F8: string = '';

--- a/Ini.pas
+++ b/Ini.pas
@@ -184,6 +184,8 @@ var
   CompDuration: integer = 60;
 
   SaveWav: boolean = false;
+  MinFarnsworthWpmC: integer = 0;
+  AllStationsWpmS: integer = 0;      // force all stations to this Wpm
   CallsFromKeyer: boolean = false;
   F8: string = '';
 
@@ -288,11 +290,13 @@ begin
       SaveWav := ReadBool(SEC_STN, 'SaveWav', SaveWav);
 
       // [Settings]
+      MinFarnsworthWpmC := ReadInteger(SEC_SET, 'MinFarnsworthWpmC', MinFarnsworthWpmC);
 
       // [Debug]
       DebugExchSettings := ReadBool(SEC_DBG, 'DebugExchSettings', DebugExchSettings);
       DebugCwDecoder := ReadBool(SEC_DBG, 'DebugCwDecoder', DebugCwDecoder);
       DebugGhosting := ReadBool(SEC_DBG, 'DebugGhosting', DebugGhosting);
+      AllStationsWpmS := ReadInteger(SEC_DBG, 'AllStationsWpmS', AllStationsWpmS);
       F8 := ReadString(SEC_DBG, 'F8', F8);
     finally
       Free;
@@ -356,6 +360,8 @@ begin
       WriteInteger(SEC_STN, 'SelfMonVolume', V);
 
       WriteBool(SEC_STN, 'SaveWav', SaveWav);
+
+      WriteInteger(SEC_SET, 'MinFarnsworthWpmC', MinFarnsworthWpmC);
     finally
       Free;
     end;

--- a/MyStn.pas
+++ b/MyStn.pas
@@ -82,6 +82,9 @@ begin
   if Ini.AllStationsWpmS > 0
     then WpmS := Ini.AllStationsWpmS
     else WpmS := AWpmS;   // set via UI
+  if Tst.IsFarnsworthAllowed() and (Ini.MinFarnsworthWpmC > WpmS)
+    then WpmC := Ini.MinFarnsworthWpmC
+    else WpmC := WpmS;
 end;
 
 

--- a/MyStn.pas
+++ b/MyStn.pas
@@ -60,6 +60,7 @@ begin
   RST := 599;
   Pitch := Ini.Pitch;
   WpmS := Ini.Wpm;
+  WpmC := WpmS;
   Amplitude := 300000;
 
   // invalidate SentExchTypes. Will be set by Tst.OnSetMyCall().
@@ -78,7 +79,9 @@ end;
 }
 procedure TMyStation.SetWpm(const AWpmS : integer);
 begin
-  WpmS := AWpmS;   // set via UI
+  if Ini.AllStationsWpmS > 0
+    then WpmS := Ini.AllStationsWpmS
+    else WpmS := AWpmS;   // set via UI
 end;
 
 
@@ -186,7 +189,7 @@ begin
   if Result then
     begin
     //create new envelope
-    Keyer.WpmS := Wpm;
+    Keyer.SetWpm(Self.WpmS, Self.WpmC);
     Keyer.MorseMsg := Keyer.Encode(ACall);
     NewEnvelope := Keyer.Envelope;
     for i:=0 to High(NewEnvelope) do

--- a/QrmStn.pas
+++ b/QrmStn.pas
@@ -36,6 +36,7 @@ begin
   Amplitude := 5000 + 25000 * Random;
   Pitch := Round(RndGaussLim(0, 300));
   WpmS := 30 + Random(20);
+  WpmC := WpmS;
 
   // DX's sent exchange types depends on kind-of-station and their callsign
   SentExchTypes:= Tst.GetSentExchTypes(skDxStation, MyCall);

--- a/Station.pas
+++ b/Station.pas
@@ -91,6 +91,8 @@ type
     procedure SendText(AMsg: string); virtual;
     procedure SendMorse(AMorse: string);
 
+    function WpmAsText : string;
+
     property Pitch: integer read FPitch write SetPitch;
     property Bfo: Single read GetBfo;
   end;
@@ -346,6 +348,15 @@ begin
     if Random < 0.97
       then Result := StringReplace(Result, '9', 'N', [rfReplaceAll]);
     end;
+end;
+
+
+function TStation.WpmAsText : string;
+begin
+  if WpmS < WpmC then
+    Result:= Format('%d/%d', [WpmS, WpmC])
+  else
+    Result:= Format('%3d', [WpmS]);
 end;
 
 end.

--- a/Station.pas
+++ b/Station.pas
@@ -55,6 +55,7 @@ type
   public
     Amplitude: Single;
     WpmS: integer;          // Words per minute, sending speed (set by UI)
+    WpmC: integer;          // Words per minute, character speed (set via .INI)
     Envelope: TSingleArray; // this station's digitized Envelope being sent
     State: TStationState;
 
@@ -143,6 +144,7 @@ begin
 end;
 
 
+// returns the next block of 512 samples from this station's current Envelope.
 function TStation.GetBlock: TSingleArray;
 begin
   Result := Copy(Envelope, SendPos, Ini.BufSize);
@@ -246,7 +248,7 @@ begin
     FBfo := 0;
     end;
 
-  Keyer.WpmS := WpmS;
+  Keyer.SetWpm(Self.WpmS, Self.WpmC);
   Keyer.MorseMsg := AMorse;
   Envelope := Keyer.Envelope;
   for i:=0 to High(Envelope) do

--- a/VCL/MorseKey.pas
+++ b/VCL/MorseKey.pas
@@ -19,20 +19,25 @@ type
     RampOn, RampOff: TSingleArray;
     FRiseTime: Single;
 
+    // Farnsworth speed s/c (e.g. 5/18). specified as (WpmS/WpmC)
+    WpmS: integer;      // sending speed    (set by UI)
+    WpmC: integer;      // character speed  (set via .INI file, default=25wpm)
+
     function GetEnvelope: TSingleArray;
     procedure LoadMorseTable;
     procedure MakeRamp;
     function BlackmanHarrisKernel(x: Single): Single;
     function BlackmanHarrisStepResponse(Len: integer): TSingleArray;
     procedure SetRiseTime(const Value: Single);
-  public
-    WpmS: integer;      // sending speed - Ts    (set by UI)
+
+public
     BufSize: integer;
     Rate: integer;
     MorseMsg: string;
     TrueEnvelopeLen: integer;
 
     constructor Create;
+    procedure SetWpm(const AWpmS : integer; const AWpmC : integer = 0);
     function Encode(Txt: string): string;
 
     property RiseTime: Single read FRiseTime write SetRiseTime;
@@ -69,6 +74,9 @@ begin
   LoadMorseTable;
   Rate := 11025;
   RiseTime := 0.005;
+  //RiseTime := 1.0 / (2.7 * Rate); // debugging with 1 step rise/fall time
+  WpmS := 0;
+  WpmC := 0;
 end;
 
 
@@ -76,6 +84,13 @@ procedure TKeyer.SetRiseTime(const Value: Single);
 begin
   FRiseTime := Value;
   MakeRamp;
+end;
+
+
+procedure TKeyer.SetWpm(const AWpmS : integer; const AWpmC : integer = 0);
+begin
+  WpmS := AWpmS;
+  WpmC := AWpmC;
 end;
 
 
@@ -112,6 +127,7 @@ var
   i: integer;
   Scale: Single;
 begin
+  assert(Len > 0);
   SetLength(Result, Len);
   //generate kernel
   for i:=0 to High(Result) do Result[i] := BlackmanHarrisKernel(i/Len);
@@ -150,10 +166,24 @@ begin
 end;
 
 
+{
+  Returns a TSingleArray containing the samples representing the current
+  MsgText. If Farnsworth spacing is enabled, additional inter-character
+  and inter-word spacing will be been applied.
+
+  The following articles discuss the timing equations used in this
+  implementation.
+    - https://morsecode.world/international/timing.html
+    - https://www.arrl.org/files/file/Technology/x9004008.pdf
+}
 function TKeyer.GetEnvelope: TSingleArray;
 var
   UnitCnt, Len, i, p: integer;
+  Farnsworth: Boolean;
+  AdjustCnt: integer;  // units added for inter-character and inter-word spacing
+  DelayPerWord: Single;
   SamplesInUnit: integer;
+  SamplesPerAdjustUnit: integer; // samples per inter-character and inter-word unit
 
   procedure AddRampOn;
   begin
@@ -175,25 +205,81 @@ var
     Inc(p, Dur * SamplesInUnit - RampLen);
   end;
 
-  procedure AddOff(Dur: integer);
+  // Add 'Dur' units of 0-value (Off) to the output stream, less 'Prior' units
+  // of spacing from the last CW character emitted. Remember that characters
+  // have a trailing ' ' after each character. When adding additional
+  // inter-word spacing, the prior units at character-spacing have to be
+  // removed and replaced with 'Dur' units of Farnsworth inter-word spacing.
+  //
+  // Dur - desired duration in units
+  // Prior - number of standard units already applied
+  // ARampLen - number of samples representing the RampOff length
+  // AFarnsAdj - if enabled, apply additional Farnsworth delay
+  procedure AddOff(Dur, Prior: integer; ARampLen: integer = 0; AFarnsAdj : Boolean = false);
   begin
-    Inc(p, Dur * SamplesInUnit - RampLen);
+    Inc(p, (Dur-Prior) * SamplesInUnit - ARampLen);
+    if AFarnsAdj then
+      Inc(p, Dur * (SamplesPerAdjustUnit - SamplesInUnit));
+  end;
+
+  // this procedure will adjust any prior UnitCnt (at WpmC) before incrementing
+  // the Farnsworth-adjusted AdjustCnt units (at WpmS).
+  procedure IncUnitCnt(Dur: integer; Prior: integer = 0);
+  begin
+    if Farnsworth then
+      begin
+        Dec(UnitCnt, Prior);
+        Inc(AdjustCnt, Dur);
+      end
+    else
+      Inc(UnitCnt, Dur-Prior);
   end;
 
 begin
+  assert(WpmS > 0, 'must init using SetWpm()');
+
   //count units
-  UnitCnt := 0;
+  UnitCnt := 0;     // intra-character spaces
+  AdjustCnt := 0;   // inter-character and inter-word spaces (Farnsworth timing)
+
+  //setup Farnsworth timing adjustments
+  DelayPerWord := 0.0;
+  SamplesPerAdjustUnit := 0;
+  Farnsworth := WpmS < WpmC;
+  if Farnsworth then
+    begin
+      // Farnsworth timing uses a different inter-character and inter-word
+      // spacing. Timing equations are discussed in these two articles:
+      // - https://morsecode.world/international/timing.html
+      // - https://www.arrl.org/files/file/Technology/x9004008.pdf
+      //
+      // DelayPerWord (19 units of spacing)
+      //    = (50 units (1 word) at WpmS) -
+      //      (31 character units at WpmC)
+      // samples = time * samples/sec
+      DelayPerWord := 50*1.2/WpmS - 31*1.2/WpmC;
+      SamplesPerAdjustUnit := Round(DelayPerWord * Rate / 19);
+    end
+  else
+    WpmC := WpmS;
+
+  // when adding farnsworth timing, the functions below have been adjusted to
+  // compensate for the 1U intra-character space added by the last character.
+  // For example, when counting for ' ' (a 3U inter-character space), we will
+  // count 3 inter-character units less the 1 unit of intra-character space
+  // already streamed by the prior character.
   for i:=1 to Length(MorseMsg) do
     case MorseMsg[i] of
-      '.': Inc(UnitCnt, 2);
-      '-': Inc(UnitCnt, 4);
-      ' ': Inc(UnitCnt, 2);
+      '.': Inc(UnitCnt, 2);     // 1 unit dit followed by 1 unit spacing
+      '-': Inc(UnitCnt, 4);     // 3 unit dash followed by 1 unit spacing
+      ' ': IncUnitCnt(3, 1);    // inter-character spacing (3U less 1U prior)
       '~': Inc(UnitCnt, 1);
-      end;
+    end;
 
   //calc buffer size
-  SamplesInUnit := Round(0.1 * Rate * 12 / WpmS);
-  TrueEnvelopeLen := UnitCnt * SamplesInUnit + RampLen;
+  SamplesInUnit := Round(0.1 * Rate * 12 / WpmC);
+  TrueEnvelopeLen := UnitCnt * SamplesInUnit +            // units at WpmC
+                     AdjustCnt * SamplesPerAdjustUnit;    // units at WpmS
   Len := BufSize * Ceil(TrueEnvelopeLen / BufSize);
   Result := nil;
   SetLength(Result, Len);
@@ -202,11 +288,12 @@ begin
   p := 0;
   for i:=1 to Length(MorseMsg) do
     case MorseMsg[i] of
-      '.': begin AddRampOn; AddOn(1); AddRampOff; AddOff(1); end;
-      '-': begin AddRampOn; AddOn(3); AddRampOff; AddOff(1); end;
-      ' ': AddOff(2);
-      '~': AddOff(1);
+      '.': begin AddRampOn; AddOn(1); AddRampOff; AddOff(1, 0, RampLen); end;
+      '-': begin AddRampOn; AddOn(3); AddRampOff; AddOff(1, 0, RampLen); end;
+      ' ': AddOff(3, 1, 0, Farnsworth);   // inter-char spacing (3U less 1U applied)
+      '~': AddOff(1, 0);                  // one unit of spacing
       end;
+  assert(p = TrueEnvelopeLen);
 end;
 
 


### PR DESCRIPTION
Introduces Farnsworth timing for the K1USN Slow Speed Test (SST) only. Fixes #188.

The Farnsworth character speed is specified using the following `MorseRunner.ini` setting:
```
[Settings]
MinFarnsworthWpmC=25
```
To increase the spacing between characters and words, slow the sending speed down using the usual UI control. For example, a UI speed of 18 with the above `.INI` file settings, the resulting Farnsworth speed would be 18/25 (18 wpm using characters sent at 25 wpm).

**Question:** Can you think of an alternate name for `MinFarnsworthWpmC`? I struggled to find an appropriate name for the Farnsworth character speed. Perhaps `FarnsworthCharacterRate=25`?