### PR TITLE
Alt-F9/Alt-F10 now uses 2 WPM speed increments. #245

### DIFF
--- a/Ini.pas
+++ b/Ini.pas
@@ -185,6 +185,7 @@ var
   ArrlClass: string = '3A';
   ArrlSection: string = 'GH';
   Wpm: integer = 25;
+  WpmStepRate: integer = 2;
   MaxRxWpm: integer = 0;
   MinRxWpm: integer = 0;
   NRDigits: integer = 1;
@@ -288,6 +289,7 @@ begin
       MainForm.UpdNRDigits(ReadInteger(SEC_STN, 'NRDigits', NRDigits));
 
       Wpm := ReadInteger(SEC_STN, 'Wpm', Wpm);
+      WpmStepRate := Max(1, Min(20, ReadInteger(SEC_STN, 'WpmStepRate', WpmStepRate)));
       Qsk := ReadBool(SEC_STN, 'Qsk', Qsk);
       CallsFromKeyer := ReadBool(SEC_STN, 'CallsFromKeyer', CallsFromKeyer);
       GetWpmUsesGaussian := ReadBool(SEC_STN, 'GetWpmUsesGaussian', GetWpmUsesGaussian);
@@ -368,6 +370,7 @@ begin
       WriteInteger(SEC_STN, 'Pitch', MainForm.ComboBox1.ItemIndex);
       WriteInteger(SEC_STN, 'BandWidth', MainForm.ComboBox2.ItemIndex);
       WriteInteger(SEC_STN, 'Wpm', Wpm);
+      WriteInteger(SEC_STN, 'WpmStepRate', WpmStepRate);
       WriteBool(SEC_STN, 'Qsk', Qsk);
 
       {

--- a/Main.pas
+++ b/Main.pas
@@ -965,24 +965,20 @@ end;
 
 
 procedure TMainForm.IncSpeed;
-const
-  INC_WPM = 2;
 begin
   if RunMode = rmHST then
     SetWpm(Trunc(Wpm / 5) * 5 + 5)
   else
-    SetWpm(Wpm + INC_WPM);
+    SetWpm(Wpm + Ini.WpmStepRate);
 end;
 
 
 procedure TMainForm.DecSpeed;
-const
-  DEC_WPM = 2;
 begin
   if RunMode = rmHST then
     SetWpm(Ceil(Wpm / 5) * 5 - 5)
   else
-    SetWpm(Wpm - DEC_WPM);
+    SetWpm(Wpm - Ini.WpmStepRate);
 end;
 
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -159,6 +159,11 @@ KEY ASSIGNMENTS
 
   PgUp/PgDn, Ctrl-F10/Ctrl-F9, Alt-F10/Alt-F9 - keying speed,
     in 2 WPM increments. HST Competition uses 5 WPM increments.
+    The default WPM Step rate is 2. Valid values range between 1 and 20.
+    You can override this value by changing the WpmStepRate entry in the
+    MorseRunner.ini file, e.g.:
+            [Station]
+            WpmStepRate=2
 
 STATISTICS AREA
   The bottom right panel shows your current score, both Raw (calculated


### PR DESCRIPTION
Alt-F9/Alt-F10 keys now use 2 WPM speed increments instead of the prior 5 WPM increment. HST Competition will remain at 5 WPM.