### PR TITLE
DxStation now sends 'R' after callsign correction

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -2,7 +2,7 @@
                               Contest Simulator
                                   freeware
 
-                Version 1.85 - ARRL Sweepstakes Contest
+                Version 1.85.1 - ARRL Sweepstakes Contest
             The sixth release of the Morse Runner Community Edition
 
                Copyright (C) 2004-2016 Alex Shovkoplyas, VE3NEA
@@ -313,6 +313,9 @@ SUBMITTING YOUR SCORE
   File -> View Score menu command.
 
 VERSION HISTORY
+
+Version 1.85.1 (October 2024)
+  - DxStation now sends 'R' after callsign correction (W7SST)
 
 Version 1.85 (September 2024)
   - Add ARRL Sweepstakes Contest (W7SST)


### PR DESCRIPTION
- this problem was introduced in 1.85
- Note: When MorePatience was introduced in May 2024, a bug (Issue #370) was introduced causing the DxStation to not send an 'R' after the user corrected a callsign. The case involved the user sending a corrected callsign using the Enter key while leaving the exchange fields blank (user sends '<his incorrect call> ?'. In this case, the DxOperator.MsgReceived function would call MorePatience for the '?' and the Patience value was set to 4. This caused DxOperator.GetReply() to send the wrong response: DxOperator.GetReply(osNeedEnd, Patience=5) --> 'R <HisCall>' DxOperator.GetReply(osNeedEnd, Patience=4) --> '<HisCall>' To fix this problem, MorePatience will maintain an existing Patience value of 5 (FULL_PATIENCE) and not set it to 4. Resolved in October 2024.
- Issue #370 