### PR TITLE
379 Fix program hang when using QRM Band Condition

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -420,10 +420,10 @@ begin
     msgMyCallNr1: SendText(AStn, '<my> <#>');
     msgMyCallNr2: SendText(AStn, '<my> <my> <#>');
     msgNrQm: SendText(AStn, 'NR?');
-    msgLongCQ: SendText(AStn, 'CQ CQ TEST <my> <my> TEST');  // QrmStation only
+    msgLongCQ: SendText(AStn, 'CQ CQ TEST <my> <my> TEST');
     msgQrl: SendText(AStn, 'QRL?');
     msgQrl2: SendText(AStn, 'QRL?   QRL?');
-    msqQsy: SendText(AStn, '<his>  QSY QSY');
+    msqQsy: SendText(AStn, '<his>  QSY QSY');                // QrmStation only
     msgAgn: SendText(AStn, 'AGN');
   end;
 end;

--- a/Main.pas
+++ b/Main.pas
@@ -508,7 +508,7 @@ end;
 procedure TMainForm.AlSoundOut1BufAvailable(Sender: TObject);
 begin
   if AlSoundOut1.Enabled then
-    try AlSoundOut1.PutData(Tst.GetAudio); except end;
+    AlSoundOut1.PutData(Tst.GetAudio);
 end;
 
 

--- a/QrmStn.pas
+++ b/QrmStn.pas
@@ -17,6 +17,7 @@ type
   public
     constructor CreateStation;
     procedure ProcessEvent(AEvent: TStationEvent); override;
+    procedure SendText(AMsg: string); override;
   end;
 
 implementation
@@ -63,6 +64,18 @@ begin
     evTimeout:
       SendMsg(msgLongCQ);
     end;
+end;
+
+
+{
+  Overriden to allow replacement of '<his>' with the user's callsign.
+  This is needed to bypass special handling of '<his>' during message
+  processing to accomodate 'Ini.CallsFromKeyer'.
+}
+procedure TQrmStation.SendText(AMsg: string);
+begin
+  AMsg := AMsg.Replace('<his>', HisCall);
+  inherited SendText(AMsg);
 end;
 
 end.

--- a/Readme.txt
+++ b/Readme.txt
@@ -314,8 +314,9 @@ SUBMITTING YOUR SCORE
 
 VERSION HISTORY
 
-Version 1.85.2 (December 2024)
+Version 1.85.2 (February 2025)
   Bug Fix Release
+  - Fix program hang when using QRM Band Condition (#379) (W7SST)
   - DxStation now sends callsign correction only after user sends partial callsign (#382) (W7SST)
   - NAQP - DX Stations are now included in simulation (#353) (W7SST)
 

--- a/Station.pas
+++ b/Station.pas
@@ -278,11 +278,16 @@ begin
   P := Pos('<', AMsg);
   while (P > 0) do
     begin
+      var Q: Integer := P;
       if ReplaceTokenAt(AMsg, P, '<my>', MyCall) then Break;
       if ReplaceTokenAt(AMsg, P, '<exch1>', Exch1) then Break;
       if ReplaceTokenAt(AMsg, P, '<exch2>', Exch2) then Break;
       if ReplaceTokenAt(AMsg, P, '<HisName>', MainForm.Edit2.Text) then Break;
       if ReplaceTokenAt(AMsg, P, '<MyName>', Tst.Me.OpName) then Break;
+      if P = Q then
+        raise Exception.CreateFmt(
+          'Internal error: TStation.SendText: unrecognized token in msg: "%s"',
+          [AMsg]);
     end;
 
 {

--- a/VCL/SndCustm.pas
+++ b/VCL/SndCustm.pas
@@ -85,6 +85,7 @@ begin
     else if Msg.hwnd <> 0 then Continue
     else
       case Msg.Message of
+        // Synchronize() causes the ProcessEvent call to be executed by the main thread.
         MM_WIM_DATA, MM_WOM_DONE: Synchronize(ProcessEvent);
         MM_WIM_CLOSE: Terminate;
         end;
@@ -99,7 +100,7 @@ begin
   except on E: Exception do
     begin
     Application.ShowException(E);
-    Terminate;
+    Application.Terminate;
     end;
   end;
 end;


### PR DESCRIPTION
Fix program hang when using QRM Band Condition

- When QRM is selected, stations will randomly send interfering
  signals near the user's frequency. Sometimes the message
  '<his>  QSY QSY' is sent followed by one or more long CQ messages.
- The hang occurs when trying to substitute the '<his>' string with
  the user's callsign. The code to perform the substitution did not
  exist and the program stayed in an infinate loop. This effectively
  froze the UI.
- The first change adds code to throw an exception for the
  case where a substring is not substituted (e.g. '<his>').
- The second change overrides the virtual TStation.SendText
  method with TQrmStn.SendText to perform the substitution. This is
  required to preserve the special processing of the '<his>' token
  when using the `CallsFromKeyer` keyword (which, to my knowledge,
  has not been tested for sometime now).
