### PR TITLE
ARRL SS - display missing or invalid exchange when incomplete exchange

### DIFF
--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -276,6 +276,9 @@ begin
   Qso.Check := StrToIntDef(ExchValidator.Check, 0);
   Qso.Sect := ExchValidator.Section;
 
+  if Qso.Prec.IsEmpty then Qso.Prec := '?';
+  if Qso.Sect.IsEmpty then Qso.Sect := '?';
+
   if not ExchValidator.Call.IsEmpty then
     Qso.Call := ExchValidator.Call;
 

--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -50,6 +50,8 @@ public
 
   function FindCallRec(out ssrec: TSweepstakesCallRec; const ACall: string): Boolean;
   procedure SendMsg(const AStn: TStation; const AMsg: TStationMessage); override;
+  function CheckEnteredCallLength(const ACall: string;
+    out AExchError: String) : boolean; override;
   function ValidateEnteredExchange(const ACall, AExch1, AExch2: string;
     out AExchError: String) : boolean; override;
   procedure SaveEnteredExchToQso(var Qso: TQso; const AExch1, AExch2: string); override;
@@ -251,6 +253,17 @@ begin
     else
       inherited SendMsg(AStn, AMsg);
   end;
+end;
+
+
+function TSweepstakes.CheckEnteredCallLength(const ACall: string;
+  out AExchError: String) : boolean;
+begin
+  AExchError := '';
+  if ExchValidator.Call.IsEmpty then
+    Result := inherited CheckEnteredCallLength(ACall, AExchError)
+  else
+    Result := True;
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -72,6 +72,11 @@ type
       const AStationCallsign : string) : TExchTypes; virtual;
     procedure SendMsg(const AStn: TStation; const AMsg: TStationMessage); virtual;
     procedure SendText(const AStn: TStation; const AMsg: string); virtual;
+    procedure OnWipeBoxes; virtual;
+    function OnExchangeEdit(const ACall, AExch1, AExch2: string;
+       out AExchSummary: string) : Boolean; virtual;
+    procedure OnExchangeEditComplete; virtual;
+    procedure SetHisCall(const ACall: string); virtual;
 
     function CheckEnteredCallLength(const ACall: string;
       out AExchError: String) : boolean; virtual;
@@ -429,6 +434,54 @@ end;
 procedure TContest.SendText(const AStn: TStation; const AMsg: string);
 begin
   AStn.SendText(AMsg);  // virtual
+end;
+
+
+{
+  Called at end of each QSO or by user's Cntl-W (Wipe Boxes) keystroke.
+}
+procedure TContest.OnWipeBoxes;
+begin
+  Log.CallSent := False;
+  Log.NrSent := False;
+end;
+
+
+{
+  Called after each keystroke of the Exch2 field (Edit3).
+}
+function TContest.OnExchangeEdit(const ACall, AExch1, AExch2: string;
+  out AExchSummary: string) : Boolean;
+begin
+  AExchSummary := '';
+  Result := False;
+end;
+
+
+{
+  Called at the start of each action/command after user has finished typing
+  in the Exchange fields. Can be overriden as needed for complex exchange
+  behaviors (e.g. ARRL SS).
+}
+procedure TContest.OnExchangeEditComplete;
+begin
+  Log.CallSent := (Mainform.Edit1.Text <> '') and
+    (Mainform.Edit1.Text = Self.Me.HisCall);
+end;
+
+
+{
+  SetHisCall will:
+  - sets TContest.Me.HisCall to the supplied callsign, ACall.
+  - sets Log.CallSent to False if the callsign should be sent.
+
+  Override as needed to provide more complex callsign behaviors (e.g. ARRL
+  Sweepstakes allows callsign corrections in the exchange).
+}
+procedure TContest.SetHisCall(const ACall: string);
+begin
+  Self.Me.HisCall := ACall;
+  Log.CallSent := ACall <> '';
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -457,7 +457,7 @@ end;
 function TContest.CheckEnteredCallLength(const ACall: string;
   out AExchError: String) : boolean;
 begin
-  Result := ACall.Length >= 3;
+  Result := StringReplace(ACall, '?', '', [rfReplaceAll]).Length >= 3;
   if not Result then
     AExchError := 'Invalid callsign';
 end;
@@ -467,7 +467,7 @@ end;
   ValidateEnteredExchange is called prior to sending the final 'TU' and calling
   SaveQSO (see Log.pas). The basic validation is a length test where each
   exchange is checked against a minimum length requirement.
-  This is contest with original 1.68 behaviors.
+  This is consistent with original 1.68 behaviors.
 
   This virtual function can be overriden for complex exchange information
   (e.g. ARRL Sweepstakes).
@@ -525,7 +525,7 @@ end;
 
 {
   SaveEnteredExchToQso will save contest-specific exchange values into a QSO.
-  This is called to enter the completed QSO into the log.
+  This is called by SaveQSO while saving the completed QSO into the log.
   This virtual function can be overriden by specialized contests as needed
   (see ARRL Sweepstakes).
 }

--- a/Contest.pas
+++ b/Contest.pas
@@ -562,6 +562,9 @@ begin
       else
         assert(false, 'missing case');
     end;
+
+  if Qso.Exch1.IsEmpty then Qso.Exch1 := '?';
+  if Qso.Exch2.IsEmpty then Qso.Exch2 := '?';
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -534,7 +534,7 @@ begin
     // Adding a contest: save contest-specific exchange values into QsoList
     //save Exchange 1 (Edit2)
     case Mainform.RecvExchTypes.Exch1 of
-      etRST:     Qso.Rst := StrToInt(AExch1);
+      etRST:     Qso.Rst := StrToIntDef(AExch1, 0);
       etOpName:  Qso.Exch1 := AExch1;
       etFdClass: Qso.Exch1 := AExch1;
       else
@@ -543,7 +543,7 @@ begin
 
     //save Exchange2 (Edit3)
     case Mainform.RecvExchTypes.Exch2 of
-      etSerialNr:    Qso.Nr := StrToInt(AExch2);
+      etSerialNr:    Qso.Nr := StrToIntDef(AExch2, 0);
       etGenericField:Qso.Exch2 := AExch2;
       etArrlSection: Qso.Exch2 := AExch2;
       etStateProv:   Qso.Exch2 := AExch2;

--- a/Log.pas
+++ b/Log.pas
@@ -759,7 +759,7 @@ end;
 {
   Save QSO data into the Log.
 
-  Called by either:
+  Called after user presses:
   - 'Enter' key (after sending 'TU' to caller).
   - 'Shift-Enter', 'Cntl-Enter' or 'Alt-Enter' (without sending 'TU' to caller).
 }
@@ -774,10 +774,8 @@ begin
     begin
     Call := StringReplace(Edit1.Text, '?', '', [rfReplaceAll]);
 
-    // Virtual functions used below allow special processing as needed
-    // for some contests (e.g. ARRL Sweepstakes).
-    if not Tst.CheckEnteredCallLength(Call, ExchError) or
-      not Tst.ValidateEnteredExchange(Call, Edit2.Text, Edit3.Text, ExchError) then
+    // Verify callsign (simple length-based check); virtual
+    if not Tst.CheckEnteredCallLength(Call, ExchError) then
       begin
         {Beep;}
         DisplayError(ExchError, clRed);

--- a/Log.pas
+++ b/Log.pas
@@ -184,7 +184,7 @@ const
   CQWW_RST_COL    = 'RST,4,L';
   CQ_ZONE_COL     = 'Zone,4,L';
   SS_CALL_COL     = 'Call,9,L';
-  SS_PREC_COL     = 'Pr,2.5,C';
+  SS_PREC_COL     = 'Pr,2.5,L';
   SS_CHECK_COL    = 'Chk,3.25,C';
 
 {$ifdef DEBUG}

--- a/Main.dfm
+++ b/Main.dfm
@@ -231,6 +231,7 @@ object MainForm: TMainForm
       TabOrder = 2
       OnEnter = Edit3Enter
       OnKeyPress = Edit3KeyPress
+      OnKeyUp = Edit3KeyUp
     end
     object Panel2: TPanel
       Left = 522

--- a/Main.pas
+++ b/Main.pas
@@ -963,7 +963,10 @@ begin
   if not N then
     SendMsg(msgNR);
   if N and (not R or not Q) then
-    SendMsg(msgQm);
+    begin
+      DisplayError(ExchError, clDefault);
+      SendMsg(msgQm);
+    end;
 
   if R and Q and (C or N) then
   begin

--- a/Main.pas
+++ b/Main.pas
@@ -728,6 +728,14 @@ begin
 
     '.', '+', '[', ',': //TU & Save
       begin
+        // verify callsign using simple length-based check
+        var ExchError: string;
+        if not Tst.CheckEnteredCallLength(Edit1.Text, ExchError) then
+          begin
+            DisplayError(ExchError, clRed);
+            Exit;
+          end;
+
         if not CallSent then
           SendMsg(msgHisCall);
         SendMsg(msgTU);
@@ -900,12 +908,20 @@ begin
         Exit;
     end;
   MustAdvance := false;
+  ExchError := '';
 
   sbar.Font.Color := clDefault;
 
   // 'Control-Enter', 'Shift-Enter' and 'Alt-Enter' are shortcuts to SaveQSO
   if (GetKeyState(VK_CONTROL) or GetKeyState(VK_SHIFT) or GetKeyState(VK_MENU)) < 0 then
   begin
+    // verify callsign before calling SaveQSO
+    if not Tst.CheckEnteredCallLength(Edit1.Text, ExchError) then
+      begin
+        DisplayError(ExchError, clRed);
+        Exit;
+      end;
+
     Log.SaveQso;
     Exit;
   end;

--- a/Test/SSExchParserTest.pas
+++ b/Test/SSExchParserTest.pas
@@ -22,7 +22,7 @@ type
     [Category('Simple')]
 
     [TestCase('Simple.1',   '1,           1...-Missing/Invalid Precedence')]
-    [TestCase('Simple.2',   '12,          0..12.-Missing/Invalid Serial NUmber')]
+    [TestCase('Simple.2',   '12,          0..12.-Missing/Invalid Serial Number')]
     [TestCase('Simple.3',   '123,         123...-Missing/Invalid Precedence')]
     [TestCase('Simple.4',   '1234,        1234...-Missing/Invalid Precedence')]
     [TestCase('Simple.5',   '11 22,       11..22.')]    // rotate to NR


### PR DESCRIPTION
ARRL SS - Display missing/invalid exchange error when missing

- When exchange contains missing or invalid elements, display an
  error message before sending '?' to notify user of what information
  is needed.
- Improve exchange error message processing
- Report callsign length error before sending 'TU'
- display '?' for missing exchange fields in Log report
- Fixes Issue #352

Minor Changes
- fix crash when missing numeric exchange
- minor change to SSExchParserTest unit test
- remove assertion in release mode