### PR TITLE
ARRL FD - reduce high number of home/portable club stations (W7SST)

### DIFF
--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -59,6 +59,8 @@ const
 var
   slst, tl: TStringList;
   i: integer;
+  S : String;
+  HomeStn, PortableStn : Boolean;
   rec: TFdCallRec;
 begin
   // reload call history if empty
@@ -106,9 +108,9 @@ begin
           // accurate since many clubs operated as a portable station without
           // a corresponding club call operating under Class A (Club).
           // Note - this algorithm will be revised after v1.84 release.
-          var S : String := rec.StnClass.substring(1);
-          var HomeStn : Boolean := S.Equals('D') or S.Equals('E');
-          var PortableStn : Boolean := S.Equals('B');
+          S := rec.StnClass.Substring(rec.StnClass.Length-1);
+          HomeStn := S.Equals('D') or S.Equals('E');
+          PortableStn := S.Equals('B');
           if (HomeStn or PortableStn) and not rec.UserText.IsEmpty then
             continue;
 

--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -95,9 +95,22 @@ begin
           if rec.Call='' then continue;
           if rec.StnClass='' then continue;
           if rec.Section='' then continue;
-          //if IsNum(rec.Number) = False then  continue;
-          //if length(rec.Name) > 10 then continue;
-          //if length(rec.Name) > 12 then continue;
+
+          // In 2020, Covid resulted in FD rule changes allowing home stations
+          // to be used and contribute to the operator's club score. This
+          // resulted in an above average number of home stations since these
+          // stations were connected to the clubs score.
+          //
+          // Skip home (D/E) and portable (B) stations with a club name by
+          // assuming they are associated with a club. This is not 100%
+          // accurate since many clubs operated as a portable station without
+          // a corresponding club call operating under Class A (Club).
+          // Note - this algorithm will be revised after v1.84 release.
+          var S : String := rec.StnClass.substring(1);
+          var HomeStn : Boolean := S.Equals('D') or S.Equals('E');
+          var PortableStn : Boolean := S.Equals('B');
+          if (HomeStn or PortableStn) and not rec.UserText.IsEmpty then
+            continue;
 
           FdCallList.Add(rec);
           rec := nil;


### PR DESCRIPTION
- Fixes #286
- Will remove home/portable stations with an associated club name in the UserText file.
- This balances the distribution of club callsigns to better match published results. Previously the number of 1D stations was much higher than it should be.
- This algorithm will be revised in a future release (Issue #285).