### PR TITLE
200 nil if ghosted before logging

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -14,6 +14,66 @@ const
   FULL_PATIENCE = 5;
 
 type
+  {
+    TOperatorState represents the various states of an independent DxStation/
+    DxOperator object. During a pile-up, multiple DxStation objects will exist.
+    These states represent the operational state of each unique station within
+    a simulated QSO.
+
+    Each state follows the back and forth transmissions between the user and
+    an indiviual DxOperator. Remember that DxStation and DxOperator objects
+    are the simulated stations within the MR simulation.
+
+    State           Description
+    NORMAL FLOW...
+    osNeedPrevEnd   Starting point. This is the initial operator state for a
+                    newly created DxStation. The station will wait for the
+                    completion of any prior QSO's as indicated by either
+                    the user's next CQ call or a 'TU' message.
+    osNeedQso       The DxOperator is waiting for their Dx callsign to be sent
+                    by user. This state begins after the user has either called
+                    CQ or finished the prior QSO by sending a 'TU' message.
+                    For RunMode rmSingle, the CQ message is assumed and
+                    the DxOperator immediately goes into this state
+                    (expecting their callsign to be sent by user).
+                    Typical response msg: send DxStation's callsign.
+    osNeedNr        DxOperator is waiting for user's exchange.
+                    DxOperator has received the user's callsign and is now
+                    waiting to receive the user's exchange.
+                    Typical response: send DxStation's exchange.
+    osNeedEnd       DxStation is waiting for 'TU' from user.
+                    User's call and exchange have been received.
+                    Typical response msg: send DxStation's exchange.
+    osDone          DxOperator has received a 'TU' from the user.
+                    This QSO is now considered complete and can be logged.
+
+    SPECIAL CASES (timeouts, call/exchange copy errors, random events)...
+    osFailed        This QSO has failed. Reasons for failure include:
+                    - DxStation is created and waits for the User to call their
+                      callsign. If the user does not call them within a given
+                      timeframe, the DxOperator will loose Patience and stop
+                      sending their callsign. This is a form of caller ghosting
+                      where the DxOperator gives up due to lack of patience
+                      (occurs whenever Patience decrements to zero).
+                    - user sends a msgNIL, which forces the QSO to fail.
+                    - user sends a msgB4, stating that they had a prior QSO.
+    osNeedCall      DxStation is expecting their call to be corrected by the
+                    user. This state is entered when user sends a partially-
+                    correct callsign. This DxOperator will wait for the correct
+                    call to be sent before sending its Exchange.
+                    The logic also appears to support the fact the user's
+                    exchange (NR) has already been copied by this DxStation.
+                    Once corrected, we should send 'R <exch>'.
+                    Typical response msg: send DxStation's callsign
+    osNeedCallNr    DxStation is expecting both their callsign and Exchange
+                    to be sent by user.
+                    This state is entered when the DxStation receives a
+                    partially-correct callsign from the user. In this case,
+                    the QSO advances from osNeedQso to osNeedCallNr.
+                    Once the correct callsign is received, the next state will
+                    be osNeedNr.
+                    Typical response msg: DxStation's callsign
+  }
   TOperatorState = (osNeedPrevEnd, osNeedQso, osNeedNr, osNeedCall,
     osNeedCallNr, osNeedEnd, osDone, osFailed);
 
@@ -27,7 +87,11 @@ type
   public
     Call: string;
     Skills: integer;
-    Patience: integer;
+    Patience: integer;  // Number of times operator will retry before leaving.
+                        // Decremented to zero upon each evTimeout.
+                        // When it reaches zero, the operator will ghost and its
+			// TDxOperator.State set to osFailed.
+			// Patience is increased with calls to MorePatience.
     RepeatCnt: integer;
     State: TOperatorState;
     function GetSendDelay: integer;
@@ -106,6 +170,11 @@ begin
 end;
 
 
+{
+  Returns the amount of time to wait for a reply after sending a transmission.
+  This is in units of block counts. A new block is fetched by the audio
+  system as needed to keep the audio stream full (See TContest.GetAudio).
+}
 function TDxOperator.GetReplyTimeout: integer;
 begin
   if RunMode = rmHst then
@@ -116,7 +185,11 @@ begin
 end;
 
 
-
+{
+  DecPatience is typically called after an evTimeout event.
+  The TDxOperator.Patience value is decremented down to zero.
+  When this count reaches zero, the DxStation is deleted from the simulation.
+}
 procedure TDxOperator.DecPatience;
 begin
   if State = osDone then Exit;
@@ -126,9 +199,34 @@ begin
 end;
 
 
+{
+  Calling this function will set the new State and compute a new Patience
+  value to represent how patient this operator will be while waiting for
+  a subsequent transmission from the user.
+
+  SetState will:
+    - set the operator State - See TOperatorState.
+    - set Patience value - represents operator patience while waiting
+      for response from user.
+      - For osNeedQso, Patience is set to a random value using a
+        Rayleigh distribution within the range of [1, 14] retries,
+        with a Mean value of 4.
+      - For all other states, Patience is set to 5.
+
+  This function is typically called by TDxOperator.MsgReceived() whenever
+  new TStationMessages are being sent to this DxStation/DxOperator by the
+  simulation engine.
+}
 procedure TDxOperator.SetState(AState: TOperatorState);
 begin
   State := AState;
+
+  {
+    Patience, set below, represents how long a station will stay around to
+    complete a QSO with the user. FULL_PATIENCE = 5. Patience is the number of
+    TimeOut events to occur before this station will disappear.
+    A TimeOut is typically in the range of 3-6 seconds (See GetReplyTimeout).
+  }
   if AState = osNeedQso
     then Patience := Round(RndRayleigh(4))
     else Patience := FULL_PATIENCE;

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -135,7 +135,7 @@ begin
           // during debug, use status bar to show CW stream
           if BDebugCwDecoder or BDebugGhosting then
             Mainform.sbar.Caption :=
-              (Format('[%s-Timeout]',[MyCall]) + '; ' +
+              (Format('[%s-osFailed], Stn deleted',[MyCall]) + '; ' +
               Mainform.sbar.Caption).Substring(0, 80);
           Free;
           Exit;
@@ -169,7 +169,7 @@ begin
               // during debug, use status bar to show CW stream
               if BDebugCwDecoder or BDebugGhosting then
                 Mainform.sbar.Caption :=
-                  (Format('[%s-Failed]',[MyCall]) + '; ' +
+                  (Format('[%s-osFailed, Stn deleted]',[MyCall]) + '; ' +
                   Mainform.sbar.Caption).Substring(0, 80);
               Free;
               Exit;

--- a/Station.pas
+++ b/Station.pas
@@ -20,6 +20,20 @@ type
     msgQrl, msgQrl2, msqQsy, msgAgn);
 
   TStationMessages = set of TStationMessage;
+
+  {
+    TStationState represents the operational states of a Station.
+
+    stListening
+        Station is waiting for Operator (the User) to send a message.
+    stCopying
+        Station is in this state while Operator's message is transmitted.
+    stPreparingToSend
+        Station is preparing a new message to be sent to the User.
+        After a brief delay time, this message is transmitted.
+    stSending
+        Station is sending it's message to the User.
+  }
   TStationState = (stListening, stCopying, stPreparingToSend, stSending);
   TStationEvent = (evTimeout, evMsgSent, evMeStarted, evMeFinished);
 
@@ -201,6 +215,7 @@ end;
 
 procedure TStation.SendMsg(AMsg: TStationMessage);
 begin
+  assert(State in [stPreparingToSend, stSending, stListening]);
   if Envelope = nil then Msg := [];
   if AMsg = msgNone then begin State := stListening; Exit; End;
   Include(Msg, AMsg);

--- a/Station.pas
+++ b/Station.pas
@@ -48,7 +48,10 @@ type
     procedure SetPitch(const Value: integer);
   protected
     SendPos: integer;
-    TimeOut: integer;
+    TimeOut: integer; // remaining Ticks until evTimeout occurs.
+                      // A Tick occurs whenever an audio block is requested.
+                      // TStation.Tick() calls ProcessEvent(evTimeout) whenever
+                      // Timeout decrements to zero.
     NrWithError: boolean;
     R1 : Single;    // holds a Random number; used in NrAsText
     procedure Init;


### PR DESCRIPTION
There are four commits in this fix. Please refer to my large comment in Issue #200 for full description of the fix, including state diagrams.

An engineering build of these changes are available [here](https://1drv.ms/u/c/353d3bde42947823/EZPYMf4gn4BLp-z6n0grDuoBRUjnro7PGXjgHh8oatOuAg?e=S7zqU2)

The checkin notes for the 4 commits are listed below...
```
1. Add comments to existing code, DxOperator, TOperatorState.

2. Fix caller ghosting after entering call and exchange info
    
    This is the first of three parts to fix the ghosting issue.
    Here, one of the root causes of caller ghosting is when the
    DxOperator.Patience value was not increased after receiving
    the last transmission from user. Thus, it would timeout sooner
    than expected. To fix this problem, the Patience value increased
    by calling TDxOperator.MorePatience. This is basically saying
    that when the DxOperator receives a transmission from the User,
    they will continue to work the QSO without loosing patience
    and giving up - thus the notion of "more patience" in introduced.
    
    This fixes issue #200. See Issue #200 for more information.

3. Fix ghosting by stations leaving the QSO early after calling them
    
    This is the second of three parts to fix the ghosting issue.
    This fix addresses the second root cause of caller ghosting
    where a Dx station would disappear almost immediately after
    being created. This would occur about 10% of the time. The user
    would enter and send the Dx station's callsign, only to discover
    that the station goes silent and does not return its exchange information.
    
    The root cause for this second problem was traced back to a call to the
    random function RndRayleigh(4). The result of this call is used to set
    the value of DxOperator.Patience. Patience represents operator patience,
    an expression of how patient the Dx operator will be while waiting for
    a responce from the user. RndRayleigh(4) will return a random integer
    value with a Mean of 4. The problem is, 11% of the time, this value
    could be 0 or 1. Given a value of 0 or 1, other logic will cause the
    DxStation would disappear almost immediately. This was fixed by replacing
    the RndRayleight(4) call with '2 + RndRayleigh(3)'. This change makes sure
    that a minimum value of 2 is returned. The new Mean is now 5 instead of 4.
    
    This fixes issue #200. See Issue #200 for more information.

4. Fix problem where ghosted calls are not added to log
    
    This is the third of three changes addressing the issue of
    caller ghosting. A ghosted call was originally handled as
    a failed QSO after the Dx Station timeout out due to User
    inactivity. Once failed, it was deleted from the simulation
    before the QSO was logged by the user. With this fix, DxStation
    will stop sending and remaining in the set of active stations.
    This allows the QSO to be logged as usual by the user.
    
    This fixes issue #200. See Issue #200 for more information.
```