### PR TITLE
Fix #319 - internal gaussian limit distribution was clipping

### DIFF
--- a/QrmStn.pas
+++ b/QrmStn.pas
@@ -58,7 +58,7 @@ begin
       Dec(Patience);
       if Patience = 0
         then Free
-        else Timeout := Round(RndGaussLim(SecondsToBlocks(4), 2));
+        else Timeout := Round(RndGaussLim(SecondsToBlocks(4), SecondsToBlocks(2)));
       end;
     evTimeout:
       SendMsg(msgLongCQ);

--- a/RndFunc.pas
+++ b/RndFunc.pas
@@ -35,10 +35,20 @@ begin
 end;
 
 
+{
+  Compute a limited gaussian distribution by eliminating values outside
+  of the specified limits. The original implememtation used a clipping
+  algorithm which resulted in a non-gaussian distribution of the returned
+  values.
+}
 function RndGaussLim(AMean, ALim: Single): Single;
 begin
-  Result := AMean + RndNormal * 0.5 * ALim;
-  Result := Max(AMean-ALim, Min(AMean+ALim, Result));
+  //Result := AMean + RndNormal * 0.5 * ALim;
+  //Result := Max(AMean-ALim, Min(AMean+ALim, Result));
+  repeat
+    Result := RndNormal * 0.5 * ALim;
+  until Abs(Result) <= ALim;
+  Result := AMean + Result;
 end;
 
 


### PR DESCRIPTION
- The internal RndGaussLim() function was clipping values outside of the specified limits. This resulted in a non-gaussian distribution.
- The fix is now discarding any over-limit values.