### PR TITLE
Improve QSO exchanges for partially correct callsigns

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -335,6 +335,8 @@ begin
     msgDeMyCall2: SendText(AStn, 'DE <my> <my>');
     msgDeMyCallNr1: SendText(AStn, 'DE <my> <#>');
     msgDeMyCallNr2: SendText(AStn, 'DE <my> <my> <#>');
+    msgMyCall2: SendText(AStn, '<my> <my>');
+    msgMyCallNr1: SendText(AStn, '<my> <#>');
     msgMyCallNr2: SendText(AStn, '<my> <my> <#>');
     msgNrQm: SendText(AStn, 'NR?');
     msgLongCQ: SendText(AStn, 'CQ CQ TEST <my> <my> TEST');  // QrmStation only

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -213,12 +213,13 @@ procedure TDxStation.SendMsg(AMsg: TStationMessage);
 begin
   inherited SendMsg(AMsg);
 
-  if BDebugExchSettings and (Mainform.Edit2.Text = '') and
-    (AMsg in [msgNR, msgR_NR, msgR_NR2,
-    msgDeMyCallNr1, msgDeMyCallNr2, msgMyCallNr2]) then
+  if BDebugExchSettings and (AMsg in [msgNR, msgR_NR, msgR_NR2,
+    msgDeMyCallNr1, msgDeMyCallNr2, msgMyCallNr1, msgMyCallNr2]) then
   begin
-    Mainform.Edit2.Text := Exch1;
-    if (SimContest <> scNaQp) or (Exch2 <> 'DX') then
+    if (Mainform.Edit2.Text = '') then
+      Mainform.Edit2.Text := Exch1;
+    if (Mainform.Edit3.Text = '') and
+      ((SimContest <> scNaQp) or (Exch2 <> 'DX')) then
       MainForm.Edit3.Text := Exch2;
   end;
 end;

--- a/Log.pas
+++ b/Log.pas
@@ -108,7 +108,7 @@ var
   RawPoints:        integer;   // accumalated raw QSO points total
   VerifiedPoints:   integer;   // accumulated verified QSO points total
   CallSent: boolean; // msgHisCall has been sent; cleared upon edit.
-  NrSent: boolean;   // msgNR has been sent. Seems to imply exchange sent.
+  NrSent: boolean;   // msgNR has been sent; cleared after qso is completed.
   ShowCorrections: boolean;    // show exchange correction column.
   Histo: THisto;
   LogColWidths : Array[0..6] of integer;  // retain original Log column widths

--- a/Main.pas
+++ b/Main.pas
@@ -1649,9 +1649,9 @@ end;
 
 
 {
-  called whenever callsign field (Edit1) changes. Any callsign edit will
+  Called whenever callsign field (Edit1) changes. Any callsign edit will
   invalidate the callsign already sent by clearing the CallSent value.
-  If the Callsign is empty, also crear the NrSent value.
+  If the Callsign is empty, also clear the NrSent value.
 }
 procedure TMainForm.Edit1Change(Sender: TObject);
 begin

--- a/Station.pas
+++ b/Station.pas
@@ -16,8 +16,8 @@ const
 type
   TStationMessage =  (msgNone, msgCQ, msgNR, msgTU, msgMyCall, msgHisCall,
     msgB4, msgQm, msgNil, msgGarbage, msgR_NR, msgR_NR2, msgDeMyCall1, msgDeMyCall2,
-    msgDeMyCallNr1, msgDeMyCallNr2, msgNrQm, msgLongCQ, msgMyCallNr2,
-    msgQrl, msgQrl2, msqQsy, msgAgn);
+    msgDeMyCallNr1, msgDeMyCallNr2, msgMyCallNr1, msgMyCallNr2, msgMyCall2,
+    msgNrQm, msgLongCQ, msgQrl, msgQrl2, msqQsy, msgAgn);
 
   TStationMessages = set of TStationMessage;
 


### PR DESCRIPTION
When running a simulation, sometimes a callsign is copied incorrectly and entered into the Callsign exchange entry field. After hitting Enter, the partial callsign is sent. The calling station will respond with a corrected callsign and optionally the exchange information.

There are two scenarios.

### 1 - User sends partial call only (using F5 function key)

This condition can easily be created by following these steps:
1. start a simulation in Single Call mode.
2. Enter the calling callsign, but change the last letter.
3. Hit `F5` to send the partial callsign.
4. This will now enter the `osNeedCallNr` state.
5. The calling station will send a response with the corrected callsign and optional exchange.

#### State `osNeedCallNr`
The following messages are sent after receiving a partially-correct callsign from the user without an exchange.
The first column shows the original messages and the second column shows the revised messages.

Original            | Freq      | Revised (v1.85)       | Freq
--------------------|-----------|-----------------------|-----
`DE <call>`         | 50%       | `DE <call>`           | 16.7% (1/6)
`DE <call> <call>`  | 50%       | `DE <call> <call>`    | 16.7% (1/6)
 .                   |.           | `<call> <call>`       | 16.7% (1/6)
 .                   |.           | `<call> <call> <exch>`| 16.7% (1/6)
 .                   |.           | `<call> <exch>`       | 33.3%   (1/3)

The following is the new code showing the responses for this case (`osNeedCallNr`).
```
    // osNeedCallNr - They have sent an almost-correct callsign.
     osNeedCallNr:
      if (RunMode = rmHst) then
        Result := msgDeMyCall1
      else
        case Trunc(R2*6) of
          0: Result := msgDeMyCall1;    // DE <my>
          1: Result := msgDeMyCall2;    // DE <my> <my>
          2: Result := msgMyCall2;      // <my> <my>
          3: Result := msgMyCallNr2;    // <my> <my> <exch>
          4,5: Result := msgMyCallNr1;  // <my> <exch>
        end;
```

### 2 - User sends partial call and their exchange (using Enter key)

This condition can easily be created by following these steps:
1. start a simulation in Single Call mode.
2. Enter the calling callsign, but change the last letter.
3. Hit `Enter` to send the partial callsign and exchange
4. This will now enter the `osNeedCall` state.
5. The calling station will send a response with the corrected callsign and exchange.

#### State `osNeedCall`
The following messages are sent after receiving a partially-correct callsign and exchange information from the user.
The first column shows the original messages and the second column shows the revised messages.
Notice the revised messages are now always sending the exchange. I suppose I should leave out the exchange on one of these.

Original                   | Freq      | Revised (v1.85)           | Freq
---------------------------|-----------|---------------------------|-----
`DE <call> <exch>`         | 50%       | `DE <call> <exch>`        | 16.7% (1/6)
`DE <call> <call> <exch>`  | 25%       | `DE <call> <call> <exch>` | 16.7% (1/6)
`<call> <call> <exch>`     | 25%       | `<call> <call> <exch>`    | 33.3% (1/3)
.                           |.           | `<call> <exch>`           | 33.3% (1/3)

The following is the new code showing the responses for this case (`osNeedCall`).
```
    // osNeedCall - I have their Exch (NR), but need user to correct my call.
    osNeedCall:
      if (RunMode = rmHst) then
        Result := msgDeMyCallNr1
      else
        case Trunc(R2*6) of
          0: Result := msgDeMyCallNr1;  // DE <my> <exch>
          1: Result := msgDeMyCallNr2;  // DE <my> <my> <exch>
          2,3: Result := msgMyCallNr2;  // <my> <my> <exch>
          4,5: Result := msgMyCallNr1;  // <my> <exch>
        end;
```
