### PR TITLE
Improve HST logging with separate exchange columns and score

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -511,7 +511,7 @@ begin
               Log.ScoreTableUpdateCheck;
 
               { TODO -omikeb -cfeature : Clean up status bar code. }
-              if Ini.RunMode = RmHst then
+              if SimContest = scHst then
                 Log.UpdateStatsHst
               else
                 Log.UpdateStats({AVerifyResults=}True);
@@ -550,7 +550,7 @@ begin
       MainForm.Run(rmStop);
       FStopPressed := false;
       MainForm.PopupScoreHst;
-      end        
+      end
     else if (SimContest = scWpx) and
       (RunMode in [rmHst, rmWpx]) and
       not FStopPressed then

--- a/Log.pas
+++ b/Log.pas
@@ -363,27 +363,19 @@ begin
     scHst:
       if ShowCorrections then
       begin
-        if (Ini.RunMode = rmHst) then
-          ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Score', 'Correct', 'Wpm')
-        else
-          ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Pref', 'Correct', 'Wpm');
+        ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Score', 'Correct', 'Wpm');
         ScoreTableScaleWidth(1, 0.90);  // shrink Call column
         ScoreTableScaleWidth(2, 0.90);  // shrink Recv column
         ScoreTableScaleWidth(3, 0.90);  // shrink Sent column
         ScoreTableScaleWidth(5, 2);   // expand Corrections column
       end
-      else if Ini.RunMode = rmHst then
-        ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Score', 'Chk', 'Wpm')
       else
-        ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Pref', 'Chk', 'Wpm');
+        ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Score', 'Chk', 'Wpm')
     else
-      begin
-        assert(false, 'missing case');
-        ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Pref', 'Chk', 'Wpm');
-      end;
+      assert(false, 'missing case');
   end;  // end case
 
-  if Ini.RunMode = rmHst then
+  if SimContest = scHst then
     Empty := ''
   else
     Empty := FormatScore(0);
@@ -734,7 +726,7 @@ begin
     Qso.Pfx := ExtractPrefix(Qso.Call);
     // extract ';'-delimited multiplier string(s) and update Qso.Points.
     Qso.MultStr := Tst.ExtractMultiplier(Qso);
-    if Ini.RunMode = rmHst then
+    if SimContest = scHst then
       Qso.Pfx := IntToStr(CallToScore(Qso.Call));
 
     //mark if dupe
@@ -769,7 +761,7 @@ begin
   end;
 
   LastQsoToScreen;
-  if Ini.RunMode = rmHst then
+  if SimContest = scHst then
     UpdateStatsHst
   else
     UpdateStats({AVerifyResults=}False);

--- a/Log.pas
+++ b/Log.pas
@@ -363,11 +363,11 @@ begin
     scHst:
       if ShowCorrections then
       begin
-        ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Score', 'Correct', 'Wpm');
+        ScoreTableSetTitle('UTC', 'Call', 'RST', 'Exch', 'Score', 'Correct', 'Wpm');
         ScoreTableScaleWidth(1, 0.90);  // shrink Call column
-        ScoreTableScaleWidth(2, 0.90);  // shrink Recv column
-        ScoreTableScaleWidth(3, 0.90);  // shrink Sent column
-        ScoreTableScaleWidth(5, 2);   // expand Corrections column
+        ScoreTableScaleWidth(2, 0.50);  // shrink RST column
+        ScoreTableScaleWidth(3, 0.60);  // shrink Exch (NR) column
+        ScoreTableScaleWidth(5, 2);     // expand Corrections column
       end
       else
         ScoreTableSetTitle('UTC', 'Call', 'Recv', 'Sent', 'Score', 'Chk', 'Wpm')
@@ -812,10 +812,16 @@ begin
         , format('%4d', [NR])
         , Pfx, Err, format('%3s', [TrueWpm]));
     scHst:
-      ScoreTableInsert(FormatDateTime('hh:nn:ss', t), Call
-        , format('%.3d %.4d', [Rst, Nr])
-        , format('%.3d %.4d', [Tst.Me.Rst, Tst.Me.NR])
-        , Pfx, Err, format('%3s', [TrueWpm]));
+      if ShowCorrections then
+        ScoreTableInsert(FormatDateTime('hh:nn:ss', t), Call
+          , format('%.3d', [Rst])
+          , format(IfThen(RunMode = rmHst, '%.4d', '%4d'), [NR])
+          , Pfx, Err, format('%3s', [TrueWpm]))
+      else
+        ScoreTableInsert(FormatDateTime('hh:nn:ss', t), Call
+          , format('%.3d %.4d', [Rst, Nr])
+          , format('%.3d %.4d', [Tst.Me.Rst, Tst.Me.NR])
+          , Pfx, Err, format('%3s', [TrueWpm]));
     scCQWW:
       ScoreTableInsert(FormatDateTime('hh:nn:ss', t), Call
         , format('%.3d', [Rst])
@@ -933,7 +939,7 @@ begin
   case Exch2Error of
     leNONE: ;
     leNR:
-      if (SimContest = scHst) and ShowHstCorrections then
+      if (SimContest = scHst) and ShowHstCorrections and (RunMode = rmHst) then
       begin
         assert(Mainform.RecvExchTypes.Exch2 = etSerialNr);
         ACorrections.Add(format('%.4d', [TrueNR]));
@@ -995,11 +1001,7 @@ begin
         Err := Corrections.DelimitedText;  // Join(' ');
         if ExchError  <> leNONE then CallColumnColor := clRed;
         if Exch1Error <> leNONE then Exch1ColumnColor := clRed;
-        if Exch2Error <> leNONE then
-          if (SimContest = scHst) and ShowHstCorrections then
-            Exch1ColumnColor := clRed
-          else
-            Exch2ColumnColor := clRed;
+        if Exch2Error <> leNONE then Exch2ColumnColor := clRed;
       end
       else
       begin

--- a/Main.pas
+++ b/Main.pas
@@ -2482,6 +2482,13 @@ begin
   end
   else
     View.Canvas.Font.Color := IfThen(SubItem = 5, clRed, clBlack);
+
+  // strike out HST Score if a QSO error exists
+  if SimContest = scHst then
+    if (SubItem = 4) and (Qso.Err <> '   ') and (Qso.TrueCall <> '') then
+      View.Canvas.Font.Style := [fsStrikeOut]
+    else
+      View.Canvas.Font.Style := [];
 end;
 
 procedure TMainForm.ListView2SelectItem(Sender: TObject; Item: TListItem;


### PR DESCRIPTION
- replace HST Recv/Sent with RST and Exch Columns
- Score column is now included in all run modes
- strike out Score whenever a QSO error occurs