### PR TITLE
NAQP - State exchange field can be empty for DX Stations (#353)

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -69,7 +69,8 @@ type
     function GetExchangeTypes(
       const AStationKind : TStationKind;
       const ARequestedMsgType : TRequestedMsgType;
-      const AStationCallsign : string) : TExchTypes; virtual;
+      const AStationCallsign : String;
+      const ARemoteCallsign : String) : TExchTypes; virtual;
     procedure SendMsg(const AStn: TStation; const AMsg: TStationMessage); virtual;
     procedure SendText(const AStn: TStation; const AMsg: string); virtual;
     procedure OnWipeBoxes; virtual;
@@ -357,7 +358,7 @@ function TContest.GetSentExchTypes(
   const AStationKind : TStationKind;
   const AMyCallsign : string) : TExchTypes;
 begin
-  Result:= Self.GetExchangeTypes(AStationKind, mtSendMsg, AMyCallsign);
+  Result:= Self.GetExchangeTypes(AStationKind, mtSendMsg, AMyCallsign, '');
 end;
 
 
@@ -372,16 +373,17 @@ function TContest.GetRecvExchTypes(
   const ADxCallsign : string) : TExchTypes;
 begin
   if AStationKind = skMyStation then
-    Result:= Self.GetExchangeTypes(AStationKind, mtRecvMsg, AMyCallsign)
+    Result:= Self.GetExchangeTypes(AStationKind, mtRecvMsg, AMyCallsign, ADxCallsign)
   else
-    Result:= Self.GetExchangeTypes(AStationKind, mtRecvMsg, ADxCallsign);
+    Result:= Self.GetExchangeTypes(AStationKind, mtRecvMsg, ADxCallsign, AMyCallsign);
 end;
 
 
 function TContest.GetExchangeTypes(
   const AStationKind : TStationKind;
   const ARequestedMsgType : TRequestedMsgType;
-  const AStationCallsign : string) : TExchTypes;
+  const AStationCallsign : String;
+  const ARemoteCallsign : String) : TExchTypes;
 begin
   Result.Exch1 := ActiveContest.ExchType1;
   Result.Exch2 := ActiveContest.ExchType2;
@@ -443,6 +445,7 @@ end;
 }
 procedure TContest.OnWipeBoxes;
 begin
+  Me.HisCall := '';
   Log.NrSent := False;
   Log.DisplayError('', clDefault);
 end;
@@ -618,7 +621,8 @@ begin
     end;
 
   if Qso.Exch1.IsEmpty then Qso.Exch1 := '?';
-  if Qso.Exch2.IsEmpty then Qso.Exch2 := '?';
+  if Qso.Exch2.IsEmpty and (Mainform.RecvExchTypes.Exch2 <> etNaQpNonNaExch2) then
+    Qso.Exch2 := '?';
 end;
 
 

--- a/DualExchContest.pas
+++ b/DualExchContest.pas
@@ -30,7 +30,8 @@ type
     function GetExchangeTypes(
       const AStationKind : TStationKind;
       const ARequestedMsgType : TRequestedMsgType;
-      const AStationCallsign : string) : TExchTypes; override;
+      const AStationCallsign : String;
+      const ARemoteCallsign : String) : TExchTypes; override;
 
   end;
 
@@ -76,7 +77,8 @@ end;
 function TDualExchContest.GetExchangeTypes(
   const AStationKind : TStationKind;
   const ARequestedMsgType : TRequestedMsgType;
-  const AStationCallsign : string) : TExchTypes;
+  const AStationCallsign : String;
+  const ARemoteCallsign : String) : TExchTypes;
 var
   HomeCallIsDX: Boolean;
   IsSimDxStation: Boolean;

--- a/Log.pas
+++ b/Log.pas
@@ -1132,6 +1132,15 @@ procedure TQso.CheckExch2(var ACorrections: TStringList);
         ACorrections.Add(TrueExch2);
     leCHK:
         ACorrections.Add(format('%.02d', [TrueCheck]));
+    leST:
+      // special case for NAQP - Non-NA Stations do not send State. Return a
+      // space (' ') to avoid printing a confusing "" in the error log.
+      if (SimContest = scNaQP) and
+        (Mainform.RecvExchTypes.Exch2 = etNaQpNonNaExch2) and
+        TrueExch2.IsEmpty then
+        ACorrections.Add(' ')
+      else
+        ACorrections.Add(TrueExch2);
     else
       ACorrections.Add(TrueExch2);
   end;

--- a/Main.pas
+++ b/Main.pas
@@ -991,9 +991,11 @@ begin
   case SimContest of
     scArrlSS:
       R := Tst.ValidateEnteredExchange(Edit1.Text, Edit2.Text, Edit3.Text, ExchError);
+    scNaQp:
+      // for NAQP, Exch2 can be empty because Non-NA (DX) Stations do not send State.
+      R := (Edit3.Text <> '') or (not (Tst as TNcjNaQp).IsCallLocalToContest(Edit1.Text));
     else
-      R := (Edit3.Text <> '') or ((SimContest = scNaQp) and
-                                  (RecvExchTypes.Exch2 = etNaQpNonNaExch2));
+      R := (Edit3.Text <> '');
   end;
 
   //send his call if did not send before, or if call changed

--- a/Readme.txt
+++ b/Readme.txt
@@ -317,6 +317,7 @@ VERSION HISTORY
 Version 1.85.2 (December 2024)
   Bug Fix Release
   - DxStation now sends callsign correction only after user sends partial callsign (#382) (W7SST)
+  - NAQP - DX Stations are now included in simulation (#353) (W7SST)
 
 Version 1.85.1 (October 2024)
   Bug Fix Release


### PR DESCRIPTION
- previously, working a Non-NA station would always send a '?' after entering the calling station's Name. The '?' is being sent because a State value was expected. The State value is not sent by the Dx station in the NAQP Contest.
- Now, the Enter Key will work correctly for Dx Stations when no State is entered.
- fix logic in TMainForm.ProcessEnter to handle empty State field
- added optimization to TNcjNaQP.IsCallLocalToContest
- improve error report for Non-NA Stations. Since Non-NA Stations do not send State. Return a space (' ') to avoid printing a confusing "" in the error log.
- add Keep50 debugging keyword