### PR TITLE
CQ WPX - editable exchange field (starting number or #)

### DIFF
--- a/Ini.pas
+++ b/Ini.pas
@@ -103,7 +103,7 @@ const
      Key: 'CqWpx';
      ExchType1: etRST;
      ExchType2: etSerialNr;
-     ExchFieldEditable: False;
+     ExchFieldEditable: True;
      ExchDefault: '5NN #';
      Msg: '''RST <serial>'' (e.g. 5NN #|123)';
      T:scWpx),

--- a/Main.dfm
+++ b/Main.dfm
@@ -950,6 +950,7 @@ object MainForm: TMainForm
         CharCase = ecUpperCase
         TabOrder = 1
         Text = '3A ON'
+        OnChange = ExchangeEditChange
         OnExit = ExchangeEditExit
       end
     end


### PR DESCRIPTION
Improve error checking while editing Exchange field.
- Exchange field is now editable for CQ WPX Contest.
- User can specify a number or `#`.
  - The number is the starting serial NR.
  - The `#` represents the auto-generated sequence number. The initial value will be randomly generated when running with `Mid-Contest` or `End of Contest` Serial NR modes.
- Improved error checking and reporting
- fixes #278