### PR TITLE
269 rename menu item nr digits to serial nr

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -44,12 +44,14 @@ type
     procedure DropStation(id : integer); virtual; abstract;
     function GetCall(id : integer) : string; virtual; abstract;
     procedure GetExchange(id : integer; out station : TDxStation); virtual; abstract;
+    function GetRandomSerialNR: Integer; virtual;
     function GetStationInfo(const ACallsign : string) : string; virtual;
     function PickCallOnly : string;
 
     function OnSetMyCall(const AUserCallsign : string; out err : string) : boolean; virtual;
     function OnContestPrepareToStart(const AUserCallsign: string;
       const ASentExchange : string) : Boolean; virtual;
+    procedure SerialNrModeChanged; virtual;
     function IsFarnsworthAllowed : Boolean;
     function GetSentExchTypes(
       const AStationKind : TStationKind;
@@ -169,6 +171,15 @@ begin
 end;
 
 
+{
+  Return a random serial number for the currently selected Serial NR mode
+  (a menu pick).
+}
+function TContest.GetRandomSerialNR: Integer;
+begin
+  Result := Ini.SerialNRSettings[Ini.SerialNR].GetNR;
+end;
+
 
 {
   GetStationInfo() returns station's DXCC information.
@@ -240,6 +251,20 @@ begin
     end
   else
     Result:= True;
+end;
+
+
+{
+  Called after
+  - 'Setup | Serial NR' menu pick
+  - 'Setup | Serial NR | Custom Range...' menu pick/modification
+
+  The base class implementation does nothing. Other derived classes can
+  update cached information based on the serial NR menu pick (e.g. CQ WPX).
+}
+procedure TContest.SerialNrModeChanged;
+begin
+  assert(RunMode <> rmStop);
 end;
 
 

--- a/CqWpx.pas
+++ b/CqWpx.pas
@@ -7,6 +7,8 @@ unit CQWPX;
 interface
 
 uses
+  Ini,        // for TSerialNRSettings, TSerialNRTypes
+  SerNRGen,   // TSerialNRGen
   Contest, CallLst, DxStn, Log;
 
 type
@@ -14,10 +16,19 @@ TCqWpx = class(TContest)
 private
   // CQ Wpx Contest uses the global Calls variable (see CallLst.pas)
   CallLst : TCallList;
+  SerialNRGen : TSerialNRGen;
+  PrevSerialNRType : TSerialNRTypes;
+  PrevRangeStr : String;
+
+  procedure InitSerialNRGen;
+  function GetNR(const station : TDxStation) : integer;
 
 public
   constructor Create;
   destructor Destroy; override;
+
+  function OnContestPrepareToStart(const AUserCallsign: string;
+    const ASentExchange : string) : Boolean; override;
   function LoadCallHistory(const AUserCallsign : string) : boolean; override;
 
   function PickStation(): integer; override;
@@ -37,7 +48,16 @@ end;
 implementation
 
 uses
-  SysUtils, Classes, ARRL;
+  SysUtils, Generics.Defaults, System.Math, {Ini,} Classes, ARRL;
+
+function TCqWpx.OnContestPrepareToStart(const AUserCallsign: string;
+  const ASentExchange : string) : Boolean;
+begin
+  InitSerialNRGen;
+
+  Result := inherited OnContestPrepareToStart(AUserCallsign, ASentExchange);
+end;
+
 
 function TCqWpx.LoadCallHistory(const AUserCallsign : string) : boolean;
 begin
@@ -56,13 +76,143 @@ constructor TCqWpx.Create;
 begin
   inherited Create;
   CallLst := TCallList.Create;
+  SerialNRGen := TSerialNRGen.Create;
 end;
 
 
 destructor TCqWpx.Destroy;
 begin
   CallLst.Free;
+  SerialNrGen.Free;
   inherited;
+end;
+
+
+procedure TCqWpx.InitSerialNRGen;
+const
+  { This distribution table contains the number of log entries
+    submitted in 2023 as binned by largest serial number sent by single-ops.
+    Data provided by Laurent, F6FVY.
+
+    It is used during the simulation to provide a similar distribution
+    of serial numbers for the Mid-Contest and End-of-Contest simulations.
+  }
+  sampleTbl : array[0..59] of TSerNRSampleBin = (
+{0} (B:    0; C: 344),   // 0-9
+    (B:   10; C: 188),   // 10-19
+    (B:   20; C: 178),   // 20-29
+    (B:   30; C: 164),   // 30-39
+    (B:   40; C: 156),   // 40-49
+{5} (B:   50; C: 179),   // 50-59
+    (B:   60; C: 149),   // 60-69
+    (B:   70; C: 126),   // 70-79
+    (B:   80; C: 118),   // 80-89
+    (B:   90; C: 124),   // 90-100
+{10}(B:  100; C: 957),   // 100-200
+    (B:  200; C: 628),   // 200-300
+    (B:  300; C: 368),   // 300-400
+    (B:  400; C: 257),   // 400-500
+    (B:  500; C: 239),   // 500-600
+{15}(B:  600; C: 150),   // 600-700
+    (B:  700; C: 129),   // 700-800
+    (B:  800; C: 100),   // 800-900
+    (B:  900; C:  65),   // 900-1000
+    (B: 1000; C:  79),   // 1000-1100
+{20}(B: 1100; C:  59),   // 1100-1200
+    (B: 1200; C:  47),   // 1200-1300
+    (B: 1300; C:  44),   // 1300-1400
+    (B: 1400; C:  26),   // 1400-1500
+    (B: 1500; C:  28),   // 1500-1600
+{25}(B: 1600; C:  36),   // 1600-1700
+    (B: 1700; C:  23),   // 1700-1800
+    (B: 1800; C:  25),   // 1800-1900
+    (B: 1900; C:  23),   // 1900-2000
+    (B: 2000; C:  17),   // 2000-2100
+{30}(B: 2100; C:  24),   // 2100-2200
+    (B: 2200; C:  16),   // 2200-2300
+    (B: 2300; C:  15),   // 2300-2400
+    (B: 2400; C:   7),   // 2400-2500
+    (B: 2500; C:  11),   // 2500-2600
+{35}(B: 2600; C:   6),   // 2600-2700
+    (B: 2700; C:  11),   // 2700-2800
+    (B: 2800; C:   4),   // 2800-2900
+    (B: 2900; C:   5),   // 2900-3000
+    (B: 3000; C:   6),   // 3000-3100
+{40}(B: 3100; C:   1),   // 3100-3200
+    (B: 3200; C:   4),   // 3200-3300
+    (B: 3300; C:   6),   // 3300-3400
+    (B: 3400; C:   3),   // 3400-3500
+    (B: 3500; C:   1),   // 3500-3600
+{45}(B: 3600; C:   2),   // 3600-3700
+    (B: 3700; C:   3),   // 3700-3800
+    (B: 3800; C:   0),   // 3800-3900
+    (B: 3900; C:   1),   // 3900-4000
+    (B: 4000; C:   2),   // 4000-4100
+{50}(B: 4100; C:   0),   // 4100-4200
+    (B: 4200; C:   0),   // 4200-4300
+    (B: 4300; C:   0),   // 4300-4400
+    (B: 4400; C:   0),   // 4400-4500
+    (B: 4500; C:   0),   // 4500-4600
+{55}(B: 4600; C:   1),   // 4600-4700
+    (B: 4700; C:   0),   // 4700-4800
+    (B: 4800; C:   0),   // 4800-4900
+    (B: 4900; C:   0),   // 4900-5000
+{59}(B: 5000; C:$FFFF)
+  );
+
+{$ifdef DEBUG}
+var
+  EntryCount : UInt16;
+  J : integer;
+{$endif}
+begin
+  if (Ini.SerialNR = PrevSerialNRType) and
+     (Ini.SerialNRSettings[Ini.SerialNR].RangeStr = PrevRangeStr) then
+    exit;
+
+  case Ini.SerialNR of
+  snStartContest,   // Start of Contest
+  snCustomRange:    // Custom Range (01-99)
+    SerialNRGen.AddRange(Ini.SerialNRSettings[Ini.SerialNR]);
+  snMidContest,     // Mid-Contest (50-500)
+  snEndContest:     // End of Contest (500-5000)
+    SerialNRGen.AddDistribution(Ini.SerialNRSettings[Ini.SerialNR], SampleTbl);
+  else
+    assert(false);
+  end;
+
+  PrevSerialNRType := Ini.SerialNR;
+  PrevRangeStr := Ini.SerialNRSettings[Ini.SerialNR].RangeStr;
+
+{$ifdef DEBUG}
+  EntryCount := SerialNRGen.GetEntryCount;
+  case Ini.SerialNR of
+  snMidContest:   // Mid-Contest (50-500)
+    begin
+      assert(SerialNRGen.FindBin(0) = 0);
+      assert(SerialNRGen.FindBin(1) = 0);
+      assert(SerialNRGen.FindBin(179) = 0);
+      assert(SerialNRGen.FindBin(180) = 1);
+      assert(SerialNRGen.FindBin(EntryCount-1) = 13-SerialNRGen.DistRangeLowIdx);
+      assert(SerialNRGen.FindBin(EntryCount) = 13-SerialNRGen.DistRangeLowIdx);
+    end;
+  snEndContest:   // End-Contest (500-5000)
+    begin
+      assert(SerialNRGen.FindBin(0) = 0);
+      assert(SerialNRGen.FindBin(1) = 0);
+      assert(SerialNRGen.FindBin(239) = 0);
+      assert(SerialNRGen.FindBin(240) = 1);
+      assert(SerialNRGen.FindBin(239+150-1) = 1);
+      assert(SerialNRGen.FindBin(239+150) = 1);
+      assert(SerialNRGen.FindBin(239+150+1) = 2);
+      assert(SerialNRGen.FindBin(EntryCount-1) = 49-SerialNRGen.DistRangeLowIdx);
+      assert(SerialNRGen.FindBin(EntryCount) = 55-SerialNRGen.DistRangeLowIdx);
+    end;
+  end;
+
+  for J := 1 to EntryCount do
+    SerialNRGen.GetNR;
+{$endif}
 end;
 
 
@@ -116,9 +266,18 @@ end;
 procedure TCqWpx.GetExchange(id : integer; out station : TDxStation);
 begin
   station.Exch1 := getExch1(station.Operid);  // RST
-  station.NR := station.Oper.GetNR;           // serial number
+  station.NR := GetNR(station);               // serial number
+  station.Exch2 := IntToStr(station.NR);
 end;
 
+
+function TCqWpx.GetNR(const station : TDxStation) : integer;
+begin
+  if (RunMode = rmHST) or (Ini.SerialNR = snStartContest) then
+    Result := station.Oper.GetNR  // Result = f(elapsed time, operator skill)
+  else
+    Result := SerialNRGen.GetNR;
+end;
 
 
 function TCqWpx.getExch1(id:integer): string;    // returns RST (e.g. 5NN)
@@ -131,7 +290,6 @@ function TCqWpx.getExch2(id:integer): string;    // returns serial number (e.g. 
 begin
   Result := '1';
 end;
-
 
 end.
 

--- a/DxOper.pas
+++ b/DxOper.pas
@@ -94,16 +94,9 @@ begin
 end;
 
 function TDxOperator.GetNR: integer;
-Var
- n1: integer;
 begin
-  if NRDigits = 1 then
-      Result := 1 + Round(Random * Tst.Minute * Skills)
-  else begin
-       n1 := trunc(power(10,NRDigits));
-       n1 := n1-1;
-       Result := Random(n1)+1;  // result is with range [1,99] (w/ NRDigits=2)
-  end;
+  assert((RunMode = rmHST) or (Ini.SerialNR = snStartContest));
+  Result := 1 + Round(Random * Tst.Minute * Skills)
 end;
 
 

--- a/Ini.pas
+++ b/Ini.pas
@@ -303,7 +303,8 @@ var
       begin
         Err := Format(
           'Error while reading MorseRunner.ini file.'#13 +
-          'Invalid Keyword Value: ''%s=%s'': %s.'#13 +
+          'Invalid Keyword Value: ''%s=%s'':'#13 +
+          '%s'#13 +
           'Please correct this keyword or remove the MorseRunner.ini file.',
           [pRange.Key, pRange.RangeStr, Err]);
         cb(Err);
@@ -528,12 +529,23 @@ begin
     ExtractStrings(['-'], [], PChar(ValueStr), sl);
     Err := '';
     if (sl.Count <> 2) or
+       (ValueStr.CountChar('-') <> 1) or
        not TryStrToInt(sl[0], Self.MinVal) or
        not TryStrToInt(sl[1], Self.MaxVal) then
-      Err := 'Invalid range. Expecting min-max (e.g. 100-300)'
+      Err := Format(
+        'Error: ''%s'' is an invalid range.'#13 +
+        'Expecting min-max values with up to 4-digits each (e.g. 100-300).',
+        [ValueStr])
+    else if (Self.MinVal > 9999) or (Self.MaxVal > 9999) then
+      Err := Format(
+        'Error: ''%s'' is an invalid range.'#13 +
+        'Expecting range values to be less than or equal to 9999.',
+        [ValueStr])
     else if (Self.MinVal > Self.MaxVal) then
-      Err := 'Invalid range.'#13 +
-             'Expecting Min value to be less than Max value.';
+      Err := Format(
+        'Error: ''%s'' is an invalid range.'#13 +
+        'Expecting Min value to be less than Max value.',
+        [ValueStr]);
     if Err = '' then
       begin
         Self.MinDigits := sl[0].Length;

--- a/Ini.pas
+++ b/Ini.pas
@@ -57,6 +57,7 @@ type
     procedure Init(const Range: string; AMin, AMax: integer);
     function IsValid : boolean;
     function ParseSerialNR(const ValueStr : string; var Err : string) : Boolean;
+    function GetNR : integer;
   end;
 
   PSerialNRSettings = ^TSerialNRSettings;
@@ -511,6 +512,16 @@ end;
 function TSerialNRSettings.IsValid: Boolean;
 begin
   Result := (MinVal > 0) and (MinVal <= MaxVal);
+end;
+
+
+function TSerialNRSettings.GetNR : integer;
+begin
+  assert(IsValid);
+  if IsValid then
+    Result := MinVal + Random(MaxVal - MinVal)
+  else
+    Result := 1;
 end;
 
 

--- a/Ini.pas
+++ b/Ini.pas
@@ -8,7 +8,7 @@ unit Ini;
 interface
 
 uses
-  SysUtils, IniFiles, SndTypes, Math;
+  IniFiles;
 
 const
   SEC_STN = 'Station';
@@ -37,6 +37,30 @@ type
                     etCqZone, etItuZone, etAge, etPower, etJaPref, etJaCity,
                     etNaQpExch2, etNaQpNonNaExch2);
 
+  // Serial NR types
+  TSerialNRTypes = (snStartContest, snMidContest, snEndContest, snCustomRange);
+
+  // Serial Number Settings.
+  // Defines parameters used to generate various serial numbers.
+  // Used by SerialNRGenerator. Stored in .ini file.
+  TSerialNRSettings = record
+    Key: PChar;         // .INI file keyword
+    RangeStr: string;   // Range specification of the form: 01-99 (stored in .ini)
+    MinVal: integer;    // range starting value
+    MaxVal: integer;    // range ending value
+
+    // MinDigits/MaxDigits below are used for formatting leading zeros:
+    // (e.g. Format('%*d', [digits, NR]
+    MinDigits: integer; // number of digits in MinVal
+    MaxDigits: integer; // number of digits in max value
+
+    procedure Init(const Range: string; AMin, AMax: integer);
+    function IsValid : boolean;
+    function ParseSerialNR(const ValueStr : string; var Err : string) : Boolean;
+  end;
+
+  PSerialNRSettings = ^TSerialNRSettings;
+
   // Contest definition.
   TContestDefinition = record
     Name: PChar;    // Contest Name. Used in SimContestCombo dropdown box.
@@ -52,9 +76,15 @@ type
 
   PContestDefinition = ^TContestDefinition;
 
+  TErrMessageCallback = reference to procedure(const aMsg : string);
+
 const
   UndefExchType1 : TExchange1Type = TExchange1Type(-1);
   UndefExchType2 : TExchange2Type = TExchange2Type(-1);
+
+  SerialNrMidContestDef : string = '50-500';
+  SerialNrEndContestDef : string = '500-5000';
+  SerialNrCustomRangeDef : string = '01-99';
 
   {
     Each contest is declared here. Long-term, this will be a generalized
@@ -189,6 +219,13 @@ var
   MaxRxWpm: integer = 0;
   MinRxWpm: integer = 0;
   NRDigits: integer = 1;
+  SerialNRSettings: array[TSerialNRTypes] of TSerialNRSettings = (
+    (Key:'SerialNrStartContest'; RangeStr:'Default';  MinVal:1;   MaxVal:176;  minDigits:1; maxDigits:3),
+    (Key:'SerialNrMidContest';   RangeStr:'50-500';   MinVal:50;  MaxVal:500;  minDigits:2; maxDigits:3),
+    (Key:'SerialNrEndContest';   RangeStr:'500-5000'; MinVal:500; MaxVal:5000; minDigits:3; maxDigits:4),
+    (Key:'SerialNrCustomRange';  RangeStr:'01-99';    MinVal:1;   MaxVal:99;   minDigits:2; maxDigits:2)
+  );
+  SerialNR: TSerialNRTypes = snStartContest;
   BandWidth: integer = 500;
   Pitch: integer = 600;
   Qsk: boolean = false;
@@ -231,7 +268,7 @@ var
   UserExchange1: array[TSimContest] of string;
   UserExchange2: array[TSimContest] of string;
 
-procedure FromIni;
+procedure FromIni(cb : TErrMessageCallback);
 procedure ToIni;
 function IsNum(Num: String): Boolean;
 function FindContestByName(const AContestName : String) : TSimContest;
@@ -240,16 +277,42 @@ function FindContestByName(const AContestName : String) : TSimContest;
 implementation
 
 uses
+  Classes,        // for TStringList
+  Math,           // for Min, Max
+  SysUtils,       // for Format(),
   Main, Contest;
 
-procedure FromIni;
+procedure FromIni(cb : TErrMessageCallback);
 var
   V: integer;
   C: PContestDefinition;
   SC: TSimContest;
   KeyName: String;
+
+  procedure ReadSerialNRSetting(
+    IniFile: TCustomIniFile;
+    snt: TSerialNRTypes;
+    const DefaultVal : string);
+  var
+    Err : string;
+    ValueStr : string;
+  begin
+    var pRange : PSerialNRSettings := @Ini.SerialNRSettings[snt];
+    ValueStr := IniFile.ReadString(SEC_STN, pRange.Key, DefaultVal);
+    if not pRange.ParseSerialNR(ValueStr, Err) then
+      begin
+        Err := Format(
+          'Error while reading MorseRunner.ini file.'#13 +
+          'Invalid Keyword Value: ''%s=%s'': %s.'#13 +
+          'Please correct this keyword or remove the MorseRunner.ini file.',
+          [pRange.Key, pRange.RangeStr, Err]);
+        cb(Err);
+      end;
+  end;
+
 begin
-  with TIniFile.Create(ChangeFileExt(ParamStr(0), '.ini')) do
+  var IniFile: TCustomIniFile := TIniFile.Create(ChangeFileExt(ParamStr(0), '.ini'));
+  with IniFile do
     try
       // initial Contest pick will be first item in the Contest Dropdown.
       V:= Ord(FindContestByName(MainForm.SimContestCombo.Items[0]));
@@ -283,7 +346,27 @@ begin
 
       MainForm.UpdCWMaxRxSpeed(ReadInteger(SEC_STN, 'CWMaxRxSpeed', MaxRxWpm));
       MainForm.UpdCWMinRxSpeed(ReadInteger(SEC_STN, 'CWMinRxSpeed', MinRxWpm));
-      MainForm.UpdNRDigits(ReadInteger(SEC_STN, 'NRDigits', NRDigits));
+
+      // convert older NRDigits (pre-V1.84) to new SerialNR (v1.84)
+      if ValueExists(SEC_STN, 'NRDigits') then begin
+        NRDigits := ReadInteger(SEC_STN, 'NRDigits', NRDigits);
+        case NRDigits of
+          1: SerialNR := snStartContest;
+          2: SerialNR := snCustomRange;
+          3: SerialNR := snMidContest;
+          4: SerialNR := snEndContest;
+          else SerialNR := snStartContest;
+        end;
+        DeleteKey(SEC_STN, 'NRDigits');
+        WriteInteger(SEC_STN, 'SerialNR', Ord(SerialNR));
+        NRDigits := 0;
+      end;
+
+      ReadSerialNRSetting(IniFile, snMidContest, SerialNrMidContestDef);
+      ReadSerialNRSetting(IniFile, snEndContest, SerialNrEndContestDef);
+      ReadSerialNRSetting(IniFile, snCustomRange, SerialNrCustomRangeDef);
+      MainForm.UpdSerialNRCustomRange(SerialNRSettings[snCustomRange].RangeStr);
+      MainForm.UpdSerialNR(ReadInteger(SEC_STN, 'SerialNR', Ord(SerialNR)));
 
       Wpm := ReadInteger(SEC_STN, 'Wpm', Wpm);
       Qsk := ReadBool(SEC_STN, 'Qsk', Qsk);
@@ -378,7 +461,15 @@ begin
       }
       WriteInteger(SEC_STN, 'CWMaxRxSpeed', MaxRxWpm);
       WriteInteger(SEC_STN, 'CWMinRxSpeed', MinRxWpm);
-      WriteInteger(SEC_STN, 'NRDigits', NRDigits);
+      WriteInteger(SEC_STN, 'SerialNR', Ord(SerialNR));
+{ future...
+      WriteString(SEC_STN, Ini.SerialNRSettings[snMidContest].Key,
+                           Ini.SerialNRSettings[snMidContest].RangeStr);
+      WriteString(SEC_STN, Ini.SerialNRSettings[snEndContest].Key,
+                           Ini.SerialNRSettings[snEndContest].RangeStr);
+}
+      WriteString(SEC_STN, Ini.SerialNRSettings[snCustomRange].Key,
+                           Ini.SerialNRSettings[snCustomRange].RangeStr);
 
       WriteInteger(SEC_BND, 'Activity', Activity);
       WriteBool(SEC_BND, 'Qrn', Qrn);
@@ -404,6 +495,60 @@ begin
     finally
       Free;
     end;
+end;
+
+
+{ TSerialNRSettings methods...}
+procedure TSerialNRSettings.Init(const Range: string; AMin, AMax: integer);
+begin
+  Self.RangeStr := Range;
+  Self.MinVal := AMin;
+  Self.MaxVal := AMax;
+end;
+
+
+function TSerialNRSettings.IsValid: Boolean;
+begin
+  Result := (MinVal > 0) and (MinVal <= MaxVal);
+end;
+
+
+function TSerialNRSettings.ParseSerialNR(
+  const ValueStr : string;
+  var Err : string) : Boolean;
+var
+  sl : TStringList;
+begin
+  sl := TStringList.Create;
+  try
+    Self.RangeStr := ValueStr;
+
+    // split Range into two strings [Min, Max)
+    sl.Clear;
+    ExtractStrings(['-'], [], PChar(ValueStr), sl);
+    Err := '';
+    if (sl.Count <> 2) or
+       not TryStrToInt(sl[0], Self.MinVal) or
+       not TryStrToInt(sl[1], Self.MaxVal) then
+      Err := 'Invalid range. Expecting min-max (e.g. 100-300)'
+    else if (Self.MinVal > Self.MaxVal) then
+      Err := 'Invalid range.'#13 +
+             'Expecting Min value to be less than Max value.';
+    if Err = '' then
+      begin
+        Self.MinDigits := sl[0].Length;
+        Self.MaxDigits := sl[1].Length;
+      end
+    else
+      begin
+        Self.MinDigits := 0;
+        Self.MaxDigits := 0;
+      end;
+    Result := Err = '';
+
+  finally
+    sl.Free;
+  end;
 end;
 
 

--- a/Main.dfm
+++ b/Main.dfm
@@ -1382,26 +1382,26 @@ object MainForm: TMainForm
       end
       object NRDigits1: TMenuItem
         Tag = 3
-        Caption = 'NR Digits'
-        object NRDigitsSet1: TMenuItem
+        Caption = 'Serial NR'
+        object SerialNRSet1: TMenuItem
+          Caption = 'Start of Contest (Default)'
+          Checked = True
+          OnClick = NRDigitsClick
+        end
+        object SerialNRSet2: TMenuItem
           Tag = 1
-          Caption = '1'
+          Caption = 'Mid-Contest (50-500)'
           OnClick = NRDigitsClick
         end
-        object NRDigitsSet2: TMenuItem
+        object SerialNRSet3: TMenuItem
           Tag = 2
-          Caption = '2'
+          Caption = 'End of Contest (500-5000)'
           OnClick = NRDigitsClick
         end
-        object NRDigitsSet3: TMenuItem
+        object SerialNRCustomRange: TMenuItem
           Tag = 3
-          Caption = '3'
-          OnClick = NRDigitsClick
-        end
-        object NRDigitsSet4: TMenuItem
-          Tag = 4
-          Caption = '4'
-          OnClick = NRDigitsClick
+          Caption = 'Custom Range (01-99)...'
+          OnClick = SerialNRCustomRangeClick
         end
       end
       object N6: TMenuItem

--- a/Main.pas
+++ b/Main.pas
@@ -2317,7 +2317,6 @@ begin
       if Err <> '' then
         begin
           // report error and try again
-          Err := Format('Error: ''%s'': %s', [RangeStr, Err]);
           MessageDlg(Err, mtError, [mbOK], 0);
         end
       else

--- a/MorseRunner.dpr
+++ b/MorseRunner.dpr
@@ -45,7 +45,8 @@ uses
   CWSST in 'CWSST.pas',
   ALLJA in 'ALLJA.pas',
   ACAG in 'ACAG.pas',
-  IaruHf in 'IaruHf.pas';
+  IaruHf in 'IaruHf.pas',
+  SerNRGen in 'SerNRGen.pas';
 
 {$R *.RES}
 

--- a/MorseRunner.dproj
+++ b/MorseRunner.dproj
@@ -164,6 +164,7 @@
         <DCCReference Include="ALLJA.pas"/>
         <DCCReference Include="ACAG.pas"/>
         <DCCReference Include="IaruHf.pas"/>
+        <DCCReference Include="SerNRGen.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Readme.txt
+++ b/Readme.txt
@@ -152,14 +152,23 @@ CONFIGURATION
         the CWops CW Academy (free classes) start with 18 WPM, 20 WPM and 25 WPM
         character speeds for each level of classes.
 
-    NR Digits
-      The number of digits the responding station will send.
-        There are four possible settings:
-          1 - generates random serial numbers starting near 1 and increasing as
-              the contest runs. Matches default behavior found in version 1.68.
-          2 - 2 digits are sent, randomly generated between 1 and 99.
-          3 - 3 digits are sent, randomly generated between 1 and 999.
-          4 - 4 digits are sent, randomly generated between 1 and 9999.
+    Serial NR
+      Serial numbers sent by the responding station can be adjusted with the
+      following settings:
+        - Start of Contest (Default)
+            Generates random serial numbers starting near 1 and increasing as
+            the contest runs. Matches default behavior found in version 1.68.
+            Used during HST Simulation.
+        - Mid-Contest (50-500)
+            Sends 2 and 3-digit numbers, randomly generated between 50 and 500.
+            Numbers will generated using a similar distribution as CQ WPX 2023.
+        - End of Contest (500-5000)
+            Sends 3 and 4-digit numbers, randomly generated between 500 and 5000.
+            Numbers will generated using a similar distribution as CQ WPX 2023.
+        - Custom Range (01-99)...
+            This option allows a user-entered range string of the form "<min>-<max>".
+            An optional leading zero can be specified for generating serial numbers
+            with leading zeros (e.g. 001-200).
 
   Responses
     There are five basic responses that you can receive:
@@ -297,6 +306,7 @@ Version 1.84 (February 2024)
   - Improve RIT adjustment using mouse wheel (W7SST)
   - Improve pattern matching for DXCC entities (used in status bar) (Coded by W7SST)
   - CQ WPX - Dx Stations will occasionally send a serial number of zero (Coded by W7SST)
+  - CQ WPX - Improved Serial Number generation (Coded by W7SST)
   - ARRL DX - incorrect handling of KH6/KL7 stations using AH6/AL7, NH6/NL7, WH6/WL7 (Coded by W7SST)
   - NAQP - Exchange field does not allow numbers (e.g. KH6 or KL7) (Coded by W7SST)
   - All Contests - WPM keyboard entry incorrect behavior for Spin Box (up down control) (Coded by W7SST)

--- a/SerNRGen.pas
+++ b/SerNRGen.pas
@@ -1,0 +1,230 @@
+unit SerNRGen;
+
+{$ifdef FPC}
+{$MODE Delphi}
+{$endif}
+
+interface
+
+uses
+  Generics.Collections, // for TArray<>
+  Ini;                  // for TSerialNumberRange
+
+type
+// Used to declare a set of bins containing the number of logs/entries
+// for a highest serial number range. An array is formed to create a
+// series of bins representing the full sample distribution. An additional
+// bin is added to the end of the array.
+// See example in CqWpx.pas.
+TSerNRSampleBin = record
+  B: UInt16;    // starting serial number for this bin
+  C: UInt16;    // number of samples (logs/entries) in this bin
+end;
+
+{
+  SerialNRGen will generate random serial number matching a sample
+  distribution representing a prior contest. F6FVY provided data showing
+  the last number sent by single-ops according to available public log
+  files from the 2023 CQ WPX contest. Please see the discussion at:
+  https://github.com/w7sst/MorseRunner/issues/269
+
+  SerialNRGen will organize this data allow easy random generation
+  of serial numbers following this same distribution.
+
+  Steps to setup a Serial Number Generator
+  1. Create a sample distribution using data from prior contest.
+      sampleTbl : array[0..5] of TSerNRSampleBin = (
+      //  BeginSN  Count       SN Range    Ratio   Percentage
+        (B:    0; C: 344),   // 0-9        344/1030 = 33.4%
+        (B:   10; C: 188),   // 10-19      188/1030 = 18.3%
+        (B:   20; C: 178),   // 20-29      178/1030 = 17.3%
+        (B:   30; C: 164),   // 30-39      164/1030 = 15.9%
+        (B:   40; C: 156),   // 40-49      156/1030 = 15.1%
+        (B:   50; C:$FFFF);  // end       1030/1030 = 100%
+  2. Call TSerialNRGen.AddDistribution(sampleTbl)
+      SerialNRGen := TSerialNRGen.Create
+      SerialNRGen.AddDistribution(sampleTbl);
+  3. Call GetNR as needed
+      Result := SerialNRGen.GetNR();
+
+  Details
+  The above data will be organized in a new table with a running sample total
+  column. This column will be used when searching for a bin instead of using
+  a floating-point percentage value. The total, 1030, is used to generate a
+  random number when searching for a bin. By searching for a bin in the range
+  [0,1030), this data can be stored using 16-bit WORD values (UInt16).
+  Once a bin is found using a Random(1030), the value is computed using
+  StartingSN + Random(BinWidth).
+                         Running
+    starting    Bin      Sample   Percent
+         SN    Width     Total
+        ( 0     10       344 )     33.4%
+        (10     10       532 )     51.7%
+        (20     10       710 )     68.9%
+        (30     10       874 )     84.9%
+        (40     10      1030 )    100.0%
+                          ^
+                          |---- Random (1030) will find the bin
+
+  Finally, TArray<>.BinarySearch has this nifty feature where it will find
+  the first occurrance of a bin with the same value. See TSerialNRGen.FindBin().
+}
+TSerialNRGen = class
+public
+type
+  TSerialNRItem = record
+    IdRangeBegin: UInt16;     // serial number range starting value
+    IdRangeWidth: UInt16;     // bin width
+    CummulativeCnt: UInt16;   // running cummulative total count
+
+    procedure Init(const ABegin, AWidth, ACnt : UInt16);
+    function GetNR() : integer;
+  end;
+  PSerNRItem = ^TSerialNRItem;
+
+var
+  SerialNrTbl : TArray<TSerialNRItem>;
+
+  constructor Create;
+  destructor Destroy; override;
+
+  procedure AddRange(const aRange : TSerialNRSettings);
+  procedure AddDistribution(const aRange : TSerialNRSettings;
+    const aSampleTbl : array of TSerNRSampleBin);
+  function FindBin(count: UInt16) : integer;
+  function GetNR() : integer;
+
+  function GetEntryCount : UInt16;
+
+private
+  LowIdx : integer;   // starting index into original sampleTbl
+  HighIdx : integer;  // ending index into original sampleTbl
+  Sum : UInt16;       // running total of log entries included in distribution
+
+{$ifdef DEBUG}
+public
+  // starting index into distribution table (used in various asserts)
+  property DistRangeLowIdx : integer read LowIdx;
+
+  // ending index into distribution table (used in various asserts)
+  property DistRangeHighIdx : integer read HighIdx;
+{$endif}
+end;
+
+implementation
+
+uses
+  Generics.Defaults, System.Math;
+
+constructor TSerialNRGen.Create;
+begin
+
+end;
+
+
+destructor TSerialNRGen.Destroy;
+begin
+  SerialNRTbl := nil;
+end;
+
+
+// used to add simple user-defined range without a sample distribution table.
+procedure TSerialNRGen.AddRange(const aRange : TSerialNRSettings);
+begin
+  SetLength(SerialNRTbl, 1);
+  Sum := 1;
+  SerialNRTbl[0].Init(aRange.MinVal, aRange.MaxVal - aRange.MinVal, Sum);
+  LowIdx := 0;
+  HighIdx := 0;
+end;
+
+// add a serial number distribution table to the generator
+procedure TSerialNRGen.AddDistribution(const aRange : TSerialNRSettings;
+  const aSampleTbl : array of TSerNRSampleBin);
+var
+  I : integer;
+begin
+  Sum := 0;
+  // note - the following is hardwired. This will replaced in the future
+  // with a more general mechanism to allow user-defined ranges to be used.
+  case aRange.MinVal of
+  50: LowIdx := 5;
+  500: LowIdx := 14;
+  else
+    assert(false);
+  end;
+  case aRange.MaxVal of
+  500: HighIdx := 13;
+  5000: HighIdx := 58;
+  else
+    assert(false);
+  end;
+
+  I := HighIdx - LowIdx + 1;
+  SetLength(SerialNRTbl, I);
+  var pItem : PSerNRItem := @SerialNRTbl[0];
+  for I := LowIdx to HighIdx do
+    begin
+      Inc(Sum, aSampleTbl[I].C);
+      assert(pItem = @SerialNRTbl[I-LowIdx]);
+      assert(I+1 < Length(aSampleTbl));
+      pItem.IdRangeBegin := aSampleTbl[I].B;
+      pItem.IdRangeWidth := aSampleTbl[I+1].B - aSampleTbl[I].B;
+      pItem.CummulativeCnt := Sum;
+      Inc(pItem);
+    end;
+end;
+
+
+function TSerialNRGen.GetNR() : integer;
+var
+  EntryCount : UInt16;
+  FoundIdx : integer;
+begin
+  EntryCount := SerialNRTbl[High(SerialNRTbl)].CummulativeCnt;
+  FoundIdx := FindBin(UInt16(Random(EntryCount)+1));  // find bin with this accumulated total
+  Result := SerialNRTbl[FoundIdx].GetNR();
+end;
+
+
+function TSerialNRGen.FindBin(count: UInt16) : integer;
+var
+  Item : TSerialNRItem;
+  FoundIdx : integer;
+begin
+  assert(count <= SerialNRTbl[High(SerialNRTbl)].CummulativeCnt);
+  assert(Sum = SerialNRTbl[High(SerialNRTbl)].CummulativeCnt);
+  count := Min(count, SerialNRTbl[High(SerialNRTbl)].CummulativeCnt);
+  Item.Init(0, 0, count);  // find bin with this accumulated total
+  TArray.BinarySearch<TSerialNRItem>(SerialNRTbl, Item, FoundIdx,
+    TComparer<TSerialNRItem>.Construct(
+      function (const Left, Right: TSerialNRItem): Integer
+      begin
+        Result := CompareValue(Left.CummulativeCnt, Right.CummulativeCnt);
+      end
+      ));
+  assert(FoundIdx < Length(SerialNRTbl));
+  Result := FoundIdx;
+end;
+
+
+function TSerialNRGen.GetEntryCount : UInt16;
+begin
+  Result := Sum;
+end;
+
+
+procedure TSerialNRGen.TSerialNRItem.Init(const ABegin, AWidth, ACnt : UInt16);
+begin
+  IdRangeBegin := ABegin;
+  IdRangeWidth := AWidth;
+  CummulativeCnt := ACnt;
+end;
+
+
+function TSerialNRGen.TSerialNRItem.GetNR() : integer;
+begin
+  Result := IdRangeBegin + Random(IdRangeWidth);
+end;
+
+end.

--- a/SerNRGen.pas
+++ b/SerNRGen.pas
@@ -1,3 +1,8 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
 unit SerNRGen;
 
 {$ifdef FPC}


### PR DESCRIPTION
    CQ WPX - Improved Serial Number generation (Coded by W7SST)
    
    - Renamed Settings > NR Digits menu item to Serial NR
    - F6FVY provided highest serial number sent by single-ops in CQ WPX 2023
    - Added ability to generate serial numbers using actual distribution
    - Added new menu picks: Start of Contest, Mid-Contest and End of Contest
    - Add new Serial NR > Custom Range... menu pick for user-defined range
    - Custom Range... specification can include leading zero (e.g. 001-250)
    - Fixes #269