### PR TITLE
Send 'TU MyCall' after three consecutive QSOs

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -21,6 +21,10 @@ type
     procedure SwapFilters;
 
   protected
+  const
+    STATION_ID_RATE = 3;  // send Station ID after 3 consecutive QSOs
+
+  var
     QsoCountSinceStationID: Integer;  // QSOs since last CQ or Station ID
     BFarnsworthEnabled : Boolean; // enables Farnsworth timing (e.g. SST Contest)
 
@@ -409,7 +413,7 @@ begin
     msgTU:
       // send station ID after 3 consecutive QSOs (the comparison below uses
       // 2 since the counter is incremented after 'TU <my>' has been sent).
-      if (RunMode <> rmHST) and (QsoCountSinceStationID >= 2)
+      if (RunMode <> rmHST) and (QsoCountSinceStationID >= (STATION_ID_RATE-1))
         then SendText(AStn, 'TU <my>')
         else SendText(AStn, 'TU');
     msgMyCall: SendText(AStn, '<my>');
@@ -873,7 +877,7 @@ var
 begin
   // reset Station ID counter after sending a CQ or 3 consecutive QSOs
   if (msgCQ in Me.Msg) or
-     ((msgTU in Me.Msg) and (QsoCountSinceStationID >= 3)) then
+     ((msgTU in Me.Msg) and (QsoCountSinceStationID >= STATION_ID_RATE)) then
     OnStationIDSent;
 
   //the stations heard my CQ and want to call

--- a/Contest.pas
+++ b/Contest.pas
@@ -407,7 +407,8 @@ begin
     msgCQ: SendText(AStn, 'CQ <my> TEST');
     msgNR: SendText(AStn, '<#>');
     msgTU:
-      // send station ID after 3 consecutive QSOs
+      // send station ID after 3 consecutive QSOs (the comparison below uses
+      // 2 since the counter is incremented after 'TU <my>' has been sent).
       if (RunMode <> rmHST) and (QsoCountSinceStationID >= 2)
         then SendText(AStn, 'TU <my>')
         else SendText(AStn, 'TU');

--- a/Contest.pas
+++ b/Contest.pas
@@ -21,6 +21,7 @@ type
     procedure SwapFilters;
 
   protected
+    QsoCountSinceStationID: Integer;  // QSOs since last CQ or Station ID
     BFarnsworthEnabled : Boolean; // enables Farnsworth timing (e.g. SST Contest)
 
     constructor Create;
@@ -89,6 +90,8 @@ type
     function GetAudio: TSingleArray;
     procedure OnMeFinishedSending;
     procedure OnMeStartedSending;
+    procedure OnSaveQsoComplete;
+    procedure OnStationIDSent;
   end;
 
 var
@@ -133,6 +136,7 @@ begin
   Agc.AgcEnabled := true;
   NoActivityCnt :=0;
   LastLoadCallsign := '';
+  QsoCountSinceStationID := 0;
   BFarnsworthEnabled := false;
 
   Init;
@@ -157,6 +161,7 @@ begin
   Stations.Clear;
   BlockNumber := 0;
   LastLoadCallsign := '';
+  QsoCountSinceStationID := 0;
   BFarnsworthEnabled := false;
 end;
 
@@ -401,7 +406,11 @@ begin
   case AMsg of
     msgCQ: SendText(AStn, 'CQ <my> TEST');
     msgNR: SendText(AStn, '<#>');
-    msgTU: SendText(AStn, 'TU');
+    msgTU:
+      // send station ID after 3 consecutive QSOs
+      if (RunMode <> rmHST) and (QsoCountSinceStationID >= 2)
+        then SendText(AStn, 'TU <my>')
+        else SendText(AStn, 'TU');
     msgMyCall: SendText(AStn, '<my>');
     msgHisCall: SendText(AStn, '<his>');
     msgB4: SendText(AStn, 'QSO B4');
@@ -861,6 +870,11 @@ var
   z: integer;
   Dx : integer;
 begin
+  // reset Station ID counter after sending a CQ or 3 consecutive QSOs
+  if (msgCQ in Me.Msg) or
+     ((msgTU in Me.Msg) and (QsoCountSinceStationID >= 3)) then
+    OnStationIDSent;
+
   //the stations heard my CQ and want to call
   if (not (RunMode in [rmSingle, RmHst])) then
     if (msgCQ in Me.Msg) or
@@ -898,6 +912,21 @@ begin
   //tell callers that I started sending
   for i:=Stations.Count-1 downto 0 do
     Stations[i].ProcessEvent(evMeStarted);
+end;
+
+
+// Called by Log.SaveQso after saving a QSO into the log.
+procedure TContest.OnSaveQsoComplete;
+begin
+  // send station ID after 3 consecutive QSOs
+  Inc(QsoCountSinceStationID);
+end;
+
+
+// Called by TContest.OnMeFinishedSending after sending 'CQ <my>' or 'TU <my>'.
+procedure TContest.OnStationIDSent;
+begin
+  QsoCountSinceStationID := 0;
 end;
 
 

--- a/Log.pas
+++ b/Log.pas
@@ -920,6 +920,9 @@ begin
   if (Tst.Me.SentExchTypes.Exch1 in [etSSNrPrecedence]) or
      (Tst.Me.SentExchTypes.Exch2 in [etSerialNr]) then
     Inc(Tst.Me.NR);
+
+  // Notify SaveQso is complete
+  Tst.OnSaveQsoComplete;
 end;
 
 

--- a/Main.pas
+++ b/Main.pas
@@ -322,6 +322,7 @@ type
     UserExchangeDirty: boolean; // SetMyExchange is called after exchange edits
     CWSpeedDirty: boolean;      // SetWpm is called after CW Speed edits
     RitLocal: integer;          // tracks incremented RIT Value
+    QsoCountSinceStationID: Integer;  // send station ID once-every-three QSOs
     function CreateContest(AContestId : TSimContest) : TContest;
     procedure ConfigureExchangeFields;
     procedure SetMyExch1(const AExchType: TExchange1Type; const Avalue: string);
@@ -369,7 +370,6 @@ type
     procedure UpdCWMaxRxSpeed(Maxspd: integer);
     procedure ClientHTTP1Redirect(Sender: TObject; var dest: string;
       var NumRedirect: Integer; var Handled: Boolean; var VMethod: string);
-
   end;
 
 function ToStr(const val : TExchange1Type): string; overload;
@@ -442,6 +442,7 @@ begin
 
   UserCallsignDirty := False;
   UserExchangeDirty := False;
+  QsoCountSinceStationID := 0;
 
   // load DXCC support
   gDXCCList := TDXCC.Create;
@@ -547,6 +548,21 @@ begin
   if AMsg = msgNR then
     NrSent := true;
   Tst.Me.SendMsg(AMsg);
+
+  // send station ID once-every-three QSOs
+  if RunMode <> rmHST then
+    case AMsg of
+    msgCQ: QsoCountSinceStationID := 0;
+    msgTU:
+      begin
+        Inc(QsoCountSinceStationID);
+        if QsoCountSinceStationID >= 3 then
+          begin
+            SendMsg(msgMyCall);
+            QsoCountSinceStationID := 0;
+          end;
+      end;
+    end;
 end;
 
 

--- a/Main.pas
+++ b/Main.pas
@@ -322,7 +322,6 @@ type
     UserExchangeDirty: boolean; // SetMyExchange is called after exchange edits
     CWSpeedDirty: boolean;      // SetWpm is called after CW Speed edits
     RitLocal: integer;          // tracks incremented RIT Value
-    QsoCountSinceStationID: Integer;  // send station ID once-every-three QSOs
     function CreateContest(AContestId : TSimContest) : TContest;
     procedure ConfigureExchangeFields;
     procedure SetMyExch1(const AExchType: TExchange1Type; const Avalue: string);
@@ -442,7 +441,6 @@ begin
 
   UserCallsignDirty := False;
   UserExchangeDirty := False;
-  QsoCountSinceStationID := 0;
 
   // load DXCC support
   gDXCCList := TDXCC.Create;
@@ -548,21 +546,6 @@ begin
   if AMsg = msgNR then
     NrSent := true;
   Tst.Me.SendMsg(AMsg);
-
-  // send station ID once-every-three QSOs
-  if RunMode <> rmHST then
-    case AMsg of
-    msgCQ: QsoCountSinceStationID := 0;
-    msgTU:
-      begin
-        Inc(QsoCountSinceStationID);
-        if QsoCountSinceStationID >= 3 then
-          begin
-            SendMsg(msgMyCall);
-            QsoCountSinceStationID := 0;
-          end;
-      end;
-    end;
 end;
 
 

--- a/MyStn.pas
+++ b/MyStn.pas
@@ -208,7 +208,7 @@ begin
     NewEnvelope := Keyer.Envelope;
     for i:=0 to High(NewEnvelope) do
       NewEnvelope[i] := NewEnvelope[i] * Amplitude;
-      
+
     //compare to the old one
     Result := Length(NewEnvelope) >= SendPos;
     if Result then

--- a/Readme.txt
+++ b/Readme.txt
@@ -314,6 +314,10 @@ SUBMITTING YOUR SCORE
 
 VERSION HISTORY
 
+Version 1.86 (Spring 2025)
+  General bug fixes and improvements...
+  - Send 'TU MyCall' after three consecutive QSOs (W7SST)
+
 Version 1.85.2 (December 2024)
   Bug Fix Release
   - DxStation now sends callsign correction only after user sends partial callsign (#382) (W7SST)


### PR DESCRIPTION
- 'TU \<my\>' is now sent after three consecutive QSOS.
- Sending CQ will reset this counter.
- The goal is to mimic good operating practice of sending Station ID after three consecutive QSOs when running.
- Does not apply to HST Competition.