### PR TITLE
Monitor Level hint now displays full audio range

### DIFF
--- a/Ini.pas
+++ b/Ini.pas
@@ -263,6 +263,7 @@ var
   HiScore: integer;
   CompDuration: integer = 60;
 
+  SelfMonVolume: Integer = 0;
   SaveWav: boolean = false;
   FarnsworthCharRate: integer = 25;
   AllStationsWpmS: integer = 0;      // force all stations to this Wpm
@@ -424,9 +425,11 @@ begin
       V := Max(1, Min(5, V));
       BufSize := 64 shl V;
 
+      // [Station]
       V := ReadInteger(SEC_STN, 'SelfMonVolume', 0);
-      MainForm.VolumeSlider1.Value := V / 80 + 0.75;
-
+      V := max(-60, min(20, V));
+      SelfMonVolume := V;
+      MainForm.VolumeSlider1.Db := SelfMonVolume;
       SaveWav := ReadBool(SEC_STN, 'SaveWav', SaveWav);
 
       // [Settings]
@@ -451,7 +454,6 @@ end;
 
 procedure ToIni;
 var
-  V: integer;
   SC: TSimContest;
   KeyName: String;
 begin
@@ -509,9 +511,8 @@ begin
       WriteInteger(SEC_TST, 'HiScore', HiScore);
       WriteInteger(SEC_TST, 'CompetitionDuration', CompDuration);
 
-      V := Round(80 * (MainForm.VolumeSlider1.Value - 0.75));
-      WriteInteger(SEC_STN, 'SelfMonVolume', V);
-
+      // [Station]
+      WriteInteger(SEC_STN, 'SelfMonVolume', SelfMonVolume);
       WriteBool(SEC_STN, 'SaveWav', SaveWav);
 
       // [Settings]

--- a/Main.pas
+++ b/Main.pas
@@ -452,6 +452,15 @@ begin
   Histo:= THisto.Create(PaintBox1);
 
   AlSoundOut1.BufCount := 4;
+
+  // Initialize Volume Slider with dB range [-60dB, +20dB]
+  // (using direct calls to avoid merge issues in .dfm)
+  VolumeSlider1.DbMax := 20;
+  VolumeSlider1.DbScale := 80;
+  VolumeSlider1.HintStep := 3;
+  VolumeSlider1.Db := 0;            // sets value = 0.75
+
+  // Read settings from .INI file
   FromIni(
     procedure (const aMsg : string)
     begin
@@ -2289,16 +2298,14 @@ begin
   end;
 end;
 
+
+{
+  The Volume slider changes and Hint generation are handled within the VCL
+  Control. See VCL/VolmSldr.pas.
+}
 procedure TMainForm.VolumeSlider1Change(Sender: TObject);
 begin
-  with VolumeSlider1 do begin
-    //-60..+20 dB
-    Db := 80 * (Value - 0.75);
-    if dB > 0 then
-      Hint := Format('+%.0f dB', [dB])
-    else
-      Hint := Format( '%.0f dB', [dB]);
-    end;
+  Ini.SelfMonVolume := round(VolumeSlider1.Db);
 end;
 
 

--- a/VCL/VolmSldr.pas
+++ b/VCL/VolmSldr.pas
@@ -19,6 +19,7 @@ type
     FDownX: integer;
     FOverloaded: boolean;
     FShowHint: boolean;
+    FHintStep: Integer;
     FDbMax: Single;
     FDbScale: Single;
 
@@ -33,6 +34,7 @@ type
     function GetDb: Single;
     procedure UpdateHint;
     procedure SetDb(const AdB: Single);
+    procedure SetHintStep(const AHintStep: Integer);
   protected
     procedure Paint; override;
     procedure MouseDown(Button: TMouseButton; Shift: TShiftState;
@@ -43,6 +45,7 @@ type
     constructor Create(AOwner: TComponent); override;
   published
     property ShowHint: boolean read FShowHint write SetShowHint;
+    property HintStep: Integer read FHintStep write SetHintStep;
     property Margin: integer read FMargin write SetMargin;
     property Value: Single read FValue write SetValue;
     property Enabled;
@@ -82,6 +85,7 @@ begin
   ControlStyle := [csCaptureMouse, csClickEvents, csDoubleClicks, csOpaque];
   FHintWin := TPermanentHintWindow.Create(Self);
   FShowHint := true;
+  FHintStep := 0;
 
   FDbMax := 0;
   FDbScale := 60;
@@ -226,9 +230,32 @@ begin
   Result := DbMax + (FValue - 1) * DbScale;
 end;
 
+procedure TVolumeSlider.SetHintStep(const AHintStep: Integer);
+begin
+  FHintStep := max(0, AHintStep);
+  UpdateHint;
+end;
+
 procedure TVolumeSlider.UpdateHint;
 begin
-  Hint := Format('%.1f dB', [dB]);
+  case FHintStep of
+  0:
+    if dB > 0 then
+      Hint := Format('+%.1f dB', [dB])
+    else
+      Hint := Format(' %.1f dB', [dB]);
+  else
+    begin
+    var V: Single := FHintStep*round(dB/FHintStep);
+    //-60..+20 dB
+    if V > 0 then
+      Hint := Format('+%.0f dB', [min(FDbMax, V)])
+    else if V >= (FDbMax-FDbScale+FHintStep) then
+      Hint := Format( '%.0f dB', [max(FDbMax-FDbScale, V)])
+    else
+      Hint := 'Off';
+    end;
+  end;
 end;
 
 procedure TVolumeSlider.SetDb(const AdB: Single);


### PR DESCRIPTION
- Self-Monitor Volume Slider now displays full range (-60..+20dB),
- The dB Hints are now displayed in 3dB steps.
- Monitor Level hint now displays 'Off' when set to -60dB.

Detail...
- Previous code in Main.pas was overriding VolumeSlider's dB setting. This override was removed to allow Volumne Slider Control to fully handle the dB setting as the volume slider was changing its position.
- Hint is now handled in VCL Vol Slider control.
- Add Ini.SelfMonValue
- Ini.SelfMonVolume is updated as slider is moved.