### PR TITLE
314 nil when logging a partial callsign

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -502,7 +502,9 @@ begin
     for i:=Stations.Count-1 downto 0 do
       if Stations[i] is TDxStation then
         with Stations[i] as TDxStation do
-          if (Oper.State = osDone) and (QsoList <> nil) and (MyCall = QsoList[High(QsoList)].Call) then begin
+          if (Oper.State = osDone) and (QsoList <> nil) and
+            ((MyCall = QsoList[High(QsoList)].Call) or
+             (Oper.IsMyCall(QsoList[High(QsoList)].Call, False) = mcAlmost)) then begin
               // grab Qso's "True" data (e.g. TrueCall, TrueExch1, TrueExch2)
               DataToLastQso; // deletes this TDxStation from Stations[]
 

--- a/DxOper.pas
+++ b/DxOper.pas
@@ -95,6 +95,7 @@ type
 			// Patience is increased with calls to MorePatience.
     RepeatCnt: integer;
     State: TOperatorState;
+    constructor Create(const ACall: string; AState: TOperatorState);
     function IsGhosting: boolean;
     function GetSendDelay: integer;
     function GetReplyTimeout: integer;
@@ -113,6 +114,16 @@ uses
   SysUtils, Ini, Math, RndFunc, Contest, Log, Main;
 
 { TDxOperator }
+
+
+constructor TDxOperator.Create(const ACall: string; AState: TOperatorState);
+begin
+  Call := ACall;
+  Skills := 1 + Random(3); //1..3
+  Patience := 0;
+  RepeatCnt := 1;
+  SetState(AState);
+end;
 
 
 {

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -53,10 +53,7 @@ begin
   Operid := Tst.PickStation;
   MyCall := Tst.GetCall(Operid);
 
-  Oper := TDxOperator.Create;
-  Oper.Call := MyCall;
-  Oper.Skills := 1 + Random(3); //1..3
-  Oper.SetState(osNeedPrevEnd);
+  Oper := TDxOperator.Create(MyCall, osNeedPrevEnd);
   NrWithError := Ini.Lids and (Random < 0.1);
 
   // DX's speed, {WpmS,WpmC}, is set once at creation time

--- a/Log.pas
+++ b/Log.pas
@@ -760,7 +760,7 @@ begin
     for i:=Tst.Stations.Count-1 downto 0 do
       if Tst.Stations[i] is TDxStation then
         with Tst.Stations[i] as TDxStation do
-          if (MyCall = Qso.Call) then
+          if ((MyCall = Qso.Call) or (Oper.IsMyCall(Qso.Call, False) = mcAlmost)) then
           begin
             Qso.TrueWpm := WpmAsText();
             Break;
@@ -770,7 +770,8 @@ begin
     for i:=Tst.Stations.Count-1 downto 0 do
       if Tst.Stations[i] is TDxStation then
         with Tst.Stations[i] as TDxStation do
-          if (Oper.State = osDone) and (MyCall = Qso.Call) then
+          if (Oper.State = osDone) and
+             ((MyCall = Qso.Call) or (Oper.IsMyCall(Qso.Call, False) = mcAlmost)) then
             begin
               DataToLastQso; //grab "True" data and delete this dx station!
               Break;
@@ -995,12 +996,10 @@ begin
       else if Dupe and not Log.ShowCorrections then
         ExchError := leDUP
       else
-      begin
         ExchError := leNONE;
 
-        // find exchange errors for the current Qso
-        Tst.FindQsoErrors(QsoList[High(QsoList)], Corrections);
-      end;
+      // find exchange errors for the current Qso
+      Tst.FindQsoErrors(QsoList[High(QsoList)], Corrections);
 
       CallColumnColor := clBlack;
       Exch1ColumnColor := clBlack;


### PR DESCRIPTION
After entering a partial callsign and exchange information, the user will hit `Enter` to finish the QSO and log the QSO. The QSO is not logged.

This was caused by the logging module only comparing for a perfect match against the caller callsign and not considering the common occurrence of a partially-correct callsign. Code was changed to allow a partially-correct callsign. This allows these QSO to be included in the log as expected.

Checkin notes:
```
Improve handling of partial callsign matches

- Report both callsign and exchange errors in QSO log.
- Add argument to IsMyCall to enable random result for lids.
```

Issue #315 will add improved messages for the partially-correct callsign case. This next review will be posted soon.

Once the second pull request/review is submitted, I will post an engineering build for testing. Stay tuned...