### PR TITLE
248/252 Improve RIT and Bandwidth adjustment using mouse wheel

### DIFF
--- a/Ini.pas
+++ b/Ini.pas
@@ -193,6 +193,7 @@ var
   Pitch: integer = 600;
   Qsk: boolean = false;
   Rit: integer = 0;
+  RitStepIncr: integer = 50;
   BufSize: integer = DEFAULTBUFSIZE;
   WebServer: string = '';
   SubmitHiScoreURL: string= '';
@@ -324,6 +325,8 @@ begin
 
       // [Settings]
       FarnsworthCharRate := ReadInteger(SEC_SET, 'FarnsworthCharacterRate', FarnsworthCharRate);
+      RitStepIncr := ReadInteger(SEC_SET, 'RitStepIncr', RitStepIncr);
+      RitStepIncr := Max(-500, Min(500, RitStepIncr));
 
       // [Debug]
       DebugExchSettings := ReadBool(SEC_DBG, 'DebugExchSettings', DebugExchSettings);
@@ -395,6 +398,7 @@ begin
       WriteBool(SEC_STN, 'SaveWav', SaveWav);
 
       WriteInteger(SEC_SET, 'FarnsworthCharacterRate', FarnsworthCharRate);
+      WriteInteger(SEC_SET, 'RitStepIncr', RitStepIncr);
     finally
       Free;
     end;

--- a/Main.dfm
+++ b/Main.dfm
@@ -57,7 +57,8 @@ object MainForm: TMainForm
   OnKeyDown = FormKeyDown
   OnKeyPress = FormKeyPress
   OnKeyUp = FormKeyUp
-  OnMouseWheel = FormMouseWheel
+  OnMouseWheelDown = FormMouseWheelDown
+  OnMouseWheelUp = FormMouseWheelUp
   PixelsPerInch = 96
   TextHeight = 15
   object Bevel1: TBevel

--- a/Main.dfm
+++ b/Main.dfm
@@ -297,7 +297,7 @@ object MainForm: TMainForm
       Width = 225
       Height = 10
       Cursor = crHandPoint
-      Hint = 'RIT'
+      Hint = 'RIT -- Use Up/Down keys or Mouse Wheel; Hold Control key for BW.'
       BevelOuter = bvLowered
       ParentShowHint = False
       ShowHint = True

--- a/Main.pas
+++ b/Main.pas
@@ -363,6 +363,7 @@ type
     MustAdvance: boolean;       // Controls when Exchange fields advance
     UserCallsignDirty: boolean; // SetMyCall is called after callsign edits
     CWSpeedDirty: boolean;      // SetWpm is called after CW Speed edits
+    RitLocal: integer;          // tracks incremented RIT Value
     function CreateContest(AContestId : TSimContest) : TContest;
     procedure ConfigureExchangeFields;
     procedure SetMyExch1(const AExchType: TExchange1Type; const Avalue: string);
@@ -1979,16 +1980,26 @@ end;
 
 
 procedure TMainForm.IncRit(dF: integer);
+var
+  RitStepIncr : integer;
 begin
-  case dF of
-   -2: Inc(Ini.Rit, -5);
-   -1: Inc(Ini.Rit, -50);
-    0: Ini.Rit := 0;
-    1: Inc(Ini.Rit, 50);
-    2: Inc(Ini.Rit, 5);
+  RitStepIncr := IfThen(RunMode = rmHST, 50, Ini.RitStepIncr);
+
+  // A negative RitStepInc will change direction of arrow/wheel movement
+  if RitStepIncr < 0 then begin
+    dF := -dF;
+    RitStepIncr := -RitStepIncr;
   end;
 
-  Ini.Rit := Min(500, Max(-500, Ini.Rit));
+  case dF of
+   -2: if Ini.Rit > -500 then Inc(RitLocal, -5);
+   -1: if Ini.Rit > -500 then Inc(RitLocal, -RitStepIncr);
+    0: RitLocal := 0;
+    1: if Ini.Rit < 500 then Inc(RitLocal, RitStepIncr);
+    2: if Ini.Rit < 500 then Inc(RitLocal, 5);
+  end;
+
+  Ini.Rit := Min(500, Max(-500, RitLocal));
   UpdateRitIndicator;
 end;
 

--- a/Main.pas
+++ b/Main.pas
@@ -21,7 +21,7 @@ uses
 
 const
   WM_TBDOWN = WM_USER+1;
-  sVersion: String = '1.84-pr3';  { Sets version strings in UI panel. }
+  sVersion: String = '1.84-pr4';  { Sets version strings in UI panel. }
 
 type
 

--- a/Main.pas
+++ b/Main.pas
@@ -292,9 +292,11 @@ type
     procedure FormKeyPress(Sender: TObject; var Key: Char);
     procedure FormKeyDown(Sender: TObject; var Key: Word;
       Shift: TShiftState);
-    procedure FormMouseWheel(Sender: TObject; Shift: TShiftState;
-      WheelDelta: Integer; MousePos: TPoint; var Handled: Boolean);
     procedure Edit1Enter(Sender: TObject);
+    procedure FormMouseWheelDown(Sender: TObject; Shift: TShiftState;
+      MousePos: TPoint; var Handled: Boolean);
+    procedure FormMouseWheelUp(Sender: TObject; Shift: TShiftState;
+      MousePos: TPoint; var Handled: Boolean);
     procedure SendClick(Sender: TObject);
     procedure Edit4Change(Sender: TObject);
     procedure ComboBox2Change(Sender: TObject);
@@ -961,6 +963,21 @@ begin
     Edit1.SelStart := P-1;
     Edit1.SelLength := 1;
   end;
+end;
+
+
+procedure TMainForm.FormMouseWheelDown(Sender: TObject; Shift: TShiftState;
+  MousePos: TPoint; var Handled: Boolean);
+begin
+  if GetKeyState(VK_CONTROL) >= 0  then IncRit(1)
+  else if RunMode <> rmHst then SetBw(ComboBox2.ItemIndex-1);
+end;
+
+procedure TMainForm.FormMouseWheelUp(Sender: TObject; Shift: TShiftState;
+  MousePos: TPoint; var Handled: Boolean);
+begin
+  if GetKeyState(VK_CONTROL) >= 0 then IncRit(-1)
+  else if RunMode <> rmHst then SetBw(ComboBox2.ItemIndex+1);
 end;
 
 
@@ -1932,16 +1949,6 @@ begin
   else
     if X > (Shape2.Left + Shape2.Width) then
       IncRit(1);
-end;
-
-
-procedure TMainForm.FormMouseWheel(Sender: TObject; Shift: TShiftState;
-  WheelDelta: Integer; MousePos: TPoint; var Handled: Boolean);
-begin
-    if WheelDelta>0 then
-        IncRit(2)
-      else
-        IncRit(-2)
 end;
 
 

--- a/Main.pas
+++ b/Main.pas
@@ -971,6 +971,7 @@ procedure TMainForm.FormMouseWheelDown(Sender: TObject; Shift: TShiftState;
 begin
   if GetKeyState(VK_CONTROL) >= 0  then IncRit(1)
   else if RunMode <> rmHst then SetBw(ComboBox2.ItemIndex-1);
+  Handled := true;  // set Handled to prevent being called 3 times
 end;
 
 procedure TMainForm.FormMouseWheelUp(Sender: TObject; Shift: TShiftState;
@@ -978,6 +979,7 @@ procedure TMainForm.FormMouseWheelUp(Sender: TObject; Shift: TShiftState;
 begin
   if GetKeyState(VK_CONTROL) >= 0 then IncRit(-1)
   else if RunMode <> rmHst then SetBw(ComboBox2.ItemIndex+1);
+  Handled := true;  // set Handled to prevent being called 3 times
 end;
 
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -161,13 +161,14 @@ KEY ASSIGNMENTS
             [Settings]
             RitStepIncr=50
 
-    Valid values range between -500 and 500. Useful values include 100, 125,
-    167 and 250 will provide 5, 4, 3 or 2 steps respectively in both directions.
-    Negative values can be used to change the direction of Up/Down arrow keys
-    or mouse movement. Note that a zero value will disable this feature.
-    HST Competition mode will ignore this setting and is set to 50Hz/Step.
+    Valid values range between -500 and 500. Negative values can be used to
+    change the direction of Up/Down arrow keys or mouse movement. Note that a
+    zero value will disable this feature. HST Competition mode will ignore this
+    setting and is set to 50Hz/Step.
 
   Ctrl-Up/Ctrl-Down arrows, Cntl-key with mouse wheel - Bandwidth adjustment.
+    Pressing the Ctrl-key while using the Up/Down arrows or moving the mouse
+    wheel will adjust the receive bandwidth.
 
   PgUp/PgDn, Ctrl-F10/Ctrl-F9, Alt-F10/Alt-F9 - keying speed,
     in 2 WPM increments. HST Competition uses 5 WPM increments.

--- a/Readme.txt
+++ b/Readme.txt
@@ -153,9 +153,9 @@ KEY ASSIGNMENTS
 
   Enter - sends various messages, depending on the state of the QSO;
 
-  Up/Down arrows - RIT;
+  Up/Down arrows, mouse wheel - RIT;
 
-  Ctrl-Up/Ctrl-Down arrows - bandwidth;
+  Ctrl-Up/Ctrl-Down arrows, Cntl-key with mouse wheel - bandwidth;
 
   PgUp/PgDn, Ctrl-F10/Ctrl-F9, Alt-F10/Alt-F9 - keying speed,
     in 2 WPM increments. HST Competition uses 5 WPM increments.
@@ -230,6 +230,8 @@ Version 1.84 (February 2024)
   - All Contests - spacebar or Tab will now select both exchange fields (Coded by W7SST)
   - All Contests - Hide Dx Station's Entity status string if same as user's Entity (Coded by W7SST)
   - K1USN SST - user test field in call history file should be optional (Coded by W7SST)
+  - Improve RIT adjustment using mouse wheel (F6FVY, W7SST)
+  - Add receive Bandwidth adjustment using Cntl-key and mouse wheel (F6FVY, W7SST)
   - DX station will send an abbreviated exchange number in the JARL ALLJA and ACAG contests (Coded by JR8PPG)
   - User's exchange number is not abbreviated (not convert 100 to 1TT) (Coded by JR8PPG)
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -153,9 +153,21 @@ KEY ASSIGNMENTS
 
   Enter - sends various messages, depending on the state of the QSO;
 
-  Up/Down arrows, mouse wheel - RIT;
+  Up/Down arrows, mouse wheel - RIT adjustment.
+    The Up/Down arrow keys or the mouse wheel can be used to adjust the
+    receive RIT value. RIT can be adjusted between -500 and 500 Hz.
+    The default RIT increment is 50Hz/Step. You can modify the RIT step
+    increment using the RitStepIncr entry in the MorseRunner.ini file, e.g.:
+            [Settings]
+            RitStepIncr=50
 
-  Ctrl-Up/Ctrl-Down arrows, Cntl-key with mouse wheel - bandwidth;
+    Valid values range between -500 and 500. Useful values include 100, 125,
+    167 and 250 will provide 5, 4, 3 or 2 steps respectively in both directions.
+    Negative values can be used to change the direction of Up/Down arrow keys
+    or mouse movement. Note that a zero value will disable this feature.
+    HST Competition mode will ignore this setting and is set to 50Hz/Step.
+
+  Ctrl-Up/Ctrl-Down arrows, Cntl-key with mouse wheel - Bandwidth adjustment.
 
   PgUp/PgDn, Ctrl-F10/Ctrl-F9, Alt-F10/Alt-F9 - keying speed,
     in 2 WPM increments. HST Competition uses 5 WPM increments.

--- a/Readme.txt
+++ b/Readme.txt
@@ -276,6 +276,9 @@ Version 1.80 (Oct 2022)
   - Change default Font to Cleartype 'segoe ui', 'Consolar';
   - Change string to Unicode, Building with Delphi 2010 sp3.
 
+1.68.4+
+  - The mouse wheel now acts as RIT. (F6FVY)
+
 1.68 (VE3NEA) 2016
   - TU + MyCall after the QSO is now equivalent to CQ
 


### PR DESCRIPTION
Improve RIT and Bandwidth adjustment using mouse wheel.

- change mouse wheel RIT movement to 50Hz/step #248
- Adjust receive Bandwidth using Cntl-key and mouse wheel #252 