### PR TITLE
264 better f7 management (F6FVY)

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -44,7 +44,7 @@ type
 implementation
 
 uses
-  SysUtils, Ini, Math, RndFunc, Contest, Log;
+  SysUtils, Ini, Math, RndFunc, Contest, Log, Main;
 
 { TDxOperator }
 
@@ -289,7 +289,8 @@ begin
       end;
 
   if msgQm in AMsg then
-    if State = osNeedPrevEnd then SetState(osNeedQso);
+    if (State = osNeedPrevEnd) and (Mainform.Edit1.Text = '') then
+      SetState(osNeedQso);
 
   if (not Ini.Lids) and (AMsg = [msgGarbage]) then State := osNeedPrevEnd;
 

--- a/DxOper.pas
+++ b/DxOper.pas
@@ -218,6 +218,7 @@ end;
 
 procedure TDxOperator.MsgReceived(AMsg: TStationMessages);
 begin
+
   //if CQ received, we can call no matter what else was sent
   if msgCQ in AMsg then
     begin
@@ -240,7 +241,6 @@ begin
     Exit;
     end;  
 
-
   if msgHisCall in AMsg then
     case IsMyCall of
       mcYes:
@@ -259,14 +259,12 @@ begin
         else if State = osNeedEnd then State := osDone;
       end;
 
-
   if msgB4 in AMsg then
     case State of
       osNeedPrevEnd, osNeedQso: SetState(osNeedQso);
       osNeedNr, osNeedEnd: State := osFailed;
       osNeedCall, osNeedCallNr: ; //same state: correct the call
       end;
-
 
   if msgNR in AMsg then
     case State of
@@ -289,6 +287,9 @@ begin
       osNeedCallNr: ;
       osNeedEnd: State := osDone;
       end;
+
+  if msgQm in AMsg then
+    if State = osNeedPrevEnd then SetState(osNeedQso);
 
   if (not Ini.Lids) and (AMsg = [msgGarbage]) then State := osNeedPrevEnd;
 


### PR DESCRIPTION
#262 F7 ('?') Instructs callers to call again if nothing has been caught or if what was caught is wrong (F6FVY)

This integrates this change from 2018 into MRCE.