### PR TITLE
341 improve exchange error reporting

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -465,8 +465,12 @@ end;
 
 {
   ValidateEnteredExchange is called prior to sending the final 'TU' and calling
-  SaveQSO (see Log.pas). This virtual function can be overriden for complex
-  exchange information (e.g. ARRL Sweepstakes).
+  SaveQSO (see Log.pas). The basic validation is a length test where each
+  exchange is checked against a minimum length requirement.
+  This is contest with original 1.68 behaviors.
+
+  This virtual function can be overriden for complex exchange information
+  (e.g. ARRL Sweepstakes).
 }
 function TContest.ValidateEnteredExchange(const ACall, AExch1, AExch2: string;
   out AExchError: String) : boolean;

--- a/Log.pas
+++ b/Log.pas
@@ -397,9 +397,8 @@ begin
     s:= StringReplace(s, '&', '&&', [rfReplaceAll]);
   end;
 
-  Mainform.sbar.Font.Color := clDefault;
-
   // during debug, use status bar to show CW stream
+  Mainform.sbar.Font.Color := clDefault;
   if not s.IsEmpty and (BDebugCwDecoder or BDebugGhosting) then
     Mainform.sbar.Caption:= LeftStr(Mainform.sbar.Caption, 40) + ' -- ' + s
   else
@@ -741,8 +740,8 @@ begin
     begin
     Call := StringReplace(Edit1.Text, '?', '', [rfReplaceAll]);
 
-    // Virtual functions used here to allow allow special processing for some
-    // contests (e.g. ARRL Sweepstakes).
+    // Virtual functions used below allow special processing as needed
+    // for some contests (e.g. ARRL Sweepstakes).
     if not Tst.CheckEnteredCallLength(Call, ExchError) or
       not Tst.ValidateEnteredExchange(Call, Edit2.Text, Edit3.Text, ExchError) then
       begin


### PR DESCRIPTION
Improve exchange error reporting #341
- Add TContest.CheckEnteredCallLength virtual function
- Add TContest.ValidateEnteredExchange virtual function
- return ExchError via ValidateEnteredExchange
- report Exchange error after hitting Enter
- callsigns must contain 3 or more characters.

See example output in Issue #341.