### PR TITLE
Self-monitor of user's CW can now be turned off

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -713,18 +713,24 @@ begin
     Blk := Me.GetBlock;
     //self-mon. gain
     Smg := Power(10, (MainForm.VolumeSlider1.Value - 0.75) * 4);
+
+    // apply linear rolloff towards zero between -57 and -60db (i.e. Smg=0 @ -60db)
+    if MainForm.VolumeSlider1.Value < 0.0375 then     // @ -57db, value = 3/80 = 0.0375
+      Smg := Smg * MainForm.VolumeSlider1.Value * 80; // 80 dB steps in [-60,+20dB]
+
     Rfg := 1;
-    for i:=0 to High(Blk) do
-      if Ini.Qsk
-        then
+    if Ini.Qsk
+      then
+        for i:=0 to High(Blk) do
            begin
-           if Rfg > (1 - Blk[i]/Me.Amplitude)
-             then Rfg := (1 - Blk[i]/Me.Amplitude)
+           if Rfg > (1 - Smg*Blk[i]/Me.Amplitude)
+             then Rfg := (1 - Smg*Blk[i]/Me.Amplitude)
              else Rfg := Rfg * 0.997 + 0.003;
            ReIm.Re[i] := Smg * Blk[i] + Rfg * ReIm.Re[i];
            ReIm.Im[i] := Smg * Blk[i] + Rfg * ReIm.Im[i];
            end
-        else
+      else
+        for i:=0 to High(Blk) do
           begin
           ReIm.Re[i] := Smg * (Blk[i]);
           ReIm.Im[i] := Smg * (Blk[i]);


### PR DESCRIPTION
- To turn off self-monitor, slide Mon-Level slider control to -60dB.
- Allows user's CW monitor to be completely silent.
- Adjusted QSK to remove annoying pumping sound when self-monitor is turned off.
- Internally added a linear rolloff algorithm between -57dB and -60dB allowing the Self-monitor gain to go to zero.