### PR TITLE
CQWW - allow user to send cut numbers in sent exchange

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -547,7 +547,7 @@ begin
       etGenericField:Qso.Exch2 := AExch2;
       etArrlSection: Qso.Exch2 := AExch2;
       etStateProv:   Qso.Exch2 := AExch2;
-      etCqZone:      Qso.NR := StrToInt(AExch2);
+      etCqZone:      Qso.Exch2 := AExch2;
       etItuZone:     Qso.Exch2 := AExch2;
       //etAge:
       etPower:       Qso.Exch2 := AExch2;

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -291,6 +291,10 @@ end;
 function TCqWw.getExch2(id:integer): string;    // returns section info (e.g. 3)
 begin
   result := CqWwCallList.Items[id].CQZone;
+
+  // insert an occasional leading zero for Zones [1-8]
+  if (result.ToInteger < 9) and (Random < 0.05) then
+    Result.Insert(0, '0');
 end;
 
 

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -251,7 +251,7 @@ begin
     case SentExchTypes.Exch2 of
       etSerialNr: TrueExch2 := IntToStr(Self.NR);
       etGenericField: TrueExch2 := Self.Exch2;
-      etCqZone: TrueExch2 := IntToStr(Self.NR);
+      etCqZone: TrueExch2 := Self.Exch2;
       etItuZone: TrueExch2 := Self.Exch2;
       etArrlSection: TrueExch2 := Self.Exch2;
       etStateProv: TrueExch2 := Self.Exch2;

--- a/ExchFields.pas
+++ b/ExchFields.pas
@@ -55,7 +55,7 @@ const
     (C: 'Section';    R: '([A-Z][A-Z])|([A-Z][A-Z][A-Z])'; L: 3;  T:Ord(etArrlSection)),
     (C: 'State/Prov'; R: '[ABCDFGHIKLMNOPQRSTUVWY][ABCDEFHIJKLMNORSTUVXYZ]';
                                                            L: 6;  T:Ord(etStateProv)),
-    (C: 'CQ-Zone';    R: '[0-9]*';                         L: 2;  T:Ord(etCqZone)),
+    (C: 'CQ-Zone';    R: '[0-9OANT]+';                     L: 2;  T:Ord(etCqZone)),
     (C: 'Zone';       R: '[0-9]*';                         L: 4;  T:Ord(etItuZone)),
     (C: 'Age';        R: '[0-9][0-9]';                     L: 2;  T:Ord(etAge)),
     (C: 'Power';      R: '([0-9]*)|(K)|(KW)|([0-9A]*[OTN]*)'; L: 4; T:Ord(etPower)),

--- a/Main.pas
+++ b/Main.pas
@@ -603,7 +603,7 @@ end;
 procedure TMainForm.Edit3KeyPress(Sender: TObject; var Key: Char);
 begin
   case RecvExchTypes.Exch2 of
-    etSerialNr, etCqZone, etItuZone, etAge:
+    etSerialNr, etItuZone, etAge:
       begin
         if RunMode <> rmHst then
           case Key of
@@ -612,6 +612,19 @@ begin
             't', 'T': Key := '0';
           end;
         // valid Zone or NR field characters...
+        if not CharInSet(Key, ['0'..'9', #8]) then
+          Key := #0;
+      end;
+    etCqZone:
+      begin
+        if RunMode <> rmHst then
+          case Key of
+            'a', 'A': Key := '1';
+            'n', 'N': Key := '9';
+            'o', 'O': Key := '0';
+            't', 'T': Key := '0';
+          end;
+        // valid CQ-Zone field characters...
         if not CharInSet(Key, ['0'..'9', #8]) then
           Key := #0;
       end;
@@ -1451,8 +1464,8 @@ begin
     etCqZone:
       begin
         Ini.UserExchange2[SimContest] := Avalue;
-        Tst.Me.Nr := StrToInt(Avalue);
-        if BDebugExchSettings then Edit3.Text := IntToStr(Tst.Me.Nr);  // testing only
+        Tst.Me.Exch2 := Avalue;
+        if BDebugExchSettings then Edit3.Text := Avalue;  // testing only
       end;
     etItuZone:
       begin

--- a/Station.pas
+++ b/Station.pas
@@ -364,7 +364,7 @@ begin
   // Adding a contest: TStation.NrAsText(), converts <#> to exchange (usually '<exch1> <exch2>'). Inject LID errors.
   case SimContest of
     scCQWW:
-      Result := Format('%s %d', [Exch1, NR]);     // <RST> <CQ-Zone>
+      Result := Format('%s %s', [Exch1, Exch2]);  // <RST> <CQ-Zone>
     scCwt:
       Result := Format('%s  %s', [Exch1, Exch2]); // <Name> <NR|State|Prov|Prefix>
     scSst:
@@ -448,14 +448,27 @@ begin
     if not IsDxStation then begin
       Result := StringReplace(Result, '0', 'T', [rfReplaceAll]);
       Result := StringReplace(Result, '9', 'N', [rfReplaceAll]);
+      if SentExchTypes.Exch2 = etCqZone then
+        Result := StringReplace(Result, '1', 'A', [rfReplaceAll]);
     end
-    else if Random < 0.4
+    else if (Random < 0.4) and (SentExchTypes.Exch2 <> etCqZone)
       then Result := StringReplace(Result, '0', 'O', [rfReplaceAll])
-    else if Random < 0.97
+    else if (Random < 0.97) and (SentExchTypes.Exch2 <> etCqZone)
       then Result := StringReplace(Result, '0', 'T', [rfReplaceAll]);
 
-    if Random < 0.97
-      then Result := StringReplace(Result, '9', 'N', [rfReplaceAll]);
+    // this function needs to be refactored so it can operate individual
+    // parts of the exchange.
+    if (SentExchTypes.Exch2 = etCqZone) then
+      begin
+        if R1 < 0.70 then
+          begin
+            Result := StringReplace(Result, '0', 'T', [rfReplaceAll]);
+            Result := StringReplace(Result, '1', 'A', [rfReplaceAll]);
+            Result := StringReplace(Result, '9', 'N', [rfReplaceAll]);
+          end;
+      end
+    else if Random < 0.97 then
+      Result := StringReplace(Result, '9', 'N', [rfReplaceAll]);
     end;
 
   // for JARL ALLJA, ACAG contest


### PR DESCRIPTION
- for CQWW Contest, user can now enter '5NN A4' in the sent exchange. (previously 'A4' was reported as an error)
- calling stations will apply cut-numbers to CQ-Zone about 70% of the time
- insert occasional leading zero (5% of the time)
- RST column is left justified
- Resolves Issue #331

Internal
- use TStation.Exch2 instead of TStation.NR to hold CQ-Zone. Allows ability to store user-entered sent exchange with cut numbers. Moves the code one step closer to using Exch2 exclusively.