### PR TITLE
Change SS Precedence distribution to 50/20/20/10

### DIFF
--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -62,7 +62,7 @@ public
   procedure SaveEnteredExchToQso(var Qso: TQso; const AExch1, AExch2: string); override;
   function GetStationInfo(const ACallsign: string) : string; override;
   function ExtractMultiplier(Qso: PQso) : string; override;
-  function GetCheckSection(const ACallsign: string; AThreshold: extended = 0): String;
+  function GetCheckSection(const ACallsign: string; AThreshold: Single = 0): String;
   function IsNum(Num: String): Boolean;
 end;
 
@@ -409,10 +409,21 @@ end;
 }
 procedure TSweepstakes.GetExchange(id : integer; out station : TDxStation);
 const
-  PrecedenceTbl: array[0..5] of string = ('Q', 'A', 'B', 'U', 'M', 'S');
+  PrecedenceTbl: array[0..5] of string = ('A', 'B', 'U', 'Q', 'M', 'S');
 begin
   station.NR := GetRandomSerialNR;  // serial number
-  station.Prec := PrecedenceTbl[Random(6)];
+
+  // Mark, KD0EE, recommends 50% calls are A, 20% B, 20% U, 10% for the rest.
+  var R: Single := Random;
+  if R < 0.50 then
+    station.Prec := PrecedenceTbl[0]
+  else if R < 0.70 then
+    station.Prec := PrecedenceTbl[1]
+  else if R < 0.90 then
+    station.Prec := PrecedenceTbl[2]
+  else
+    station.Prec := PrecedenceTbl[3+Random(3)];
+
   station.Chk := SweepstakesCallList.Items[id].Check;
   station.Sect := SweepstakesCallList.Items[id].Section;
   station.UserText := SweepstakesCallList.Items[id].UserText;
@@ -461,7 +472,7 @@ end;
   so the user has to correct the string being copied.
 }
 function TSweepstakes.GetCheckSection(const ACallsign: string;
-  AThreshold: extended): String;
+  AThreshold: Single): String;
 var
   ssrec: TSweepstakesCallRec;
   section: string;

--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -414,10 +414,12 @@ begin
   station.NR := GetRandomSerialNR;  // serial number
 
   // Mark, KD0EE, recommends 50% calls are A, 20% B, 20% U, 10% for the rest.
+  // Jim, K6OK, reported     37% calls are A, 19% B, 36% U, 10% for the rest.
+  // Using the average ...             43% A, 19% B, 28% U, 10% for Q, M and S.
   var R: Single := Random;
-  if R < 0.50 then
+  if R < 0.43 then
     station.Prec := PrecedenceTbl[0]
-  else if R < 0.70 then
+  else if R < 0.62 then
     station.Prec := PrecedenceTbl[1]
   else if R < 0.90 then
     station.Prec := PrecedenceTbl[2]

--- a/Main.pas
+++ b/Main.pas
@@ -2244,7 +2244,8 @@ begin
         (ActiveControl = Edit3) and (Edit3.Text = '') and
         (Random < (ShowCheckSection/100)) then
           begin
-            var S: string := (Tst as TSweepstakes).GetCheckSection(Edit1.Text, 0.25);
+            // inject a Section error 10% of the time
+            var S: string := (Tst as TSweepstakes).GetCheckSection(Edit1.Text, 0.10);
             if not S.IsEmpty then
               S := S + ' ';
             Edit3.Text := S;

--- a/Util/Lexer.pas
+++ b/Util/Lexer.pas
@@ -145,7 +145,6 @@ begin
       Rule.regex := Reg;
       Rule.tokenType := Def.T;
       Rules.Add(Rule);
-      Reg := nil;
     end;
 end;
 


### PR DESCRIPTION
Stations are created with the following distributions for Precedence values:
- 50% A
- 20% B
- 20% U
- 10% for remaining Q, M, S to be evenly distributed

Also changed Section error injection to 10%.

Issue #364.