### PR TITLE
ARRL SS - display parsed exchange summary (#357)

### DIFF
--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -322,12 +322,17 @@ end;
 function TSweepstakes.OnExchangeEdit(const ACall, AExch1, AExch2: string;
   out AExchSummary: string; out AExchError: string) : Boolean;
 begin
-  // incrementally parse the exchange with each keystroke
-  ExchValidator.ValidateEnteredExchange(ACall, AExch1, AExch2, AExchError);
+  if Ini.ShowExchangeSummary <> 0 then
+    begin
+      // incrementally parse the exchange with each keystroke
+      ExchValidator.ValidateEnteredExchange(ACall, AExch1, AExch2, AExchError);
 
-  // return summary (displayed above Exch2's Caption)
-  AExchSummary := ExchValidator.ExchSummary;
-  Result := not AExchSummary.IsEmpty;
+      // return summary (displayed above Exch2's Caption)
+      AExchSummary := ExchValidator.ExchSummary;
+      Result := not AExchSummary.IsEmpty;
+    end
+  else
+    Result := False;
 end;
 
 

--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -52,7 +52,7 @@ public
   procedure SendMsg(const AStn: TStation; const AMsg: TStationMessage); override;
   procedure OnWipeBoxes; override;
   function OnExchangeEdit(const ACall, AExch1, AExch2: string;
-    out AExchSummary: string) : Boolean; override;
+    out AExchSummary: string; out AExchError: string) : Boolean; override;
   procedure OnExchangeEditComplete; override;
   procedure SetHisCall(const ACall: string); override;
   function CheckEnteredCallLength(const ACall: string;
@@ -177,7 +177,7 @@ function TSweepstakes.ValidateMyExchange(const AExchange: string;
 const
   // Syntax: [123|#][ ]<Precedence> <Check> <Section>
   Regexpr: string = ' *(?P<exch1>(?P<nr>[0-9]+|#)? *(?P<prec>[QABUMS])) +'
-                  + '(?P<chk>[0-9]{2}) +(?P<sect>[A-Z]+) *';
+                  + '(?P<chk>[0-9]{2}) +(?P<sect>[A-Z]{2,3}) *';
 var
   reg: TPerlRegEx;
   Exch1, Exch2: string;
@@ -319,13 +319,11 @@ end;
   Overriden here to handle complex ARRL Sweepstakes exchange.
   Returns whether Exchange summary is non-empty.
 }
-function TSweepstakes.OnExchangeEdit(
-  const ACall, AExch1, AExch2: string; out AExchSummary: string) : Boolean;
-var
-  ExchError: string;
+function TSweepstakes.OnExchangeEdit(const ACall, AExch1, AExch2: string;
+  out AExchSummary: string; out AExchError: string) : Boolean;
 begin
   // incrementally parse the exchange with each keystroke
-  ExchValidator.ValidateEnteredExchange(ACall, AExch1, AExch2, ExchError);
+  ExchValidator.ValidateEnteredExchange(ACall, AExch1, AExch2, AExchError);
 
   // return summary (displayed above Exch2's Caption)
   AExchSummary := ExchValidator.ExchSummary;

--- a/ExchFields.pas
+++ b/ExchFields.pas
@@ -66,7 +66,7 @@ const
    ,(C: 'State';      R: '([0-9A-Z/]*)';                   L: 6; T:Ord(etNaQpExch2))
    ,(C: 'State';      R: '()|([0-9A-Z/]*)';                L: 6; T:Ord(etNaQpNonNaExch2))
    ,(C: 'Nr Prec CK Sect';
-                      R: '[0-9ONT]{1,2} +[A-Z]+';          L: 32; T:Ord(etSSCheckSection))
+                      R: '[0-9ONT]{1,2} +[A-Z]{2,3}';      L: 32; T:Ord(etSSCheckSection))
   );
 
 implementation

--- a/Ini.pas
+++ b/Ini.pas
@@ -255,7 +255,7 @@ var
   NoStopActivity: integer=0;
   GetWpmUsesGaussian: boolean = false;
   ShowCheckSection: integer=50;
-  ShowExchangeSummaryInStatusBar: boolean = true;
+  ShowExchangeSummary: integer = 1; // 0=Off, 1=Above Field, 2=Status Bar
 
   Duration: integer = 30;
   RunMode: TRunMode = rmStop;
@@ -435,7 +435,7 @@ begin
       RitStepIncr := ReadInteger(SEC_SET, 'RitStepIncr', RitStepIncr);
       RitStepIncr := Max(-500, Min(500, RitStepIncr));
       ShowCheckSection := ReadInteger(SEC_SET, 'ShowCheckSection', ShowCheckSection);
-      ShowExchangeSummaryInStatusBar := ReadBool(SEC_SET, 'ShowExchangeSummaryInStatusBar', ShowExchangeSummaryInStatusBar);
+      ShowExchangeSummary := ReadInteger(SEC_SET, 'ShowExchangeSummary', ShowExchangeSummary);
 
       // [Debug]
       DebugExchSettings := ReadBool(SEC_DBG, 'DebugExchSettings', DebugExchSettings);
@@ -519,7 +519,7 @@ begin
       WriteInteger(SEC_SET, 'WpmStepRate', WpmStepRate);
       WriteInteger(SEC_SET, 'RitStepIncr', RitStepIncr);
       WriteInteger(SEC_SET, 'ShowCheckSection', ShowCheckSection);
-      WriteBool(SEC_SET, 'ShowExchangeSummaryInStatusBar', ShowExchangeSummaryInStatusBar);
+      WriteInteger(SEC_SET, 'ShowExchangeSummary', ShowExchangeSummary);
 
     finally
       Free;

--- a/Ini.pas
+++ b/Ini.pas
@@ -255,6 +255,7 @@ var
   NoStopActivity: integer=0;
   GetWpmUsesGaussian: boolean = false;
   ShowCheckSection: integer=50;
+  ShowExchangeSummaryInStatusBar: boolean = true;
 
   Duration: integer = 30;
   RunMode: TRunMode = rmStop;
@@ -434,6 +435,7 @@ begin
       RitStepIncr := ReadInteger(SEC_SET, 'RitStepIncr', RitStepIncr);
       RitStepIncr := Max(-500, Min(500, RitStepIncr));
       ShowCheckSection := ReadInteger(SEC_SET, 'ShowCheckSection', ShowCheckSection);
+      ShowExchangeSummaryInStatusBar := ReadBool(SEC_SET, 'ShowExchangeSummaryInStatusBar', ShowExchangeSummaryInStatusBar);
 
       // [Debug]
       DebugExchSettings := ReadBool(SEC_DBG, 'DebugExchSettings', DebugExchSettings);
@@ -517,6 +519,7 @@ begin
       WriteInteger(SEC_SET, 'WpmStepRate', WpmStepRate);
       WriteInteger(SEC_SET, 'RitStepIncr', RitStepIncr);
       WriteInteger(SEC_SET, 'ShowCheckSection', ShowCheckSection);
+      WriteBool(SEC_SET, 'ShowExchangeSummaryInStatusBar', ShowExchangeSummaryInStatusBar);
 
     finally
       Free;

--- a/Log.pas
+++ b/Log.pas
@@ -454,18 +454,21 @@ end;
 // Refresh Status Bar
 // [<Exchange Summary> --] [(Error | UserText)] [>> Debug]
 procedure UpdateSbar;
-  var S: String;
+var
+  S: String;
 begin
   // optional exchange summary...
-  if SimContest in [scArrlSS] then
-    begin
-      if Ini.ShowExchangeSummaryInStatusBar then
-        S := SBarSummaryMsg
-      else if SBarSummaryMsg.IsEmpty then
-        Mainform.Label3.Caption := Exchange2Settings[etSSCheckSection].C
-      else
-        Mainform.Label3.Caption := SBarSummaryMsg;
-    end;
+  if Ini.ShowExchangeSummary <> 0 then
+    if SimContest in [scArrlSS] then
+      case Ini.ShowExchangeSummary of
+        1:
+          if SBarSummaryMsg.IsEmpty then
+            Mainform.Label3.Caption := Exchange2Settings[etSSCheckSection].C
+          else
+            Mainform.Label3.Caption := SBarSummaryMsg;
+        2:
+          S := SBarSummaryMsg;
+      end;
 
   // error or UserText...
   if not SBarErrorMsg.IsEmpty then

--- a/Log.pas
+++ b/Log.pas
@@ -26,7 +26,10 @@ procedure SetExchColumns(AExch1ColPos, AExch2ColPos: integer;
 procedure ScoreTableInsert(const ACol1, ACol2, ACol3, ACol4, ACol5, ACol6: string; const ACol7: string = ''; const ACol8: string = '');
 procedure ScoreTableUpdateCheck;
 function FormatScore(const AScore: integer):string;
-procedure UpdateSbar(const ACallsign: string);
+procedure UpdateSbar;
+procedure SbarUpdateStationInfo(const ACallsign: string);
+procedure SBarUpdateSummary(const AExchSummary: String);
+procedure SBarUpdateDebugMsg(const AMsgText: string);
 procedure DisplayError(const AExchError: string; const AColor: TColor);
 function ExtractCallsign(Call: string): string;
 function ExtractPrefix(Call: string; DeleteTrailingLetters: boolean = True): string;
@@ -119,7 +122,12 @@ var
   VerifiedPoints:   integer;   // accumulated verified QSO points total
   CallSent: boolean; // msgHisCall has been sent; cleared upon edit.
   NrSent: boolean;   // msgNR has been sent; cleared after qso is completed.
-  ShowCorrections: boolean;    // show exchange correction column.
+  ShowCorrections: boolean;   // show exchange correction column.
+  SBarDebugMsg: String;         // sbar debug message
+  SBarStationInfo: String;    // sbar station info (UserText from call history file)
+  SBarSummaryMsg: String;     // sbar exchange summary (ARRL SS)
+  SBarErrorMsg: String;       // sbar exchange error
+  SBarErrorColor: TColor;     // sbar exchange error color
   Histo: THisto;
 
   // the following column index values are used to set error flags in TQso.ColumnErrorFlags
@@ -198,6 +206,7 @@ var
 {$ifdef DEBUG}
   Indent: Integer = 0;    // used by DebugLnEnter/DebugLnExit
 {$endif}
+  SBarLastCallsign: String;       // used to optimize SBrSetStationInfo
 
 constructor THisto.Create(APaintBox: TPaintBOx);
 begin
@@ -395,45 +404,104 @@ begin
   end;
   MainForm.ListView2.Items.EndUpdate;
 
-  //UpdateSbar(MainForm.ListView2.Items.Count);
   MainForm.ListView2.Perform(WM_VSCROLL, SB_BOTTOM, 0);
 end;
 
 //Update Callsign info
-procedure UpdateSbar(const ACallsign: string);
+procedure SbarUpdateStationInfo(const ACallsign: string);
 var
   s: string;
 begin
+  if ACallSign = SBarLastCallsign then Exit;
+  SBarLastCallsign := ACallsign;
+
   s:= '';
   if not ACallsign.IsEmpty then
   begin
-    // Adding a contest: UpdateSbar - update status bar with station info (e.g. FD shows UserText)
+    // Adding a contest: SbarUpdateStationInfo - update status bar with station info (e.g. FD shows UserText)
     s := Tst.GetStationInfo(ACallsign);
 
     // '&' are suppressed in this control; replace with '&&'
     s:= StringReplace(s, '&', '&&', [rfReplaceAll]);
   end;
 
-  // during debug, use status bar to show CW stream
-  Mainform.sbar.Font.Color := clDefault;
-  if not s.IsEmpty and (BDebugCwDecoder or BDebugGhosting) then
-    Mainform.sbar.Caption := LeftStr(Mainform.sbar.Caption, 40) + ' -- ' + s
+  SBarStationInfo := s;
+  UpdateSbar;
+end;
+
+
+procedure SBarUpdateSummary(const AExchSummary: String);
+begin
+  if SBarSummaryMsg = AExchSummary then Exit;
+
+  SBarSummaryMsg := AExchSummary;
+  UpdateSbar;
+end;
+
+
+
+procedure SBarUpdateDebugMsg(const AMsgText: string);
+begin
+  if SBarDebugMsg = AMsgText then Exit;
+
+  if AMsgText.IsEmpty then
+    SBarDebugMsg := ''
   else
-    MainForm.sbar.Caption := '  ' + s;
+    SBarDebugMsg := (AMsgText + '; ' + SBarDebugMsg).Substring(0, 40);
+  UpdateSbar;
+end;
+
+// Refresh Status Bar
+// [<Exchange Summary> --] [(Error | UserText)] [>> Debug]
+procedure UpdateSbar;
+  var S: String;
+begin
+  // optional exchange summary...
+  if SimContest in [scArrlSS] then
+    begin
+      if Ini.ShowExchangeSummaryInStatusBar then
+        S := SBarSummaryMsg
+      else if SBarSummaryMsg.IsEmpty then
+        Mainform.Label3.Caption := Exchange2Settings[etSSCheckSection].C
+      else
+        Mainform.Label3.Caption := SBarSummaryMsg;
+    end;
+
+  // error or UserText...
+  if not SBarErrorMsg.IsEmpty then
+    begin
+      if not S.IsEmpty then
+        S := S + ' -- ';
+      S := S + SBarErrorMsg;
+    end
+  else if not SBarStationInfo.IsEmpty then
+    begin
+      if not S.IsEmpty then
+        S := S + ' -- ';
+      S := S + SBarStationInfo;
+    end;
+
+  // during debug, use status bar to show CW stream
+  if not SBarDebugMsg.IsEmpty then
+    S := format('  %-45s >> %-40s', [S, SBarDebugMsg]);
+
+  if SBarErrorMsg.IsEmpty then
+    Mainform.sbar.Font.Color := clDefault
+  else
+    Mainform.sbar.Font.Color := SBarErrorColor;
+
+  MainForm.sbar.Caption := S;
 end;
 
 
 procedure DisplayError(const AExchError: string; const AColor: TColor);
 begin
-  if AExchError.IsEmpty then Exit;
+  if (Log.SBarErrorMsg = AExchError) and
+     (Log.SBarErrorColor = AColor) then Exit;
 
-  Mainform.sbar.Font.Color := AColor;
-  if (BDebugCwDecoder or BDebugGhosting) then
-    Mainform.sbar.Caption := LeftStr(Mainform.sbar.Caption, 40) + ' -- ' + AExchError
-  else
-    Mainform.sbar.Caption := AExchError;
-  Mainform.sbar.Align:= alBottom;
-  Mainform.sbar.Visible:= true;
+  Log.SBarErrorMsg := AExchError;
+  Log.SBarErrorColor := AColor;
+  UpdateSbar;
 end;
 
 

--- a/Main.dfm
+++ b/Main.dfm
@@ -49,7 +49,6 @@ object MainForm: TMainForm
     000000FF000001FF000083FF0000E7FF0000E7FF0000}
   KeyPreview = True
   Menu = MainMenu1
-  OldCreateOrder = False
   Position = poScreenCenter
   OnClose = FormClose
   OnCreate = FormCreate
@@ -59,7 +58,6 @@ object MainForm: TMainForm
   OnKeyUp = FormKeyUp
   OnMouseWheelDown = FormMouseWheelDown
   OnMouseWheelUp = FormMouseWheelUp
-  PixelsPerInch = 96
   TextHeight = 15
   object Bevel1: TBevel
     Left = 0
@@ -543,7 +541,6 @@ object MainForm: TMainForm
       ScrollBars = ssVertical
       TabOrder = 1
       Visible = False
-      Zoom = 100
     end
     object ListView2: TListView
       Left = 0

--- a/Main.pas
+++ b/Main.pas
@@ -1522,22 +1522,25 @@ begin
       end;
     etSSCheckSection:
       begin
-        // retain current field sizes
-        SaveEdit1Width := Edit1.Width;
-        SaveLabel3Left := Label3.Left;
-        SaveEdit3Left := Edit3.Left;
-        SaveEdit3Width := Edit3.Width;
+        if SaveEdit3Left = 0 then
+          begin
+            // retain current field sizes
+            SaveEdit1Width := Edit1.Width;
+            SaveLabel3Left := Label3.Left;
+            SaveEdit3Left := Edit3.Left;
+            SaveEdit3Width := Edit3.Width;
 
-        // hide Exch1 (Edit2)
-        Edit2.Hide;
-        Label2.Hide;
+            // hide Exch1 (Edit2)
+            Edit2.Hide;
+            Label2.Hide;
 
-        // reduce Edit1 width; shift Exch Field 2 to the left and grow
-        var Reduce1: integer := (SaveEdit1Width * 4) div 9;
-        Label3.Left := Label3.Left - (Label3.Left - Label2.Left) - Reduce1;
-        Edit3.Left := Edit2.Left - Reduce1;
-        Edit3.Width := Edit3.Width + (SaveEdit3Left - Edit2.Left + Reduce1 + 15);
-        Edit1.Width := Edit1.Width - Reduce1;
+            // reduce Edit1 width; shift Exch Field 2 to the left and grow
+            var Reduce1: integer := (SaveEdit1Width * 4) div 9;
+            Label3.Left := Label3.Left - (Label3.Left - Label2.Left) - Reduce1;
+            Edit3.Left := Edit2.Left - Reduce1;
+            Edit3.Width := Edit3.Width + (SaveEdit3Left - Edit2.Left + Reduce1 + 15);
+            Edit1.Width := Edit1.Width - Reduce1;
+          end;
 
         Ini.UserExchange2[SimContest] := Avalue; // <check> <sect> (e.g. 72 OR)
         Tst.Me.Exch2 := Avalue;

--- a/Main.pas
+++ b/Main.pas
@@ -532,13 +532,9 @@ begin
     // retain current callsign, including ''.
     Tst.SetHisCall(Edit1.Text);   // virtual; sets Tst.Me.HisCall and Log.CallSent
 
-    // if his callsign is empty or hasn't changed, return
-    if not CallSent then
-      Exit;
-
     // update "received" Exchange field types. Some contests change field
-    // types based on MyCall or dx station's call (current value of Edit1).
-    RecvExchTypes:= Tst.GetRecvExchTypes(skMyStation, Tst.Me.MyCall, Trim(Edit1.Text));
+    // types based on MyCall and/or DX station's call (Tst.Me.HisCall).
+    RecvExchTypes:= Tst.GetRecvExchTypes(skMyStation, Tst.Me.MyCall, Tst.Me.HisCall);
   end;
   if AMsg = msgNR then
     NrSent := true;
@@ -597,10 +593,16 @@ procedure TMainForm.Edit3KeyUp(Sender: TObject; var Key: Word;
 begin
   // some contests have additional processing (e.g. ARRL SS)
   // (exclude function keys so we can use the debugger)
-  var ExchSummary: string;
+  var ExchSummary, ExchError: string;
   if (SimContest in [scArrlSS]) and ((Key < VK_F1) or (Key > VK_F12)) then
     begin
-      Tst.OnExchangeEdit(Edit1.Text, Edit2.Text, Edit3.Text, ExchSummary);
+      if Tst.OnExchangeEdit(Edit1.Text, Edit2.Text, Edit3.Text,
+        ExchSummary, ExchError) then
+        begin
+          Log.SBarUpdateSummary(ExchSummary);
+          if not Log.SBarErrorMsg.IsEmpty and ExchError.IsEmpty then
+            Log.DisplayError('', clDefault);
+        end;
     end;
 end;
 
@@ -740,6 +742,9 @@ begin
 
     ';': //<his> <#>
       begin
+        // some contests have additional exchange processing (e.g. ARRL SS)
+        Tst.OnExchangeEditComplete;  // sets Log.CallSent
+
         SendMsg(msgHisCall);
         SendMsg(msgNr);
       end;
@@ -786,6 +791,7 @@ begin
   case Key of
     VK_INSERT: //<his> <#>
       begin
+      Tst.OnExchangeEditComplete;
       SendMsg(msgHisCall);
       SendMsg(msgNr);
       Key := 0;
@@ -880,7 +886,7 @@ begin
       if ActiveControl = Edit1 then
         begin
           if SimContest = scFieldDay then
-            UpdateSbar(Edit1.Text);
+            SbarUpdateStationInfo(Edit1.Text);
           if SimContest = scArrlSS then
             ActiveControl := Edit3
           else
@@ -952,7 +958,9 @@ begin
   // remember not to give a hint if exchange entry is affected by this info.
   // for certain contests (e.g. ARRL Field Day), update update status bar
   if SimContest in [scCwt, scFieldDay, scWpx, scCQWW, scArrlDx, scIaruHf] then
-    UpdateSbar(Edit1.Text);
+    SbarUpdateStationInfo(Edit1.Text)
+  else if not BDebugCwDecoder then
+    SbarUpdateStationInfo('');
 
   //no QSO in progress, send CQ
   if Edit1.Text = '' then
@@ -968,6 +976,9 @@ begin
 
   // Update CallSent (HisCall has been sent)
   Tst.OnExchangeEditComplete;
+
+  // clear prior error string
+  DisplayError('', clDefault);
 
   //current state
   C := CallSent;
@@ -1694,6 +1705,9 @@ begin
   Edit2.Text := '';
   Edit3.Text := '';
   ActiveControl := Edit1;
+
+  if SimContest = scArrlSS then
+    Log.SBarUpdateSummary('');
 
   if Assigned(Tst) then
     Tst.OnWipeBoxes;
@@ -2613,7 +2627,7 @@ procedure TMainForm.ListView2SelectItem(Sender: TObject; Item: TListItem;
   Selected: Boolean);
 begin
     if (Selected and mnuShowCallsignInfo.Checked) then
-        UpdateSbar(Item.SubItems[0]);
+        SbarUpdateStationInfo(Item.SubItems[0]);
 end;
 
 procedure TMainForm.Activity1Click(Sender: TObject);

--- a/Readme.txt
+++ b/Readme.txt
@@ -556,15 +556,18 @@ CONTEST INFORMATION
       Valid values range between 0 and 100, representing 0% and 100%.
       Note that a zero value will disable this feature.
 
-      An Exchange Summary is provided as the user enters the received exchange
-      into the Exchange field. This summary shows QSO information as it will
-      entered into the log. For example: "192B W7SST 72 OR". By default, this
-      information is displayed in the status bar. If desired, the exchange
-      summary can be written into the label above the exchange field entry
-      field by setting the following keyword in the MorseRunner.ini file:
+      As the user enters an exchange into the exchange entry field, an Exchange
+      Summary is provided in the Label above the field. This summary shows QSO
+      information as it will entered into the log. For example:
+        "192B W7SST 72 OR".
+      By default, this information is displayed above the exchange entry field.
+      If desired, the exchange summary can be turned off. This is controlled by
+      setting the following keyword in the MorseRunner.ini file:
         [Settings]
-        ShowExchangeSummaryInStatusBar=0
-      Valid values are: 0-display above entry field; or 1-display in status bar.
+        ShowExchangeSummary=N
+      Valid values for N:
+        0 - Off
+        1 - Display summary in label above entry field (default)
 
     CQ WPX
     When: Last weekend in May

--- a/Readme.txt
+++ b/Readme.txt
@@ -61,8 +61,8 @@ CONFIGURATION
 
   Band Conditions and Sounds
      It has been brought to our attention that our Morse Runner's Morse Code
-     sounds different than the original 1.67/1.68. This is true, and if you 
-     caught this you have good ears! We corrected the spacing in the original 
+     sounds different than the original 1.67/1.68. This is true, and if you
+     caught this you have good ears! We corrected the spacing in the original
      program to match the rules for proper Morse Code. For more on this see:
      https://github.com/w7sst/MorseRunner/issues/301
 
@@ -185,7 +185,12 @@ CONFIGURATION
     Show Check/Section (for ARRL Sweepstakes only)
       This contest has a complicated exchange and there is a setting to prepopulate
       the exchange to match N1MM's behavior. Please see the contest rules section
-      below for more information. 
+      below for more information.
+
+    Show Exchange Summary In Status Bar (for ARRL Sweepstakes only)
+      This contest will display the parsed exchange summary in either the status
+      bar (default) or optionally in the label/caption above the exchange entry
+      field. Please see the contest rules section below for more information.
 
 
   Responses
@@ -235,7 +240,7 @@ KEY ASSIGNMENTS
   Alt-W            - Wipes the input fields (with Windows chime)
   Shift-Enter      - Saves the QSO without sending anything
   Ctrl-Enter       - Saves the QSO without sending anything
-  Alt-Enter        - Saves the QSO without sending anything (with Windows Chime)
+  Alt-Enter        - Saves the QSO without sending anything
   Tab Key          - Moves to Call, RST, CQ-Zone, Station Call, and your exchange
   Shift Tab        - Moves to Call, RST, CQ-Zone, Station Call, and your exchange
   Up arrow         - Moves the RIT right (reversible in settings)
@@ -550,6 +555,16 @@ CONTEST INFORMATION
         ShowCheckSection=50
       Valid values range between 0 and 100, representing 0% and 100%.
       Note that a zero value will disable this feature.
+
+      An Exchange Summary is provided as the user enters the received exchange
+      into the Exchange field. This summary shows QSO information as it will
+      entered into the log. For example: "192B W7SST 72 OR". By default, this
+      information is displayed in the status bar. If desired, the exchange
+      summary can be written into the label above the exchange field entry
+      field by setting the following keyword in the MorseRunner.ini file:
+        [Settings]
+        ShowExchangeSummaryInStatusBar=0
+      Valid values are: 0-display above entry field; or 1-display in status bar.
 
     CQ WPX
     When: Last weekend in May

--- a/Station.pas
+++ b/Station.pas
@@ -137,6 +137,7 @@ uses
   Main,     // for Mainform.sbar.Caption, BDebugCwDecoder
   QrmStn,   // for TQrmStation.ClassType
   Contest,  // for Tst (TContest), Tst.Me.OpName
+  Log,      // for SBarUpdateDebugMsg
   StrUtils, // for PosEx
   TypInfo,  // for typeInfo
   SysUtils, Math, MorseKey;
@@ -227,7 +228,7 @@ begin
 
   // during debug, use status bar to show CW stream
   if (AMsg = msgTU) and BDebugCwDecoder and not (self is TQrmStation) then
-    Mainform.sbar.Caption:= '';
+    Log.SBarUpdateDebugMsg('');
 
   // Create contest-specific messages...
   Tst.SendMsg(self, AMsg);
@@ -296,7 +297,7 @@ begin
 
   // during debug, use status bar to show CW stream
   if BDebugCwDecoder and not (self is TQrmStation) then
-    Mainform.sbar.Caption := (MsgText + '; ' + Mainform.sbar.Caption).Substring(0, 80);
+    Log.SBarUpdateDebugMsg(MsgText);
 
   SendMorse(Keyer.Encode(MsgText));
 end;


### PR DESCRIPTION
Cleanup error/status reporting code for ARRL Sweepstakes
    
    - clear exchange error after each QSO
    - improve status bar handling allowing exchange summary to be displayed
    - remove 'Call' from exchange entry heading for Arrl SS.
    - Add ShowExchangeSummaryInStatusBar to MorseRunner.ini file
    - fix problem where F5 (HisCall) was not sending the previous QSO's callsign.