### PR TITLE
CWOPS CWT - fix call history reader to ignore comment lines

### DIFF
--- a/ACAG.pas
+++ b/ACAG.pas
@@ -84,7 +84,8 @@ begin
 
         rec.Call := UpperCase(tl.Strings[0]);
         rec.Number := UpperCase(tl.Strings[1]);
-        if (tl.Count >= 3) then rec.UserText := tl.Strings[2];
+        rec.UserText := '';
+        if (tl.Count >= 3) then rec.UserText := Trim(tl.Strings[2]);
         if rec.Call = '' then continue;
         if rec.Number = '' then continue;
 

--- a/ALLJA.pas
+++ b/ALLJA.pas
@@ -84,7 +84,8 @@ begin
 
         rec.Call := UpperCase(tl.Strings[0]);
         rec.Number := UpperCase(tl.Strings[1]);
-        if (tl.Count >= 3) then rec.UserText := tl.Strings[2];
+        rec.UserText := '';
+        if (tl.Count >= 3) then rec.UserText := Trim(tl.Strings[2]);
         if rec.Call = '' then continue;
         if rec.Number = '' then continue;
 

--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -70,6 +70,7 @@ begin
   tl:= TStringList.Create;
   tl.Delimiter := DelimitChar;
   tl.StrictDelimiter := True;
+  rec := nil;
 
   try
     FdCallList.Clear;
@@ -77,16 +78,20 @@ begin
     slst.LoadFromFile(ParamStr(1) + 'FD_2022-004.TXT');
 
     for i:= 0 to slst.Count-1 do begin
+      if (slst.Strings[i].StartsWith('!!Order!!')) then continue;
+      if (slst.Strings[i].StartsWith('#')) then continue;
+
       tl.DelimitedText := slst.Strings[i];
 
       if (tl.Count > 2) then begin
-          if (tl.Strings[0] = '!!Order!!') then continue;
-
-          rec := TFdCallRec.Create;
+          if rec = nil then
+            rec := TFdCallRec.Create;
           rec.Call := UpperCase(tl.Strings[0]);
           rec.StnClass := UpperCase(tl.Strings[1]);
           rec.Section := UpperCase(tl.Strings[2]);
-          if (tl.Count >= 4) then rec.UserText := tl.Strings[3];
+          rec.UserText := '';
+          if (tl.Count >= 4) then rec.UserText := Trim(tl.Strings[3]);
+
           if rec.Call='' then continue;
           if rec.StnClass='' then continue;
           if rec.Section='' then continue;
@@ -95,6 +100,7 @@ begin
           //if length(rec.Name) > 12 then continue;
 
           FdCallList.Add(rec);
+          rec := nil;
       end;
     end;
 
@@ -103,6 +109,7 @@ begin
   finally
     slst.Free;
     tl.Free;
+    if rec <> nil then rec.Free;
   end;
 end;
 

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -72,10 +72,13 @@ begin
         CWOPSList.Clear;
 
         slst.LoadFromFile(ParamStr(1) + 'CWOPS.LIST');
-        slst.Sort;
 
         for i:= 0 to slst.Count-1 do begin
+            if (slst.Strings[i].StartsWith('!!Order!!')) then continue;
+            if (slst.Strings[i].StartsWith('#')) then continue;
+
             self.Delimit(tl, slst.Strings[i]);
+
             if (tl.Count >= 3) then begin
                 if CWO = nil then
                   CWO:= TCWOPSRec.Create;
@@ -84,7 +87,7 @@ begin
                 CWO.Exch1:= UpperCase(tl.Strings[NameInx]);
                 CWO.Exch2:= UpperCase(tl.Strings[ExchInx]);
                 if tl.Count > UserTextInx then
-                  CWO.UserText:= tl.Strings[UserTextInx];
+                  CWO.UserText:= Trim(tl.Strings[UserTextInx]);
                 if CWO.Call='' then continue;
                 if CWO.Exch1='' then  continue;
                 if CWO.Exch2='' then continue;

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -68,6 +68,7 @@ begin
   tl:= TStringList.Create;
   tl.Delimiter := DelimitChar;
   tl.StrictDelimiter := True;
+  rec := nil;
 
   try
     CqWwCallList.Clear;
@@ -75,20 +76,24 @@ begin
     slst.LoadFromFile(ParamStr(1) + 'CQWWCW.TXT');
 
     for i:= 0 to slst.Count-1 do begin
+      if (slst.Strings[i].StartsWith('!!Order!!')) then continue;
+      if (slst.Strings[i].StartsWith('#')) then continue;
+
       tl.DelimitedText := slst.Strings[i];
 
       if (tl.Count > 2) then begin
-          if (tl.Strings[0] = '!!Order!!') then continue;
-
-          rec := TCqWwCallRec.Create;
+          if rec = nil then
+            rec := TCqWwCallRec.Create;
           rec.Call := UpperCase(tl.Strings[0]);
           rec.CQZone := UpperCase(tl.Strings[1]);
-          if (tl.Count >= 3) then rec.UserText := tl.Strings[2];
+          rec.UserText := '';
+          if tl.Count >= 3 then rec.UserText := Trim(tl.Strings[2]);
           if rec.Call='' then continue;
           if rec.CQZone='' then continue;
           if IsNum(rec.CQZone) = False then continue;
 
           CqWwCallList.Add(rec);
+          rec := nil;
       end;
     end;
 
@@ -104,6 +109,7 @@ begin
   finally
     slst.Free;
     tl.Free;
+    if rec <> nil then rec.Free;
   end;
 end;
 


### PR DESCRIPTION
- fix call history reader to ignore comments and setup lines
- fix memory leaks
- strip lead/trailing whitespace on user text fields