### PR TITLE
fixed: "00" must be replaced before "0" #204

### DIFF
--- a/Station.pas
+++ b/Station.pas
@@ -358,8 +358,8 @@ begin
     (MyCall <> Ini.Call) then
     begin
     if Random < 0.4 then begin
-      Result := StringReplace(Result, '0', 'O', [rfReplaceAll]);
       Result := StringReplace(Result, '00', 'TT', [rfReplaceAll]);
+      Result := StringReplace(Result, '0', 'O', [rfReplaceAll]);
     end
     else if Random < 0.8
       then Result := StringReplace(Result, '0', 'T', [rfReplaceAll]);


### PR DESCRIPTION
I have responded to mike's comment. 00 must be replaced before 0.

https://github.com/w7sst/MorseRunner/commit/2b56510498a0f707c8b929a2803930f389632caf#r138520966

