### PR TITLE
216 NAQP does not accept numbers in state field

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -61,7 +61,7 @@ type
     function GetExchangeTypes(
       const AStationKind : TStationKind;
       const ARequestedMsgType : TRequestedMsgType;
-      const ADxCallsign : string) : TExchTypes; virtual;
+      const AStationCallsign : string) : TExchTypes; virtual;
     procedure SendMsg(const AStn: TStation; const AMsg: TStationMessage); virtual;
     procedure SendText(const AStn: TStation; const AMsg: string); virtual;
     function ExtractMultiplier(Qso: PQso) : string; virtual;
@@ -273,7 +273,7 @@ end;
 function TContest.GetExchangeTypes(
   const AStationKind : TStationKind;
   const ARequestedMsgType : TRequestedMsgType;
-  const ADxCallsign : string) : TExchTypes;
+  const AStationCallsign : string) : TExchTypes;
 begin
   Result.Exch1 := ActiveContest.ExchType1;
   Result.Exch2 := ActiveContest.ExchType2;

--- a/Contest.pas
+++ b/Contest.pas
@@ -252,7 +252,7 @@ function TContest.GetSentExchTypes(
   const AStationKind : TStationKind;
   const AMyCallsign : string) : TExchTypes;
 begin
-  Result:= Self.GetExchangeTypes(AStationKind, mtSendMsg, {ADxCallsign=}'');
+  Result:= Self.GetExchangeTypes(AStationKind, mtSendMsg, AMyCallsign);
 end;
 
 
@@ -484,7 +484,8 @@ begin
        begin
          MainForm.Edit1.Text := DxStn.LastDxCallsign;
          MainForm.Edit2.Text := DxStn.LastExch1;
-         MainForm.Edit3.Text := DxStn.LastExch2;
+         if (SimContest <> scNaQp) or (DxStn.LastExch2 <> 'DX') then
+           MainForm.Edit3.Text := DxStn.LastExch2;
        end;
   end
   else

--- a/DualExchContest.pas
+++ b/DualExchContest.pas
@@ -29,7 +29,7 @@ type
     function GetExchangeTypes(
       const AStationKind : TStationKind;
       const ARequestedMsgType : TRequestedMsgType;
-      const ADxCallsign : string) : TExchTypes; override;
+      const AStationCallsign : string) : TExchTypes; override;
 
   end;
 
@@ -75,7 +75,7 @@ end;
 function TDualExchContest.GetExchangeTypes(
   const AStationKind : TStationKind;
   const ARequestedMsgType : TRequestedMsgType;
-  const ADxCallsign : string) : TExchTypes;
+  const AStationCallsign : string) : TExchTypes;
 var
   HomeCallIsDX: Boolean;
   IsSimDxStation: Boolean;

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -213,6 +213,7 @@ begin
       etPower: TrueExch2 := Self.Exch2;
       etJaPref: TrueExch2 := Self.Exch2;
       etJaCity: TrueExch2 := Self.Exch2;
+      etNaQpExch2, etNaQpNonNaExch2: TrueExch2 := Self.Exch2;
       else
         assert(false);
     end;

--- a/Ini.pas
+++ b/Ini.pas
@@ -34,7 +34,8 @@ type
 
   // Exchange Field #2 Types
   TExchange2Type = (etSerialNr, etGenericField, etArrlSection, etStateProv,
-                    etCqZone, etItuZone, etAge, etPower, etJaPref, etJaCity);
+                    etCqZone, etItuZone, etAge, etPower, etJaPref, etJaCity,
+                    etNaQpExch2, etNaQpNonNaExch2);
 
   // Contest definition.
   TContestDefinition = record
@@ -102,12 +103,12 @@ const
     (Name: 'NCJ NAQP';
      Key: 'NAQP';
      ExchType1: etOpName;
-     ExchType2: etStateProv;
+     ExchType2: etNaQpExch2;
      ExchFieldEditable: True;
      ExchDefault: 'MIKE OR';
-     Msg: '''<name> <state-prov>'' (e.g. MIKE OR)';
+     Msg: '''<name> [<state|prov|dxcc-entity>]'' (e.g. MIKE OR)';
      T:scNaQp),
-     // expecting two strings [Name,State-Prov] (e.g. MIKE OR)
+     // expecting one or two strings {Name,[State|Prov|DXCC Entity]} (e.g. MIKE OR)
 
     (Name: 'HST (High Speed Test)';
      Key: 'HST';

--- a/Log.pas
+++ b/Log.pas
@@ -570,6 +570,8 @@ var
       etPower:       Result := Length(text) > 0;
       etJaPref:      Result := Length(text) > 2;
       etJaCity:      Result := Length(text) > 3;
+      etNaQpExch2:   Result := Length(text) > 0;
+      etNaQpNonNaExch2: Result := Length(text) >= 0;
       else
         assert(false, 'missing case');
     end;
@@ -616,6 +618,12 @@ begin
       etPower:       Qso.Exch2 := Edit3.Text;
       etJaPref:      Qso.Exch2 := Edit3.Text;
       etJaCity:      Qso.Exch2 := Edit3.Text;
+      etNaQpExch2:   Qso.Exch2 := Edit3.Text;
+      etNaQpNonNaExch2:
+        if Edit3.Text = '' then
+          Qso.Exch2 := 'DX'
+        else
+          Qso.Exch2 := Edit3.Text;
       else
         assert(false, 'missing case');
     end;
@@ -785,6 +793,12 @@ begin
                    Err := 'PWR';
         etJaPref: if TrueExch2 <> Exch2 then Err := 'NR ';
         etJaCity: if TrueExch2 <> Exch2 then Err := 'NR ';
+        etNaQpExch2:  if TrueExch2 <> Exch2 then Err := 'ST ';
+        etNaQpNonNaExch2:
+          // Non-NA stations do not send a location (typically logged as DX)
+          if not (TrueExch2.Equals(Exch2) or
+                  (Exch2.Equals('DX') and TrueExch2.IsEmpty)) then
+            Err := 'ST ';
         else
           assert(false, 'missing exchange 2 case');
       end;

--- a/NAQPCW.txt
+++ b/NAQPCW.txt
@@ -18,6 +18,11 @@
 # SPRINTNS 
 # SPRINTRTTY 
 # SPRINTSSB 
+#
+# DxOnly
+# HiOnly
+# AkOnly
+# NaOnly
 4U1WB,MASA,DC,
 7L1WII,SAM,,
 8P5A,TOM,,

--- a/Station.pas
+++ b/Station.pas
@@ -288,7 +288,7 @@ begin
 end;
 
 
-                                                
+
 {
   This function formats the exchange string to be sent by this station
   by combining exchange fields 1 and 2.
@@ -307,7 +307,12 @@ begin
       Result := Format('%s %s', [Exch1, Exch2]); // <Name> <State|Prov|DX>
     scFieldDay:
       Result := Format('%s %s', [Exch1, Exch2]);
-    scNaQp, scArrlDx:
+    scNaQp:
+      if Exch2.IsEmpty then
+        Result := Exch1
+      else
+        Result := Format('%s %s', [Exch1, Exch2]);  // make this virtual?
+    scArrlDx:
       Result := Format('%s %s', [Exch1, Exch2]);
     scAllJa, scAcag:
       Result := Format('%s %s', [Exch1, Exch2]);


### PR DESCRIPTION
NAQP does not accept numbers in state field

- allow '/' and numbers in State/Prov/Entity field
- fix North America and Hawaii (NA) and other NA/Non-NA behaviors
- allow KH6/KP4 to be used in the user's exchange
- non-NA stations send Name only (no location)
- when working a non-NA station, an empty State field is logged as DX
- when user is a non-NA station, only NA stations are worked
- only NA State/Prov/Entity (including Hawaii) are valid multipliers