### PR TITLE
HST Competition - add error check for correct settings

### DIFF
--- a/Main.pas
+++ b/Main.pas
@@ -1706,6 +1706,22 @@ begin
     if UserCallsignDirty then
        SetMyCall(Trim(Edit4.Text));
 
+    // if requesting an HST run, verify the correct contest and serial NR
+    // mode is selected.
+    if (Value = rmHst) and
+       ((SimContest <> scHst) or (Ini.SerialNR <> snStartContest)) then
+    begin
+      var S : string :=
+        'Error: HST Competition mode requires the following settings:'#13 +
+        '  1. ''HST (High Speed Test)'' in the Contest dropdown.'#13 +
+        '  2. ''Start of Contest'' in the ''Settings | Serial NR'' menu.'#13 +
+        'Please correct these settings and try again.';
+      Application.MessageBox(PChar(S),
+        'Error',
+        MB_OK or MB_ICONERROR);
+      Exit;
+    end;
+
     // load call history and other contest-specific setup before starting
     if not Tst.OnContestPrepareToStart(Ini.Call, ExchangeEdit.Text) then
       Exit;
@@ -1723,7 +1739,7 @@ begin
   //main ctls
   EnableCtl(SimContestCombo, BStop);
   EnableCtl(Edit4,  BStop);
-  EnableCtl(ExchangeEdit, BStop);
+  EnableCtl(ExchangeEdit, BStop and ActiveContest.ExchFieldEditable);
   EnableCtl(SpinEdit2, BStop);
   SetToolbuttonDown(ToolButton1, not BStop);
 
@@ -1775,10 +1791,12 @@ begin
   Flutter1.Enabled := not BCompet;
   Lids1.Enabled := not BCompet;
 
-
   //hst specific
   Activity1.Enabled := Value <> rmHst;
   CWBandwidth2.Enabled := Value <> rmHst;
+  CWMinRxSpeed1.Enabled := Value <> rmHst;
+  CWMaxRxSpeed1.Enabled := Value <> rmHst;
+  NRDigits1.Enabled := Value <> rmHst;
 
   EnableCtl(SpinEdit3, RunMode <> rmHst);
   if RunMode = rmHst then SpinEdit3.Value := 4;


### PR DESCRIPTION
HST Competition - add error check for correct settings

- HST Competition requires HST Contest and default 'Start of Contest' Serial Numbers to be set.
- disabled Exchange edit field when HST is running.
- disabled Serial NR menu when HST is running.
- disabled CW Min/Max menu items when HST is running.