### PR TITLE
Add callers to the pile-up when a QSO is done (F6FVY)

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -551,14 +551,18 @@ procedure TContest.OnMeFinishedSending;
 var
   i: integer;
   z: integer;
+  Dx : integer;
 begin
   //the stations heard my CQ and want to call
-  if (not (RunMode in [rmSingle, {rmFieldDay,???} RmHst])) then
+  if (not (RunMode in [rmSingle, RmHst])) then
     if (msgCQ in Me.Msg) or
        ((QsoList <> nil) and ((msgTU in Me.Msg) or (msgMyCall in Me.Msg))) then
        begin
           z := 0;
-          for i:=1 to RndPoisson(Activity / 2) - DxCount do
+          Dx := DxCount;
+          if not (msgCQ in Me.Msg) then
+             if Dx > 0 then Dec(Dx);  // The just finished Q has to be deducted
+          for i:=1 to RndPoisson(Activity / 2) - Dx do
              begin
                  Stations.AddCaller;
                  z := 1;

--- a/Contest.pas
+++ b/Contest.pas
@@ -555,23 +555,22 @@ begin
   //the stations heard my CQ and want to call
   if (not (RunMode in [rmSingle, {rmFieldDay,???} RmHst])) then
     if (msgCQ in Me.Msg) or
-       ((QsoList <> nil) and (msgTU in Me.Msg) and (msgMyCall in Me.Msg))then
+       ((QsoList <> nil) and ((msgTU in Me.Msg) or (msgMyCall in Me.Msg))) then
        begin
           z := 0;
-          for i:=1 to RndPoisson(Activity / 2) do
+          for i:=1 to RndPoisson(Activity / 2) - DxCount do
              begin
                  Stations.AddCaller;
                  z := 1;
              end;
-             if z=0 then begin
-                // No maximo fica 3 cq sem contesters
-                inc(NoActivityCnt);
-                if ((NoActivityCnt > 2) or (NoStopActivity > 0) )  then begin
-                    Stations.AddCaller;
-                    NoActivityCnt := 0;
-                end;
-
+          if z=0 then begin
+             // No maximo fica 3 cq sem contesters
+             inc(NoActivityCnt);
+             if ((NoActivityCnt > 2) or (NoStopActivity > 0) )  then begin
+                 Stations.AddCaller;
+                 NoActivityCnt := 0;
              end;
+          end;
        end;
   //tell callers that I finished sending
   for i:=Stations.Count-1 downto 0 do


### PR DESCRIPTION
Add callers to the pile-up when a QSO is done #260
    
Formally, no caller was added to a QSO was done, and hitting F1 several times in a row was adding too many callers regarding the activity setting.
    
With this mod:
1. New callers may be added once a QSO is entered.
2. The total number of callers is always respecting the activity setting