### PR TITLE
218 ARRL DX format for KH6/KL7 is incorrect

### DIFF
--- a/ARRL.LIST
+++ b/ARRL.LIST
@@ -3,6 +3,10 @@ Used with permission: DXCC Country List, copyright ARRL.
 March 2022 Edition
 https://www.arrl.org/files/file/DXCC/2022_DXCC_Current.pdf
 
+Updated January 2024 by W7SST - added additional regular expression info from:
+- https://en.wikipedia.org/wiki/ITU_prefix
+- https://www.country-files.com
+
 1A;1A;Sov. Mil. Order of Malta;EU;28;15;246
 3A;3A;Monaco;EU;27;14;260
 3B6,7;3B[6|7];Agalega & St. Brandon Is.;AF;53;39;004
@@ -12,41 +16,36 @@ https://www.arrl.org/files/file/DXCC/2022_DXCC_Current.pdf
 3C0;3C0;Annobon I.;AF;52;36;195
 3D2;3D2;Fiji/Conway Reef/Rotuma I.;OC;56;32;176
 3DA;3DA;Swaziland;AF;57;38;468
-3V;3V;Tunisia;AF;37;33;474
-3W;3W;Viet Nam;AS;49;26;293
-XV;XV;Viet Nam;AS;49;26;293
+3V;(3V)|(TS);Tunisia;AF;37;33;474
+3W;(3W)|(XV);Viet Nam;AS;49;26;293
 3X;3X;Guinea;AF;46;35;107
 3Y;3Y;Bouvet;AF;67;38;024
 3Y;3Y;Peter 1 I.;AN;72;12;199
-4J;4J;Azerbaijan;AS;29;21;018
-4K;4K;Azerbaijan;AS;29;21;018
+4J;4[JK];Azerbaijan;AS;29;21;018
 4L;4L;Georgia;AS;29;21;075
 4O;4O;Montenegro;EU;28;15;514
-4S;4S;Sri Lanka;AS;41;22;315
+4S;4[PQRS];Sri Lanka;AS;41;22;315
 4U_ITU;4U[0-9];ITU HQ;EU;28;14;117
 4U_UN;4U_UN;United Nations HQ;NA;08;05;289
 4W;4W;Timor - Leste;OC;54;28;511
-4X;4X;Israel;AS;39;20;336
-4Z;4Z;Israel;AS;39;20;336
+4X;4[XZ];Israel;AS;39;20;336
 5A;5A;Libya;AF;38;34;436
-5B;5B;Cyprus;AS;39;20;215
-C4;C4;Cyprus;AS;39;20;215
-P3;P3;Cyprus;AS;39;20;215
-5H-5I;5[H-I];Tanzania;AF;53;37;470
-5N;5N;Nigeria;AF;46;35;450
-5R;5R;Madagascar;AF;53;39;438
+5B;5B|C4|H2|P3;Cyprus;AS;39;20;215
+5H-5I;5[HI];Tanzania;AF;53;37;470
+5N;5[NO];Nigeria;AF;46;35;450
+5R;(5[RS])|(6X);Madagascar;AF;53;39;438
 5T;5T;Mauritania;AF;46;35;444
 5U;5U;Niger;AF;46;35;187
 5V;5V;Togo;AF;46;35;483
 5W;5W;Samoa;OC;62;32;190
 5X;5X;Uganda;AF;48;37;286
-5Y-5Z;5[Y-Z];Kenya;AF;48;37;430
-6V-6W;6[V-W];Senegal;AF;46;35;456
+5Y-5Z;5[YZ];Kenya;AF;48;37;430
+6V-6W;6[VW];Senegal;AF;46;35;456
 6Y;6Y;Jamaica;NA;11;08;082
 7O;7O;Yemen;AS;39;21;492
 7P;7P;Lesotho;AF;57;38;432
 7Q;7Q;Malawi;AF;53;37;440
-7T-7Y;7[T-Y];Algeria;AF;37;33;400
+7T-7Y;7[RT-Y];Algeria;AF;37;33;400
 8P;8P;Barbados;NA;11;08;062
 8Q;8Q;Maldives;AS/AF;41;22;159
 8R;8R;Guyana;SA;12;09;129
@@ -56,49 +55,49 @@ P3;P3;Cyprus;AS;39;20;215
 9I-9J;9[I-J];Zambia;AF;53;36;482
 9K;9K;Kuwait;AS;39;21;348
 9L;9L;Sierra Leone;AF;46;35;458
-9M2,4;9M[2|4];West Malaysia;AS;54;28;299
-9M6,8;9M[6|8];East Malaysia;OC;54;28;046
+9M2,4;9[MW][24];West Malaysia;AS;54;28;299
+9M6,8;9[MW][68];East Malaysia;OC;54;28;046
 9N;9N;Nepal;AS;42;22;369
-9Q-9T;9[Q-T];Dem. Rep. of Congo;AF;52;36;414
+9Q-9T;9[O-T];Dem. Rep. of Congo;AF;52;36;414
 9U;9U;Burundi;AF;52;36;404
-9V;9V;Singapore;AS;54;28;381
+9V;(9V)|(S6);Singapore;AS;54;28;381
 9X;9X;Rwanda;AF;52;36;454
 9Y-9Z;9[Y-Z];Trinidad & Tobago;SA;11;09;090
-A2;A2;Botswana;AF;57;38;402
+A2;(80)|(A2);Botswana;AF;57;38;402
 A3;A3;Tonga;OC;62;32;160
 A4;A4;Oman;AS;39;21;370
 A5;A5;Bhutan;AS;41;22;306
 A6;A6;United Arab Emirates;AS;39;21;391
 A7;A7;Qatar;AS;39;21;376
 A9;A9;Bahrain;AS;39;21;304
-AP;AP;Pakistan;AS;41;21;372
+AP;[6A][P-S];Pakistan;AS;41;21;372
 B;B;China;AS;33,42-44,47,48;23,24;318
 BS7;BS7;Scarborough Reef,China;AS;50;27;506
-BU-BX;B[M-OU-X];Taiwan;AS;44;24;386
-BV9P;BV9P;Pratas I. China;AS;44;24;505
+BU-BX;B[M-QU-X];Taiwan;AS;44;24;386
+BV9P;B[MNOPQUVWX]9P;Pratas I. China;AS;44;24;505
 C2;C2;Nauru;OC;65;31;157
 C3;C3;Andorra;EU;27;14;203
 C5;C5;The Gambia;AF;46;35;422
 C6;C6;Bahamas;NA;11;08;060
 C8-9;C[8-9];Mozambique;AF;53;37;181
-CA-CE;C[A-E];Chile;SA;14,16;12;112
-CE0;CE0;Easter I.;SA;63;12;047
-CE0;CE0;Juan Fernandez Is.;SA;14;12;125
-CE0;CE0;San Felix & San Ambrosio;SA;14;12;217
+CA-CE;(3G)|(C[A-E])|(X[QR]);Chile;SA;14,16;12;112
+CE0;((3G)|(C[A-E])|(X[QR]))0;Easter I.;SA;63;12;047
+CE0;((3G)|(C[A-E])|(X[QR]))0Z;Juan Fernandez Is.;SA;14;12;125
+CE0;((3G)|(C[A-E])|(X[QR]))0X;San Felix & San Ambrosio;SA;14;12;217
 CE9/KC4;CE9/KC4;Antarctica;AN;67,69-74;12,13,29,30,32,38,39;013
-CM,CO;C[M|O];Cuba;NA;11;08;070
-CN;CN;Morocco;AF;37;33;446
+CM,CO;(C[LMO])|(T4);Cuba;NA;11;08;070
+CN;(CN)|(5[C-G]);Morocco;AF;37;33;446
 CP;CP;Bolivia;SA;12,14;10;104
-CT;CT;Portugal;EU;37;14;272
-CT3;CT3;Madeira Is.;AF;36;33;256
-CU;CU;Azores;EU;36;14;149
+CT;C[Q-T];Portugal;EU;37;14;272
+CT3;(CQ[239])|(C[RST][39]);Madeira Is.;AF;36;33;256
+CU;(CQ[18])|(CR[128])|(CS[48])|(CT8)|(CU);Azores;EU;36;14;149
 CV-CX;C[V-X];Uruguay;SA;14;13;144
 CY0;CY0;Sable I.;NA;09;05;211
 CY9;CY9;St. Paul I.;NA;09;05;252
 D2-3;D[2-3];Angola;AF;52;36;401
 D4;D4;Cape Verde;AF;46;35;409
 D6;D6;Comoros;AF;53;39;411
-DA-DR;D[A-R];Fed. Rep. of Germany;EU;28;14;230
+DA-DR;(D[A-R])|(Y[2-9]);Fed. Rep. of Germany;EU;28;14;230
 DU-DZ;D[U-Z];Philippines;OC;50;27;375
 4D-4I;4[D-I];Philippines;OC;50;27;375
 E3;E3;Eritrea;AF;48;37;051
@@ -107,22 +106,22 @@ E5;E5;N. Cook Is.;OC;62;32;191
 E5;E5;S. Cook Is.;OC;62;32;234
 E6;E6;Niue;OC;62;32;188
 E7;E7;Bosnia-Herzegovina;EU;28;15;501
-EA-EH;E[A-H];Spain;EU;37;14;281
-EA6-EH6;E[A-H]6;Balearic Is.;EU;37;14;021
-EA8-EH8;E[A-H]8;Canary Is.;AF;36;33;029
-EA9-EH9;E[A-H]9;Ceuta & Melilla;AF;37;33;032
+EA-EH;(E[A-H])|(A[M-O]);Spain;EU;37;14;281
+EA6-EH6;(A[M-O]6)|(E[A-H]6);Balearic Is.;EU;37;14;021
+EA8-EH8;(A[M-O]8)|(E[A-H]8);Canary Is.;AF;36;33;029
+EA9-EH9;(A[M-O]9)|(E[A-H]9);Ceuta & Melilla;AF;37;33;032
 EI-EJ;E[I-J];Ireland;EU;27;14;245
 EK;EK;Armenia;AS;29;21;014
-EL;EL;Liberia;AF;46;35;434
-EP-EQ;E[P-Q];Iran;AS;40;21;330
+EL;(5[LM])|(6Z)|(A8)|(D5)|(EL);Liberia;AF;46;35;434
+EP-EQ;(9[BCD])|(E[P-Q]);Iran;AS;40;21;330
 ER;ER;Moldova;EU;29;16;179
 ES;ES;Estonia;EU;29;15;052
-ET;ET;Ethiopia;AF;48;37;053
+ET;(9[EF])|(ET);Ethiopia;AF;48;37;053
 EU-EW;E[U-W];Belarus;EU;29;16;027
 EX;EX;Kyrgyzstan;AS;30,31;17;135
 EY;EY;Tajikistan;AS;30;17;262
 EZ;EZ;Turkmenistan;AS;30;17;280
-F;F;France;EU;27;14;227
+F;(F)|(H[WXY])|(T[HMOPQVX]);France;EU;27;14;227
 FG,TO;(FG)|(TO);Guadeloupe;NA;11;08;079
 FH,TO;(FH)|(TO);Mayotte;AF;53;39;169
 FJ,TO;(FJ)|(TO);Saint Barthelemy;NA;11;08;516
@@ -135,118 +134,118 @@ FO,TX;(FO)|(TX);French Polynesia;OC;63;32;175
 FO,TX;(FO)|(TX);Marquesas Is.;OC;63;31;509
 FP;FP;St. Pierre & Miquelon;NA;09;05;277
 FR,TO;(FR)|(TO);Reunion I.;AF;53;39;453
-FT/G,TO;(FT)|(TO);Glorioso Is.;AF;53;39;099
-FT/J,E,TO;(FT)|(TO);Juan de Nova,Europa;AF;53;39;124
-FT/T,TO;(FT)|(TO);Tromelin I.;AF;53;39;276
+FT/G,TO;(FT[0-9]G)|(TO);Glorioso Is.;AF;53;39;099
+FT/J,E,TO;(FT[0-46-9][JE])|(TO);Juan de Nova,Europa;AF;53;39;124
+FT/T,TO;(FT[0-9]T)|(TO);Tromelin I.;AF;53;39;276
 FS,TO;(FS)|(TO);Saint Martin;NA;11;08;213
-FT/W;FT;Crozet I.;AF;68;39;041
-FT/X;FT;Kerguelen Is.;AF;68;39;131
-FT/Z;FT;Amsterdam & St. Paul Is.;AF;68;39;010
-FW;FW;Wallis & Futuna Is.;OC;62;32;298
+FT/W;FT[0458]W;Crozet I.;AF;68;39;041
+FT/X;FT[02458]X;Kerguelen Is.;AF;68;39;131
+FT/Z;FT[0-8]Z;Amsterdam & St. Paul Is.;AF;68;39;010
+FW;[FT]W;Wallis & Futuna Is.;OC;62;32;298
 FY;FY;French Guiana;SA;12;09;063
-G,GX,M;(G)|(GX)|(M);England;EU;27;14;223
-GD,GT;G[DT];Isle of Man;EU;27;14;114
-GI,GN;G[IN];Northern Ireland;EU;27;14;265
-GJ,GH;G[JH];Jersey;EU;27;14;122
-GM,GS;G[MS];Scotland;EU;27;14;279
-GU,GP;G[UP];Guernsey;EU;27;14;106
-GW,GC;G[WC];Wales;EU;27;14;294
+G,GX,M;(2E)|(G)|(GX)|(M);England;EU;27;14;223
+GD,GT;(2D)|(G[DT])|(M[DT]);Isle of Man;EU;27;14;114
+GI,GN;(2I)|(G[IN])|(M[IN]);Northern Ireland;EU;27;14;265
+GJ,GH;(2J)|(G[JH])|(M[JH]);Jersey;EU;27;14;122
+GM,GS;(2[AM])|(G[MS])|(M[AMS]);Scotland;EU;27;14;279
+GU,GP;(2U)|(G[UP])|(M[UP]);Guernsey;EU;27;14;106
+GW,GC;(2W)|(G[WC])|(M[WC]);Wales;EU;27;14;294
 H4;H4;Solomon Is.;OC;51;28;185
 H40;H40;Temotu Province;OC;51;32;507
-HA,HG;H[A|G];Hungary;EU;28;15;239
-HB;HB;Switzerland;EU;28;14;287
-HB0;HB0;Liechtenstein;EU;28;14;251
+HA,HG;H[AG];Hungary;EU;28;15;239
+HB;H[BE];Switzerland;EU;28;14;287
+HB0;H[BE]0;Liechtenstein;EU;28;14;251
 HC-HD;H[C-D];Ecuador;SA;12;10;120
 HC8-HD8;H[C-D]8;Galapagos Is.;SA;12;10;071
-HH;HH;Haiti;NA;11;08;078
+HH;(4V)|(HH);Haiti;NA;11;08;078
 HI;HI;Dominican Republic;NA;11;08;072
-HJ-HK,5J-5K;(H[J-K])|(5[J-K]);Colombia;SA;12;09;116
-HK0;HK0;Malpelo I.;SA;12;09;161
-HK0;HK0;San Andres & Providencia;NA;11;07;216
-HL,6K-6N;(HL)|(6[K-N]);Republic of Korea;AS;44;25;137
-HO-HP;H[O-P];Panama;NA;11;07;088
+HJ-HK,5J-5K;(H[J-K])|(5[JK]);Colombia;SA;12;09;116
+HK0/a;H[JK]0M;Malpelo I.;SA;12;09;161
+HK0/m;[5H][JK]0;San Andres & Providencia;NA;11;07;216
+HL,6K-6N;(HL)|(6[K-N])|(D[789ST])|(KL9K);Republic of Korea;AS;44;25;137
+HO-HP;(3[EF])|(H[389OP]);Panama;NA;11;07;088
 HQ-HR;H[Q-R];Honduras;NA;11;07;080
 HS,E2;(HS)|(E2);Thailand;AS;49;26;387
 HV;HV;Vatican;EU;28;15;295
-HZ;HZ;Saudi Arabia;AS;39;21;378
-I;I;Italy;EU;28,33;15;248
-IS0,IM0;I[S|M]0;Sardinia;EU;28;15;225
+HZ;[78H]Z;Saudi Arabia;AS;39;21;378
+I;(4V)|(I);Italy;EU;28,33;15;248
+IS0,IM0;(I[SM]0)|(IW0[U-Z]);Sardinia;EU;28;15;225
 J2;J2;Djibouti;AF;48;37;382
 J3;J3;Grenada;NA;11;08;077
 J5;J5;Guinea-Bissau;AF;46;35;109
 J6;J6;St. Lucia;NA;11;08;097
 J7;J7;Dominica;NA;11;08;095
 J8;J8;St. Vincent;NA;11;08;098
-JA-JS,7J-7N;(J[A-S])|(7[J-N]);Japan;AS;45;25;339
+JA-JS,7J-7N;(J[A-S])|(7[J-N])|(8[J-N]);Japan;AS;45;25;339
 JD1;JD1;Minami Torishima;OC;90;27;177
 JD1;JD1;Ogasawara;AS;45;27;192
 JT-JV;J[T-V];Mongolia;AS;32,33;23;363
 JW;JW;Svalbard;EU;18;40;259
-JX;JX;an Mayen;EU;18;40;118
+JX;JX;Jan Mayen;EU;18;40;118
 JY;JY;Jordan;AS;39;20;342
-K,W,N,AA-AK;K|W|N|A[A-K];United States of America;NA;6,7,8;3,4,5;291
+K,W,N,AA-AK;K|W|N|A[A-GI-K];United States of America;NA;6,7,8;3,4,5;291
 KG4;KG4;Guantanamo Bay;NA;11;08;105
-KH0;KH0;Mariana Is.;OC;64;27;166
-KH1;KH1;Baker & Howland Is.;OC;61;31;020
-KH2;KH2;Guam;OC;64;27;103
-KH3;KH3;Johnston I.;OC;61;31;123
-KH4;KH4;Midway I.;OC;61;31;174
-KH5;KH5;Palmyra & Jarvis Is.;OC;61,62;31;197
+KH0;[AKNW]H0;Mariana Is.;OC;64;27;166
+KH1;[AKNW]H1;Baker & Howland Is.;OC;61;31;020
+KH2;[AKNW]H2;Guam;OC;64;27;103
+KH3;[AKNW]H3;Johnston I.;OC;61;31;123
+KH4;[AKNW]H4;Midway I.;OC;61;31;174
+KH5;[AKNW]H5;Palmyra & Jarvis Is.;OC;61,62;31;197
 KH5K;KH5K;Kingman Reef;OC;61;31;134
-KH6,7;KH[6-7];Hawaii;OC;61;31;110
-KH7K;KH7K;Kure I.;OC;61;31;138
-KH8;KH8;American Samoa;OC;62;32;009
+KH6;[AKNW]H[6-7];Hawaii;OC;61;31;110
+KH7K;[AKNW]H7K;Kure I.;OC;61;31;138
+KH8;[AKNW]H8;American Samoa;OC;62;32;009
 KH8;KH8;Swains I.;OC;62;32;515
-KH9;KH9;Wake I.;OC;65;31;297
-KL,AL,NL,WL;[KANW]L;Alaska;NA;1,2;1;006
-KP1;KP1;Navassa I.;NA;11;08;182
-KP2;KP2;Virgin Is.;NA;11;08;285
-KP3,4;KP[3-4];Puerto Rico;NA;11;08;202
-KP5;KP5;Desecheo I.;NA;11;08;043
+KH9;[AKNW]H9;Wake I.;OC;65;31;297
+KL;[KANW]L;Alaska;NA;1,2;1;006
+KP1;[KNW]P1;Navassa I.;NA;11;08;182
+KP2;[KNW]P2;Virgin Is.;NA;11;08;285
+KP4;[KNW]P[3-4];Puerto Rico;NA;11;08;202
+KP5;[KNW]P5;Desecheo I.;NA;11;08;043
 LA-LN;L[A-N];Norway;EU;18;14;266
-LO-LW;L[0-W];Argentina;SA;14,16;13;100
+LO-LW;(A[YZ])|(L[1-9O-W]);Argentina;SA;14,16;13;100
 LX;LX;Luxembourg;EU;27;14;254
 LY;LY;Lithuania;EU;29;15;146
 LZ;LZ;Bulgaria;EU;28;20;212
-OA-OC;O[A-C];Peru;SA;12;10;136
+OA-OC;(4T)|(O[A-C]);Peru;SA;12;10;136
 OD;OD;Lebanon;AS;39;20;354
 OE;OE;Austria;EU;28;15;206
-OF-OI;O[F-I];Finland;EU;18;15;224
-OH0;OH0;Aland Is.;EU;18;15;005
+OF-OI;O[F-J];Finland;EU;18;15;224
+OH0;O[FGHI]0;Aland Is.;EU;18;15;005
 OJ0;OJ0;Market Reef;EU;18;15;167
 OK-OL;O[K-L];Czech Republic;EU;28;15;503
 OM;OM;Slovak Republic;EU;28;15;504
 ON-OT;O[N-T];Belgium;EU;27;14;209
-OU-OW,OZ;O[U-WZ];Denmark;EU;18;14;221
-OX;OX;Greenland;NA;5,75;40;237
+OU-OW,OZ;(5[PQ])|(O[U-WZ]);Denmark;EU;18;14;221
+OX;O[XP];Greenland;NA;5,75;40;237
 OY;OY;Faroe Is.;EU;18;14;222
 P2;P2;Papua New Guinea;OC;51;28;163
 P4;P4;Aruba;SA;11;09;091
-P5;P5;DPRK Korea;AS;44;25;344
+P5;P[5-9];DPRK Korea;AS;44;25;344
 PA-PI;P[A-I];Netherlands;EU;27;14;263
 PJ2;PJ2;Curacao;SA;11;09;517
 PJ4;PJ4;Bonaire;SA;11;09;520
 PJ5,6;PJ[5-6];Saba & St. Eustatius;NA;11;08;519
-PJ7;PJ7;St Maarten;NA;11;08;518
-PP-PY;P[P-Y];Brazil;SA;12,13,15;11;108
-PP0-PY0F;P[P-Y]0F;Fernando de Noronha;SA;13;11;056
-PP0-PY0S;P[P-Y]0S;St. Peter & St. Paul Rocks;SA;13;11;253
-PP0-PY0T;P[P-Y]0T;Trindade & Martim Vaz Is.;SA;15;11;273
+PJ7;PJ[078];St Maarten;NA;11;08;518
+PP-PY;(P[P-Y])|(Z[V-Z]);Brazil;SA;12,13,15;11;108
+PP0-PY0F;(P[P-Y]0[FR])|(P[P-Y]0Z[FR])|(Z[V-Z]0[FR])|(Z[V-X]0Z[FR]);Fernando de Noronha;SA;13;11;056
+PP0-PY0S;(P[P-Y]0S)|(P[P-Y]0ZS)|(Z[V-Z]0S)|(Z[V-Z]0ZS);St. Peter & St. Paul Rocks;SA;13;11;253
+PP0-PY0T;(P[P-Y]0T)|(P[P-Y]0ZT)|(Z[V-Z]0T)|(Z[V-Z]0ZT);Trindade & Martim Vaz Is.;SA;15;11;273
 PZ;PZ;Suriname;SA;12;09;140
 R1/F;R1;Franz Josef Land;EU;75;40;061
 S0;S0;Western Sahara;AF;46;33;302
-S2;S2;Bangladesh;AS;41;22;305
+S2;S[23];Bangladesh;AS;41;22;305
 S5;S5;Slovenia;EU;28;15;499
 S7;S7;Seychelles;AF;53;39;379
 S9;S9;Sao Tome & Principe;AF;47;36;219
 SA-SM,7S-8S;(S[A-M])|([7-8]S);Sweden;EU;18;14;284
-SN-SR;S[N-R];Poland;EU;28;15;269
-ST;ST;Sudan;AF;47,48;34;466
-SU;SU;Egypt;AF;38;34;478
+SN-SR;(3Z)|(HF)|(S[N-R]);Poland;EU;28;15;269
+ST;(6[TU])|(ST);Sudan;AF;47,48;34;466
+SU;(6[AB])|(S[SU]);Egypt;AF;38;34;478
 SV-SZ,J4;(S[V-Z])|(J4);Greece;EU;28;20;236
 SV/A;SV;Mount Athos;EU;28;20;180
-SV5,J45;(SV5)|(J45);Dodecanese;EU;28;20;045
-SV9,J49;(SV9)|(J49);Crete;EU;28;20;040
+SV5,J45;(S[V-Z]5)|(J45);Dodecanese;EU;28;20;045
+SV9,J49;(S[V-Z]9)|(J49);Crete;EU;28;20;040
 T2;T2;Tuvalu;OC;65;31;282
 T30;T30;W. Kiribati(Gilbert Is. );OC;65;31;301
 T31;T31;C. Kiribati(British Phoenix Is.);OC;62;31;031
@@ -255,11 +254,11 @@ T33;T33;Banaba I.(Ocean I.);OC;65;31;490
 T5,6O;(T5)|(6O);Somalia;AF;48;37;232
 T7;T7;San Marino;EU;28;15;278
 T8;T8;Palau;OC;64;27;022
-TA-TC;T[A-C];Turkey;EU/AS;39;20;390
+TA-TC;(T[A-C])|(YM);Turkey;EU/AS;39;20;390
 TF;TF;Iceland;EU;17;40;242
 TG,TD;T[DG];Guatemala;NA;12;07;076
 TI,TE;T[IE];Costa Rica;NA;11;07;308
-TI9;TI9;Cocos I.;NA;12;07;037
+TI9;T[EI]9;Cocos I.;NA;12;07;037
 TJ;TJ;Cameroon;AF;47;36;406
 TK;TK;Corsica;EU;28;15;214
 TL;TL;Central Africa;AF;47;36;408
@@ -269,7 +268,7 @@ TT;TT;Chad;AF;47;36;410
 TU;TU;Cote d'Ivoire;AF;46;35;428
 TY;TY;Benin;AF;46;35;416
 TZ;TZ;Mali;AF;46;35;442
-UA-UI1-7,RA-RZ;(U[A-I][1-7])|(R[A-Z]);European Russia;EU;19,20,29,30;16;054
+UA-UI1-7,RA-RZ;(U[A-I][1-7])|(R[A-Z])|(R);European Russia;EU;19,20,29,30;16;054
 UA2,RA2;[UR]A2;Kaliningrad;EU;29;15;126
 UA-UI8,9,0,RA-RZ;(U[A-I][890])|(R[A-Z]);Asiatic Russia;AS;20-26,30-35,75;16,17,18,19,23;015
 UJ-UM;U[J-M];Uzbekistan;AS;30;17;292
@@ -282,52 +281,52 @@ V5;V5;Namibia;AF;57;38;464
 V6;V6;Micronesia;OC;65;27;173
 V7;V7;Marshall Is.;OC;65;31;168
 V8;V8;Brunei Darussalam;OC;54;28;345
-VA-VG,VO,VY;V[A-GOY];Canada;NA;2,3,4,9,75;1-5;001
-VK,AX;(VK)|(AX);Australia;OC;55,58,59;29,30;150
+VA-VG,VO,VY;(C[FGJK])|(V[A-GOY])|(VY9)|(X[LM]);Canada;NA;2,3,4,9,75;1-5;001
+VK,AX;(V[I-L])|(AX);Australia;OC;55,58,59;29,30;150
 VK0;VK0;Heard I.;AF;68;39;111
 VK0;VK0;Macquarie I.;OC;60;30;153
-VK9C;VK9C;Cocos(Keeling) Is.;OC;54;29;038
-VK9L;VK9L;Lord Howe I.;OC;60;30;147
-VK9M;VK9M;Mellish Reef;OC;56;30;171
-VK9N;VK9N;Norfolk I.;OC;60;32;189
-VK9W;VK9W;Willis I.;OC;55;30;303
-VK9X;VK9X;Christmas I.;OC;54;29;035
+VK9C;(AS9[CY])|(V[IK]9[CY])|(VK9[FK]C)|(VK9ZY)|(VZ9Y);Cocos(Keeling) Is.;OC;54;29;038
+VK9L;(AX9L)|(VI9L)|(VK9FL)|(VK9L)|(VK9ZL)|(VZ9L);Lord Howe I.;OC;60;30;147
+VK9M;(AS9M)|(V[IKZ]9M);Mellish Reef;OC;56;30;171
+VK9N;(AX9)|(VI9)|(VK9)VK9N;Norfolk I.;OC;60;32;189
+VK9W;(AX9[WZ])|(VI9[WZ])|(VK9FW)|(VK9[WZ])|(VZ9W);Willis I.;OC;55;30;303
+VK9X;(AX9X)|(VI9X)|(VK9FW)|(VK9KX)|(V[KZ]9X);Christmas I.;OC;54;29;035
 VP2E;VP2E;Anguilla;NA;11;08;012
 VP2M;VP2M;Montserrat;NA;11;08;096
 VP2V;VP2V;British Virgin Is.;NA;11;08;065
-VP5;VP5;Turks & Caicos Is.;NA;11;08;089
+VP5;V[PQ]5;Turks & Caicos Is.;NA;11;08;089
 VP6;VP6;Pitcairn I.;OC;63;32;172
 VP6;VP6;Ducie I.;OC;63;32;513
 VP8;VP8;Falkland Is.;SA;16;13;141
 VP8,LU;(VP8)|(LU);South Georgia I.;SA;73;13;235
 VP8,LU;(VP8)|(LU);South Orkney Is.;SA;73;13;238
 VP8,LU;(VP8)|(LU);South Sandwich Is.;SA;73;13;240
-VP8,LU,CE9,HF0,4K1;(VP8)|(LU)|(CE9)|(HF0)|(4K1);South Shetland Is.;SA;73;13;241
+VP8,LU,CE9,HF0,4K1;(VP8)|(LU)|(CE9)|(HF0)|(4K1)|(XR9);South Shetland Is.;SA;73;13;241
 VP9;BP9;Bermuda;NA;11;05;064
 VQ9;VQ9;Chagos Is.;AF;41;39;033
 VR;VR;Hong Kong,China;AS;44;24;321
-VU;VU;India;AS;41;22;324
+VU;(8[T-Y])|(A[T-W])|(V[T-W]);India;AS;41;22;324
 VU4;VU4;Andaman & Nicobar Is.;AS;49;26;011
 VU7;VU7;Lakshadweep Is.;AS;41;22;142
-XA-XI;X[A-I];Mexico;NA;10;06;050
-XA4-XI4;X[A-I]4;Revillagigedo;NA;10;06;204
+XA-XI;(X[A-I])|(4[ABC])|(6[D-J]);Mexico;NA;10;06;050
+XA4-XI4;(X[A-I]4)|(4[ABC]4)|(6[D-J]4);Revillagigedo;NA;10;06;204
 XT;XT;Burkina Faso;AF;46;35;480
 XU;XU;Cambodia;AS;49;26;312
 XW;XW;Laos;AS;49;26;143
 XX9;XX9;Macao,China;AS;44;24;152
 XY-XZ;X[Y-Z];Myanmar;AS;49;26;309
 YA,T6;(YA)|(T6);Afghanistan;AS;40;21;003
-YB-YH;Y[B-H];Indonesia;OC;51,54;28;327
-YI;YI;Iraq;AS;39;21;333
+YB-YH;(7[A-I])|(8[A-I])|(P[K-O])|(Y[B-H]);Indonesia;OC;51,54;28;327
+YI;(YI)|(HN[0-9]);Iraq;AS;39;21;333
 YJ;YJ;Vanuatu;OC;56;32;158
-YK;YK;Syria;AS;39;20;384
+YK;(6C)|(YK);Syria;AS;39;20;384
 YL;YL;Latvia;EU;29;15;145
 YN,H6-7,HT;(YN)|(H[6-7])|(HT);Nicaragua;NA;11;07;086
 YO-YR;Y[O-R];Romania;EU;28;20;275
 YS,HU;(YS)|(HU);El Salvador;NA;11;07;074
 YT-YU;Y[T-U];Serbia;EU;28;15;296
 YV-YY,4M;(Y[V-Y])|(4M);Venezuela;SA;12;09;148
-YV0;YV0;Aves I.;NA;11;08;017
+YV0;(4M0)|(Y[V-Y]0);Aves I.;NA;11;08;017
 Z2;Z2;Zimbabwe;AF;53;38;452
 Z3;Z3;Macedonia;EU;28;15;502
 Z6;Z6;Republic of Kosovo;EU;28;15;522
@@ -340,10 +339,10 @@ ZD8;ZD8;Ascension I.;AF;66;36;205
 ZD9;ZD9;Tristan da Cunha & Gough I.;AF;66;38;274
 ZF;ZF;Cayman Is.;NA;11;08;069
 ZK3;ZK3;Tokelau Is.;OC;62;31;270
-ZL-ZM;Z[L-M];New Zealand;OC;60;32;170
-ZL7;ZL7;Chatham Is.;OC;60;32;034
-ZL8;ZL8;Kermadec Is.;OC;60;32;133
+ZL-ZM;(Z[L-M])|(ZL50);New Zealand;OC;60;32;170
+ZL7;Z[LM]7;Chatham Is.;OC;60;32;034
+ZL8;Z[LM]8;Kermadec Is.;OC;60;32;133
 ZL9;ZL9;Auckland & Campbell Is.;OC;60;32;016
 ZP;ZP;Paraguay;SA;14;11;132
-ZR-ZU;Z[R-U];South Africa;AF;57;38;462
-ZS8;ZS8;Prince Edward & Marion Is.;AF;57;38;201
+ZR-ZU;(Z[R-U])|(H5)|(S4)|(S8)|(V9)|(Z[RSTU]);South Africa;AF;57;38;462
+ZS8;Z[RSTU]8;Prince Edward & Marion Is.;AF;57;38;201

--- a/ARRL.LIST
+++ b/ARRL.LIST
@@ -143,7 +143,7 @@ FT/X;FT[02458]X;Kerguelen Is.;AF;68;39;131
 FT/Z;FT[0-8]Z;Amsterdam & St. Paul Is.;AF;68;39;010
 FW;[FT]W;Wallis & Futuna Is.;OC;62;32;298
 FY;FY;French Guiana;SA;12;09;063
-G,GX,M;(2E)|(G)|(GX)|(M);England;EU;27;14;223
+G,GX,M;(2E)|(GX)|(G)|(M);England;EU;27;14;223
 GD,GT;(2D)|(G[DT])|(M[DT]);Isle of Man;EU;27;14;114
 GI,GN;(2I)|(G[IN])|(M[IN]);Northern Ireland;EU;27;14;265
 GJ,GH;(2J)|(G[JH])|(M[JH]);Jersey;EU;27;14;122
@@ -176,7 +176,7 @@ J5;J5;Guinea-Bissau;AF;46;35;109
 J6;J6;St. Lucia;NA;11;08;097
 J7;J7;Dominica;NA;11;08;095
 J8;J8;St. Vincent;NA;11;08;098
-JA-JS,7J-7N;(J[A-S])|(7[J-N])|(8[J-N]);Japan;AS;45;25;339
+JA-JS,7J-7N;(J[A-S])|([78][J-N]);Japan;AS;45;25;339
 JD1;JD1;Minami Torishima;OC;90;27;177
 JD1;JD1;Ogasawara;AS;45;27;192
 JT-JV;J[T-V];Mongolia;AS;32,33;23;363
@@ -195,7 +195,7 @@ KH5K;KH5K;Kingman Reef;OC;61;31;134
 KH6;[AKNW]H[6-7];Hawaii;OC;61;31;110
 KH7K;[AKNW]H7K;Kure I.;OC;61;31;138
 KH8;[AKNW]H8;American Samoa;OC;62;32;009
-KH8;KH8;Swains I.;OC;62;32;515
+KH8;KH8S;Swains I.;OC;62;32;515
 KH9;[AKNW]H9;Wake I.;OC;65;31;297
 KL;[KANW]L;Alaska;NA;1,2;1;006
 KP1;[KNW]P1;Navassa I.;NA;11;08;182
@@ -228,9 +228,9 @@ PJ4;PJ4;Bonaire;SA;11;09;520
 PJ5,6;PJ[5-6];Saba & St. Eustatius;NA;11;08;519
 PJ7;PJ[078];St Maarten;NA;11;08;518
 PP-PY;(P[P-Y])|(Z[V-Z]);Brazil;SA;12,13,15;11;108
-PP0-PY0F;(P[P-Y]0[FR])|(P[P-Y]0Z[FR])|(Z[V-Z]0[FR])|(Z[V-X]0Z[FR]);Fernando de Noronha;SA;13;11;056
-PP0-PY0S;(P[P-Y]0S)|(P[P-Y]0ZS)|(Z[V-Z]0S)|(Z[V-Z]0ZS);St. Peter & St. Paul Rocks;SA;13;11;253
-PP0-PY0T;(P[P-Y]0T)|(P[P-Y]0ZT)|(Z[V-Z]0T)|(Z[V-Z]0ZT);Trindade & Martim Vaz Is.;SA;15;11;273
+PP0-PY0F;(P[P-Y]|Z[V-X])0Z?[FR];Fernando de Noronha;SA;13;11;056
+PP0-PY0S;(P[P-Y]|Z[V-Z])0Z?S;St. Peter & St. Paul Rocks;SA;13;11;253
+PP0-PY0T;(P[P-Y]|Z[V-Z])0Z?T;Trindade & Martim Vaz Is.;SA;15;11;273
 PZ;PZ;Suriname;SA;12;09;140
 R1/F;R1;Franz Josef Land;EU;75;40;061
 S0;S0;Western Sahara;AF;46;33;302
@@ -268,9 +268,9 @@ TT;TT;Chad;AF;47;36;410
 TU;TU;Cote d'Ivoire;AF;46;35;428
 TY;TY;Benin;AF;46;35;416
 TZ;TZ;Mali;AF;46;35;442
-UA-UI1-7,RA-RZ;(U[A-I][1-7])|(R[A-Z])|(R);European Russia;EU;19,20,29,30;16;054
+UA-UI1-7,RA-RZ;(U[A-I]?|R[A-Z]?)[1-7];European Russia;EU;19,20,29,30;16;054
 UA2,RA2;[UR]A2;Kaliningrad;EU;29;15;126
-UA-UI8,9,0,RA-RZ;(U[A-I][890])|(R[A-Z]);Asiatic Russia;AS;20-26,30-35,75;16,17,18,19,23;015
+UA-UI8,9,0,RA-RZ;(U[A-I]?|R[A-Z]?)[890];Asiatic Russia;AS;20-26,30-35,75;16,17,18,19,23;015
 UJ-UM;U[J-M];Uzbekistan;AS;30;17;292
 UN-UQ;U[N-Q];Kazakhstan;AS;29,30,31;17;130
 UR-UZ,EM-EO;(U[R-Z])|(E[M-O]);Ukraine;EU;29;16;288
@@ -281,16 +281,16 @@ V5;V5;Namibia;AF;57;38;464
 V6;V6;Micronesia;OC;65;27;173
 V7;V7;Marshall Is.;OC;65;31;168
 V8;V8;Brunei Darussalam;OC;54;28;345
-VA-VG,VO,VY;(C[FGJK])|(V[A-GOY])|(VY9)|(X[LM]);Canada;NA;2,3,4,9,75;1-5;001
+VA-VG,VO,VY;(C[FGJK])|(VY9)|(V[A-GOY])|(X[LM]);Canada;NA;2,3,4,9,75;1-5;001
 VK,AX;(V[I-L])|(AX);Australia;OC;55,58,59;29,30;150
 VK0;VK0;Heard I.;AF;68;39;111
 VK0;VK0;Macquarie I.;OC;60;30;153
+VK9N;(AX9)|(V[IK]9);Norfolk I.;OC;60;32;189
 VK9C;(AS9[CY])|(V[IK]9[CY])|(VK9[FK]C)|(VK9ZY)|(VZ9Y);Cocos(Keeling) Is.;OC;54;29;038
 VK9L;(AX9L)|(VI9L)|(VK9FL)|(VK9L)|(VK9ZL)|(VZ9L);Lord Howe I.;OC;60;30;147
 VK9M;(AS9M)|(V[IKZ]9M);Mellish Reef;OC;56;30;171
-VK9N;(AX9)|(VI9)|(VK9)VK9N;Norfolk I.;OC;60;32;189
 VK9W;(AX9[WZ])|(VI9[WZ])|(VK9FW)|(VK9[WZ])|(VZ9W);Willis I.;OC;55;30;303
-VK9X;(AX9X)|(VI9X)|(VK9FW)|(VK9KX)|(V[KZ]9X);Christmas I.;OC;54;29;035
+VK9X;(AX9X)|(VI9X)|(VK9FX)|(VK9KX)|(V[KZ]9X);Christmas I.;OC;54;29;035
 VP2E;VP2E;Anguilla;NA;11;08;012
 VP2M;VP2M;Montserrat;NA;11;08;096
 VP2V;VP2V;British Virgin Is.;NA;11;08;065
@@ -326,7 +326,7 @@ YO-YR;Y[O-R];Romania;EU;28;20;275
 YS,HU;(YS)|(HU);El Salvador;NA;11;07;074
 YT-YU;Y[T-U];Serbia;EU;28;15;296
 YV-YY,4M;(Y[V-Y])|(4M);Venezuela;SA;12;09;148
-YV0;(4M0)|(Y[V-Y]0);Aves I.;NA;11;08;017
+YV0;(Y[V-Y]0)|(4M0);Aves I.;NA;11;08;017
 Z2;Z2;Zimbabwe;AF;53;38;452
 Z3;Z3;Macedonia;EU;28;15;502
 Z6;Z6;Republic of Kosovo;EU;28;15;522
@@ -339,10 +339,10 @@ ZD8;ZD8;Ascension I.;AF;66;36;205
 ZD9;ZD9;Tristan da Cunha & Gough I.;AF;66;38;274
 ZF;ZF;Cayman Is.;NA;11;08;069
 ZK3;ZK3;Tokelau Is.;OC;62;31;270
-ZL-ZM;(Z[L-M])|(ZL50);New Zealand;OC;60;32;170
+ZL-ZM;(ZL50)|(Z[L-M]);New Zealand;OC;60;32;170
 ZL7;Z[LM]7;Chatham Is.;OC;60;32;034
 ZL8;Z[LM]8;Kermadec Is.;OC;60;32;133
 ZL9;ZL9;Auckland & Campbell Is.;OC;60;32;016
 ZP;ZP;Paraguay;SA;14;11;132
-ZR-ZU;(Z[R-U])|(H5)|(S4)|(S8)|(V9)|(Z[RSTU]);South Africa;AF;57;38;462
+ZR-ZU;(Z[R-U])|(H5)|(S4)|(S8)|(V9);South Africa;AF;57;38;462
 ZS8;Z[RSTU]8;Prince Edward & Marion Is.;AF;57;38;201

--- a/ArrlDx.pas
+++ b/ArrlDx.pas
@@ -202,8 +202,20 @@ end;
 
 
 function TArrlDx.PickStation(): integer;
+var
+  dxcc: TDxCCRec;
 begin
-     result := random(ArrlDxCallList.Count);
+  result := random(ArrlDxCallList.Count);
+  while (ArrlDxCallList.Count > 1) do
+    begin
+      // Keep stations that have a valid DXCC entry
+      if gDXCCList.FindRec(dxcc, ArrlDxCallList[result].Call) then
+        break;
+
+      // drop this station and try again
+      DropStation(result);
+      result := random(ArrlDxCallList.Count);
+    end;
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -266,7 +266,10 @@ function TContest.GetRecvExchTypes(
   const AMyCallsign : string;
   const ADxCallsign : string) : TExchTypes;
 begin
-  Result:= Self.GetExchangeTypes(AStationKind, mtRecvMsg, ADxCallsign);
+  if AStationKind = skMyStation then
+    Result:= Self.GetExchangeTypes(AStationKind, mtRecvMsg, AMyCallsign)
+  else
+    Result:= Self.GetExchangeTypes(AStationKind, mtRecvMsg, ADxCallsign);
 end;
 
 


### PR DESCRIPTION
ARRL DX contest now allows Hawaii and Alaska stations with NH6 or AL7 prefixes.

The main issue here was incomplete regular expressions in the ARRL.LIST (DXCC) file.