### PR TITLE
Update Readme.txt and roll version number for v1.85.1 release

### DIFF
--- a/Main.pas
+++ b/Main.pas
@@ -22,7 +22,7 @@ uses
 
 const
   WM_TBDOWN = WM_USER+1;
-  sVersion: String = '1.85.1-d1';  { Sets version strings in UI panel. }
+  sVersion: String = '1.85.1';  { Sets version strings in UI panel. }
 
 type
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -315,7 +315,11 @@ SUBMITTING YOUR SCORE
 VERSION HISTORY
 
 Version 1.85.1 (October 2024)
+  Bug Fix Release
   - DxStation now sends 'R' after callsign correction (W7SST)
+  - Fix memory leak (W7SST)
+
+  General
   - Removed 100-person subsciption limit for user's group on groups.io
 
 Version 1.85 (September 2024)

--- a/Readme.txt
+++ b/Readme.txt
@@ -316,6 +316,7 @@ VERSION HISTORY
 
 Version 1.85.1 (October 2024)
   - DxStation now sends 'R' after callsign correction (W7SST)
+  - Removed 100-person subsciption limit for user's group on groups.io
 
 Version 1.85 (September 2024)
   - Add ARRL Sweepstakes Contest (W7SST)


### PR DESCRIPTION
Minor change mentioning removal of 100-person subscription limit on groups.io. This is in addition to prior changes relating to Issue #370.

Also updates version number to v1.85.1 for release.