### PR TITLE
DxStation sends corrected call only after user sends partial callsign

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -2,7 +2,7 @@
                               Contest Simulator
                                   freeware
 
-                Version 1.85.1 - ARRL Sweepstakes Contest
+                Version 1.85.2 - ARRL Sweepstakes Contest
             The sixth release of the Morse Runner Community Edition
 
                Copyright (C) 2004-2016 Alex Shovkoplyas, VE3NEA
@@ -313,6 +313,10 @@ SUBMITTING YOUR SCORE
   File -> View Score menu command.
 
 VERSION HISTORY
+
+Version 1.85.2 (December 2024)
+  Bug Fix Release
+  - DxStation now sends callsign correction only after user sends partial callsign (#382) (W7SST)
 
 Version 1.85.1 (October 2024)
   Bug Fix Release


### PR DESCRIPTION
- restores pre-1.85 behavior where DxStation sends only corrected callsign after user sends a partial callsign using F5 Key.
- v1.85/v1.85.1 was sending both corrected callsign and exchange. Only the corrected callsign should be sent.
- The user can use the F5 Key to send a partial callsign
- This fix restores original behavior where the DxStation will respond with callsign only after receiving an incorrect or partial callsign.
- However, if the user uses the Enter Key and sends both callsign and exchange, then the Dx Station will respond with their callsign and exchange. This will occur most of the time (~80%); otherwise the Dx Station will respond with only their corrected callsign.