### PR TITLE
208 SST Contest - allow empty user text when loading call history

### DIFF
--- a/CWSST.pas
+++ b/CWSST.pas
@@ -92,7 +92,6 @@ begin
                 if SST.Call='' then continue;
                 if SST.Exch1='' then  continue;
                 if SST.Exch2='' then continue;
-                if SST.UserText='' then continue;
                 if length(SST.Exch1) > 10 then continue;
                 if length(SST.Exch2) > 5 then continue;
 


### PR DESCRIPTION
fix #208. SST Contest - call history file can now contain empty user-text message fields.
These callsign entries where being dropped and excluded from the contest. 