### PR TITLE
Dx Station sends full exchange after user sends partial callsign

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -446,7 +446,16 @@ begin
         else if State = osNeedCall then SetState(osNeedEnd);
 
       mcAlmost:
-        if State in [osNeedPrevEnd, osNeedQso] then SetState(osNeedCallNr)
+        if State in [osNeedPrevEnd, osNeedQso] then
+          begin
+            if not (RunMode in [rmHST, rmWpx]) and
+              (msgNR in AMsg) and (Random < 0.8) then
+              // user sent partial call and exchange; send my call and exchange
+              SetState(osNeedCallNr)
+            else
+              // user sent partial callsign only; resend my call
+              MorePatience
+          end
         else if State = osNeedCallNr then MorePatience
         else if State = osNeedNr then SetState(osNeedCallNr)
         else if State = osNeedEnd then SetState(osNeedCall);

--- a/Main.pas
+++ b/Main.pas
@@ -22,7 +22,7 @@ uses
 
 const
   WM_TBDOWN = WM_USER+1;
-  sVersion: String = '1.85.1';  { Sets version strings in UI panel. }
+  sVersion: String = '1.85.2';  { Sets version strings in UI panel. }
 
 type
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -2,7 +2,7 @@
                               Contest Simulator
                                   freeware
 
-                Version 1.85.1 - ARRL Sweepstakes Contest
+                Version 1.85.2 - ARRL Sweepstakes Contest
             The sixth release of the Morse Runner Community Edition
 
                Copyright (C) 2004-2016 Alex Shovkoplyas, VE3NEA
@@ -313,6 +313,10 @@ SUBMITTING YOUR SCORE
   File -> View Score menu command.
 
 VERSION HISTORY
+
+Version 1.85.2 (December 2024)
+  Bug Fix Release
+  - DxStation now sends callsign correction only after user sends partial callsign (#382) (W7SST)
 
 Version 1.85.1 (October 2024)
   Bug Fix Release


### PR DESCRIPTION
- The user can use the F5 Key to send a partial callsign
- The DxStation responds with both corrected callsign and their full exchange.
- Normally, the DxStation would only send their exchange after receiving the user's full exchange.
- This fix restores original behavior where the DxStation will respond with callsign only after receiving an incorrect or partial callsign.
- However, if the user uses the Enter Key and sends both callsign and exchange, then the Dx Station will respond with their callsign and exchange. This will occur most of the time (~80%); otherwise the Dx Station will respond with only their corrected callsign.