### PR TITLE
No RIT needed for Single Call mode (W7SST)

### DIFF
--- a/DxStn.pas
+++ b/DxStn.pas
@@ -78,7 +78,10 @@ begin
     Qsb.Bandwidth := 3 + Random * 30;
 
   Amplitude := 9000 + 18000 * (1 + RndUShaped);
-  Pitch := Round(RndGaussLim(0, 300));
+  if RunMode = rmSingle then
+    Pitch := Round(RndGaussLim(0, 50))
+  else
+    Pitch := Round(RndGaussLim(0, 300));
 
   if Ini.RunMode = rmHst then
     begin


### PR DESCRIPTION
No RIT needed for Single Call mode (W7SST)

In single call mode, each new DxStation is created with a Pitch in the range of [-50, 50] Hz instead of the usual [-300, 300] Hz. This change will keep the station in the audio passband without the need for the user to use RIT control. By having a 100Hz range, the audio of each new station will sound different than the previous station.