### PR TITLE
HST Competition - display running score in lower-left corner

### DIFF
--- a/Log.pas
+++ b/Log.pas
@@ -361,7 +361,7 @@ begin
 
   MainForm.PaintBox1.Invalidate;
 
-  //MainForm.Panel11.Caption := IntToStr(Score);
+  MainForm.Panel11.Caption := IntToStr(Score);
 end;
 
 {


### PR DESCRIPTION
The running HST Competition score has been disabled since version 1.70. It has now been restored.