### PR TITLE
Fix #320 - QRM Station now has 2 to 6 second timeout delay

### DIFF
--- a/QrmStn.pas
+++ b/QrmStn.pas
@@ -58,7 +58,7 @@ begin
       Dec(Patience);
       if Patience = 0
         then Free
-        else Timeout := Round(RndGaussLim(SecondsToBlocks(4), 2));
+        else Timeout := Round(RndGaussLim(SecondsToBlocks(4), SecondsToBlocks(2)));
       end;
     evTimeout:
       SendMsg(msgLongCQ);


### PR DESCRIPTION
- Previous code was creating QRM stations with ~0.1 second timeout.
- This timeout is the time between transmissions.
- timeout delay is now 2 to 6 seconds using a limited gaussian distribution