### PR TITLE
Refactor - move Exchange definitions/tables (#332)

### DIFF
--- a/ArrlDx.pas
+++ b/ArrlDx.pas
@@ -52,6 +52,7 @@ implementation
 
 uses
   SysUtils, ARRL, CallLst,
+  ExchFields,
   Ini, Main;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -85,6 +85,7 @@ implementation
 
 uses
   SysUtils, RndFunc, Math, DxOper,
+  ExchFields,
   Main, CallLst, ARRL;
 
 { TContest }

--- a/DualExchContest.pas
+++ b/DualExchContest.pas
@@ -8,6 +8,7 @@ unit DualExchContest;
 interface
 
 uses
+  ExchFields,
   Contest, Station, Ini;
 
 type

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -38,6 +38,7 @@ implementation
 uses
   SysUtils, Classes, RndFunc, Dialogs,
   Main,     // for Mainform
+  ExchFields, // for TExchField
   CallLst, Log, Ini, Contest;
 
 { TDxStation }

--- a/ExchFields.pas
+++ b/ExchFields.pas
@@ -1,0 +1,70 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
+unit ExchFields;
+
+interface
+
+uses
+  Classes
+  ;
+
+type
+  // Exchange Field #1 types
+  TExchange1Type = (etRST, etOpName, etFdClass);
+
+  // Exchange Field #2 Types
+  TExchange2Type = (etSerialNr, etGenericField, etArrlSection, etStateProv,
+                    etCqZone, etItuZone, etAge, etPower, etJaPref, etJaCity,
+                    etNaQpExch2, etNaQpNonNaExch2);
+
+  {
+    Defines the characteristics and behaviors of an exchange field.
+    Used to declare various exchange field behaviors. Field Definitions
+    are indexed by a contest definition (e.g. ARRL FD uses etFdClass and
+    etStateProv). As new contests are added, new field definition
+    may be required. When adding a new exchange field definition,
+    search for existing code usages to find areas that will require changes.
+  }
+  TFieldDefinition = record
+    C: PChar;     // Caption
+    R: PChar;     // Regular Expression
+    L: smallint;  // MaxLength
+    T: smallint;  // Type
+  end;
+
+  PFieldDefinition = ^TFieldDefinition;
+
+const
+  // Adding a contest: define contest-specific field types
+  // Exchange Field 1 settings/rules
+  Exchange1Settings: array[TExchange1Type] of TFieldDefinition = (
+    (C: 'RST';   R: '[1-5E][1-9N][1-9N]';     L: 3;   T:Ord(etRST))
+   ,(C: 'Name';  R: '[A-Z][A-Z]*';            L: 10;  T:Ord(etOpName))
+   ,(C: 'Class'; R: '[1-9][0-9]*[A-F]';       L: 3;   T:Ord(etFdClass))
+  );
+
+  // Exchange Field 2 settings/rules
+  Exchange2Settings: array[TExchange2Type] of TFieldDefinition = (
+    (C: 'Nr.';        R: '([0-9OTN]+)|(#)';                L: 4;  T:Ord(etSerialNr)),
+    (C: 'Exch';       R: '[0-9A-Z]*';                      L: 12; T:Ord(etGenericField)),
+    (C: 'Section';    R: '([A-Z][A-Z])|([A-Z][A-Z][A-Z])'; L: 3;  T:Ord(etArrlSection)),
+    (C: 'State/Prov'; R: '[ABCDFGHIKLMNOPQRSTUVWY][ABCDEFHIJKLMNORSTUVXYZ]';
+                                                           L: 6;  T:Ord(etStateProv)),
+    (C: 'CQ-Zone';    R: '[0-9]*';                         L: 2;  T:Ord(etCqZone)),
+    (C: 'Zone';       R: '[0-9]*';                         L: 4;  T:Ord(etItuZone)),
+    (C: 'Age';        R: '[0-9][0-9]';                     L: 2;  T:Ord(etAge)),
+    (C: 'Power';      R: '([0-9]*)|(K)|(KW)|([0-9A]*[OTN]*)'; L: 4; T:Ord(etPower)),
+    (C: 'Number';     R: '([0-9AOTN]*)([LMHP])';           L: 4; T:Ord(etJaPref)),
+    (C: 'Number';     R: '([0-9AOTN]*)([LMHP])';           L: 7; T:Ord(etJaCity))
+    // NAQP Contest: NA Stations send name and (state/prov/dxcc);
+    //           Non-NA stations send name only
+   ,(C: 'State';      R: '([0-9A-Z/]*)';                   L: 6; T:Ord(etNaQpExch2))
+   ,(C: 'State';      R: '()|([0-9A-Z/]*)';                L: 6; T:Ord(etNaQpNonNaExch2))
+  );
+
+implementation
+
+end.

--- a/Ini.pas
+++ b/Ini.pas
@@ -8,6 +8,7 @@ unit Ini;
 interface
 
 uses
+  ExchFields,
   IniFiles;
 
 const
@@ -28,14 +29,6 @@ type
   TSimContest = (scWpx, scCwt, scFieldDay, scNaQp, scHst, scCQWW, scArrlDx,
                  scSst, scAllJa, scAcag, scIaruHf);
   TRunMode = (rmStop, rmPileup, rmSingle, rmWpx, rmHst);
-
-  // Exchange Field #1 types
-  TExchange1Type = (etRST, etOpName, etFdClass);
-
-  // Exchange Field #2 Types
-  TExchange2Type = (etSerialNr, etGenericField, etArrlSection, etStateProv,
-                    etCqZone, etItuZone, etAge, etPower, etJaPref, etJaCity,
-                    etNaQpExch2, etNaQpNonNaExch2);
 
   // Serial NR types
   TSerialNRTypes = (snStartContest, snMidContest, snEndContest, snCustomRange);

--- a/Log.pas
+++ b/Log.pas
@@ -134,6 +134,7 @@ implementation
 uses
   Windows, SysUtils, RndFunc, Math,
   Graphics,     // for TColor
+  ExchFields,   // for exchange field types
   StdCtrls, PerlRegEx, StrUtils,
   Contest, Main, DxStn, DxOper, Ini, Station, MorseKey;
 

--- a/Main.pas
+++ b/Main.pas
@@ -17,58 +17,12 @@ uses
   VolmSldr, VolumCtl, StdCtrls, Station, Menus, ExtCtrls,
   ComCtrls, Spin, SndTypes,
   WavFile,
+  ExchFields,   // for TFieldDefinition
   System.ImageList, Vcl.ToolWin, Vcl.ImgList;
 
 const
   WM_TBDOWN = WM_USER+1;
   sVersion: String = '1.84';  { Sets version strings in UI panel. }
-
-type
-
-  {
-    Defines the characteristics and behaviors of an exchange field.
-    Used to declare various exchange field behaviors. Field Definitions
-    are indexed by a contest definition (e.g. ARRL FD uses etFdClass and
-    etStateProv). As new contests are added, new field definition
-    may be required. When adding a new exchange field definition,
-    search for existing code usages to find areas that will require changes.
-  }
-  TFieldDefinition = record
-    C: PChar;     // Caption
-    R: PChar;     // Regular Expression
-    L: smallint;  // MaxLength
-    T: smallint;  // Type
-  end;
-
-  PFieldDefinition = ^TFieldDefinition;
-
-const
-  // Adding a contest: define contest-specific field types
-  // Exchange Field 1 settings/rules
-  Exchange1Settings: array[TExchange1Type] of TFieldDefinition = (
-    (C: 'RST';   R: '[1-5E][1-9N][1-9N]'; L: 3;  T:Ord(etRST)),
-    (C: 'Name';  R: '[A-Z][A-Z]*';      L: 10; T:Ord(etOpName)),
-    (C: 'Class'; R: '[1-9][0-9]*[A-F]'; L: 3;  T:Ord(etFdClass))
-  );
-
-  // Exchange Field 2 settings/rules
-  Exchange2Settings: array[TExchange2Type] of TFieldDefinition = (
-    (C: 'Nr.';        R: '([0-9OTN]+)|(#)';                L: 4;  T:Ord(etSerialNr)),
-    (C: 'Exch';       R: '[0-9A-Z]*';                      L: 12; T:Ord(etGenericField)),
-    (C: 'Section';    R: '([A-Z][A-Z])|([A-Z][A-Z][A-Z])'; L: 3;  T:Ord(etArrlSection)),
-    (C: 'State/Prov'; R: '[ABCDFGHIKLMNOPQRSTUVWY][ABCDEFHIJKLMNORSTUVXYZ]';
-                                                           L: 6;  T:Ord(etStateProv)),
-    (C: 'CQ-Zone';    R: '[0-9]*';                         L: 2;  T:Ord(etCqZone)),
-    (C: 'Zone';       R: '[0-9]*';                         L: 4;  T:Ord(etItuZone)),
-    (C: 'Age';        R: '[0-9][0-9]';                     L: 2;  T:Ord(etAge)),
-    (C: 'Power';      R: '([0-9]*)|(K)|(KW)|([0-9A]*[OTN]*)'; L: 4; T:Ord(etPower)),
-    (C: 'Number';     R: '([0-9AOTN]*)([LMHP])';           L: 4; T:Ord(etJaPref)),
-    (C: 'Number';     R: '([0-9AOTN]*)([LMHP])';           L: 7; T:Ord(etJaCity))
-    // NAQP Contest: NA Stations send name and (state/prov/dxcc);
-    //           Non-NA stations send name only
-   ,(C: 'State';      R: '([0-9A-Z/]*)';                   L: 6; T:Ord(etNaQpExch2))
-   ,(C: 'State';      R: '()|([0-9A-Z/]*)';                L: 6; T:Ord(etNaQpNonNaExch2))
-  );
 
 type
 

--- a/MorseRunner.dpr
+++ b/MorseRunner.dpr
@@ -46,6 +46,7 @@ uses
   ALLJA in 'ALLJA.pas',
   ACAG in 'ACAG.pas',
   IaruHf in 'IaruHf.pas',
+  ExchFields in 'ExchFields.pas',
   SerNRGen in 'SerNRGen.pas';
 
 {$R *.RES}

--- a/MorseRunner.dproj
+++ b/MorseRunner.dproj
@@ -164,6 +164,7 @@
         <DCCReference Include="ALLJA.pas"/>
         <DCCReference Include="ACAG.pas"/>
         <DCCReference Include="IaruHf.pas"/>
+        <DCCReference Include="ExchFields.pas"/>
         <DCCReference Include="SerNRGen.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/MyStn.pas
+++ b/MyStn.pas
@@ -33,6 +33,7 @@ type
 implementation
 
 uses
+  ExchFields,
   SysUtils, RndFunc, Ini, MorseKey, Contest, Main, ARRL;
 
 { TMyStation }

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -52,6 +52,7 @@ implementation
 
 uses
   SysUtils, Classes, Contnrs, PerlRegEx,
+  ExchFields,
   Ini, ARRL, Contest;
 
 function TNcjNaQp.LoadCallHistory(const AUserCallsign : string) : boolean;

--- a/QrnStn.pas
+++ b/QrnStn.pas
@@ -20,7 +20,9 @@ type
 implementation
 
 uses
-  Ini, RndFunc, Math;
+  Ini, RndFunc,
+  ExchFields,
+  Math;
 
 constructor TQrnStation.CreateStation;
 var

--- a/Station.pas
+++ b/Station.pas
@@ -8,7 +8,9 @@ unit Station;
 interface
 
 uses
-  Classes, SndTypes, Ini;
+  Classes, SndTypes,
+  ExchFields,
+  Ini;
 
 const
   NEVER = MAXINT;


### PR DESCRIPTION
- move Exchange definitions and tables to a new file, ExchFields.pas
- Code was simply moved to new file, ExchFields.pas. No functional changes.