### PR TITLE
262 modify the reply or not algorithm (F6FVY)

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -148,12 +148,14 @@ end;
 
 function TDxOperator.IsMyCall: TCallCheckResult;
 const
-  W_X = 2; W_Y = 2; W_D = 2;
+  W_X = 1; W_Y = 1; W_D = 1;
 var
   C, C0: string;
   M: array of array of integer;
   x, y: integer;
   T, L, D: integer;
+
+  P: integer;
 begin
   C0 := Call;
   C := Tst.Me.HisCall;
@@ -187,13 +189,15 @@ begin
       M[x,y] := MinIntValue([T,D,L]);
     end;
 
-  //classify by penalty
-  case M[High(M), High(M[0])] of
-    0:   Result := mcYes;
-    1,2: Result := mcAlmost;             
-    else Result := mcNo;
-  end;
+  P := M[High(M), High(M[0])];
 
+  if (P = 0) then
+    Result := mcYes
+  else if (((Length(C0) <= 4) and (Length(C0) - P >= 3)) or
+       ((Length(C0) > 4) and (Length(C0) - P >= 4))) then
+    Result := mcAlmost
+  else
+    Result := mcNo;
 
   //callsign-specific corrections
 


### PR DESCRIPTION
#262 Modify the "reply or not" algorithm (F6FVY)
    
The "reply or not" algorithm has been modified to allow callers with long callsigns to reply, even if only few letters are caught.
This change integrates this change from 2018 into MRCE mainline.
