### PR TITLE
326 caller ghosting with short or partial callsigns

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -774,8 +774,9 @@ begin
       if Stations[i] is TDxStation then
         with Stations[i] as TDxStation do
           if (Oper.State = osDone) and (QsoList <> nil) and
-            ((MyCall = QsoList[High(QsoList)].Call) or
-             (Oper.IsMyCall(QsoList[High(QsoList)].Call, False) = mcAlmost)) then begin
+            (Oper.CallConfidenceCheck(QsoList[High(QsoList)].Call, False)
+              in [mcYes, mcAlmost]) then
+            begin
               // grab Qso's "True" data (e.g. TrueCall, TrueExch1, TrueExch2)
               DataToLastQso; // deletes this TDxStation from Stations[]
 
@@ -808,7 +809,7 @@ begin
               Log.DisplayError('', clDefault);
               Log.SBarUpdateSummary('');
 }
-          end;
+            end;
 
   //show info
   ShowRate;
@@ -917,6 +918,11 @@ begin
              end;
           end;
        end;
+
+  //update caller's Confidence metric
+  if msgHisCall in Tst.Me.Msg then
+    Stations.FindBestMatches(Tst.Me.HisCall);
+
   //tell callers that I finished sending
   for i:=Stations.Count-1 downto 0 do
     Stations[i].ProcessEvent(evMeFinished);

--- a/DxOper.pas
+++ b/DxOper.pas
@@ -85,6 +85,8 @@ type
   TDxOperator = class
   private
     R2: Single;         // holds a Random number; used in MsgReceived, GetReply
+    LastCheckedCall: String;            // last call passed to IsMyCall()
+    LastCallCheck: TCallCheckResult;    // IsMyCall()'s last result
     procedure DecPatience;
     procedure MorePatience(AValue: integer = 0);
   public
@@ -97,6 +99,8 @@ type
                         // Patience is increased with calls to MorePatience.
     RepeatCnt: integer;
     State: TOperatorState;
+    CallConfidence: Integer;  // confidence-level of partial call match (0-100%).
+                              // set by IsMyCall.
     CorrectedCallAndExchSent: Boolean;  // DxOper has sent callsign correction
                                         // and exchange in one message.
     constructor Create(const ACall: string; AState: TOperatorState);
@@ -109,13 +113,15 @@ type
     procedure MsgReceived(AMsg: TStationMessages);
     procedure SetState(AState: TOperatorState);
     function GetReply: TStationMessage;
-    function IsMyCall(const ACall: string; ARandomResult: boolean): TCallCheckResult;
+    function IsMyCall(const APattern: string; ARandomResult: boolean;
+      ACallConfidencePtr: PInteger = nil): TCallCheckResult;
   end;
 
 
 implementation
 
 uses
+  PerlRegEx,        // for regular expression support
   SysUtils, Ini, Math, RndFunc, Contest, Log, Main;
 
 { TDxOperator }
@@ -129,6 +135,9 @@ begin
   Patience := 0;
   RepeatCnt := 1;
   SetState(AState);
+  LastCheckedCall := '';
+  LastCallCheck := mcNo;
+  CallConfidence := 0;
   CorrectedCallAndExchSent := false;
 end;
 
@@ -345,78 +354,159 @@ begin
 end;
 
 
-function TDxOperator.IsMyCall(const ACall: string;
-  ARandomResult: boolean): TCallCheckResult;
-const
-  W_X = 1; W_Y = 1; W_D = 1;
+{
+  IsMyCall() will compare the user-entered callsign (APattern) against this
+  operator's callsign. It supports wildcard search using '?' or substring
+  matches, including the starting, ending, or any substring within the call.
+  This will allow the user to partially match a received callsign using any
+  copied portion of the call, including a single character.
+
+  The algorithm uses several steps:
+  1. if the enter-call contains '?', then regular expression searching is used.
+     Each '?' will match a single character and a trailing '?' will match zero
+     or more characters at the end of the callsign.
+  2a. next, a dynamic programming algorithm called "edit distance" is used to
+      compute the number of wrong or missing characters.
+  2b. If no match is found, we search for the user-entered string to exist
+      anywhere within the callsign.
+  3. Finally, a call match Confidence value is computed to represent how
+     close the entered-string matches the operator's callsign. When multiple
+     callsigns partially match the entered string, the call(s) with the
+     highest confidence is used.
+
+  Confidence is defined as:
+      Confidence = 100 * (# matching characters) / callsign_length
+
+    Examples:
+      1. Call W7SST, searching with 'SST' has confidence = 60%.
+      2. Call K7OK, searching with 'OK', has confidence = 50%.
+      3. Given 4 calls, with entered search string 'W7AB'
+            W7ABC - confidence = 100*4/5 = 80%
+            W7ABX - confidence = 100*4/5 = 80%
+            W7AU  - confidence = 100*3/4 = 75%
+            W7ABU/6 - confidence = 100*4/7 = 57%
+         The first two calls with the highest confidence will respond
+         to the partial call match.
+}
+function TDxOperator.IsMyCall(const APattern: string; ARandomResult: boolean;
+  ACallConfidencePtr: PInteger): TCallCheckResult;
 var
-  C, C0: string;
+  C0: string;
   M: array of array of integer;
   x, y: integer;
-  T, L, D: integer;
-
   P: integer;
+  reg: TPerlRegEx;
 begin
   C0 := Call;
-  C := ACall;
+  reg := NIL;
 
-  SetLength(M, Length(C)+1, Length(C0)+1);
+  Result := mcNo;
 
-  //dynamic programming algorithm
+  if LastCheckedCall = APattern then
+    begin
+      Result := LastCallCheck;
+      if ACallConfidencePtr <> nil then ACallConfidencePtr^ := CallConfidence;
+    end
+  else
+    begin
+      LastCheckedCall := APattern;
 
-  for y:=0 to High(M[0]) do
-    M[0,y] := 0;
-  for x:=1 to High(M) do
-    M[x,0] := M[x-1,0] + W_X;
+      if APattern.Contains('?') then
+        try
+          reg := TPerlRegEx.Create();
+          if APattern.EndsWith('?') then
+            reg.RegEx := APattern.Replace('?','.') + '*'
+          else
+            reg.RegEx := APattern.Replace('?','.');
+          reg.Subject := C0;
+          if reg.Match then
+            begin
+              Result := mcAlmost;
+              // count incorrect characters
+              P := C0.Length - APattern.Replace('?', '', [rfReplaceAll]).Length;
+              // confidence = 100 * correct chars / total length
+              CallConfidence := (100 * (C0.Length - P)) div C0.Length;
+            end
+          else
+            begin
+              Result := mcNo;
+              CallConfidence := 0;
+            end;
+        finally
+          FreeAndNil(reg);
+        end
+      else
+        begin
+          //dynamic programming algorithm to determine "Edit Distance", which is
+          //the number of character edits needed for the two strings to match.
+          SetLength(M, Length(APattern)+1, Length(C0)+1);
+          for x:=0 to High(M) do
+            M[x,0] := x;
+          for y:=0 to High(M[0]) do
+            M[0,y] := y;
 
-  for x:=1 to High(M) do
-    for y:=1 to High(M[0]) do begin
-      T := M[x,y-1];
-      //'?' can match more than one char
-      //end may be missing
-      if (x < High(M)) and (C[x] <> '?') then
-        Inc(T, W_Y);
+          for x:=1 to High(M) do
+            for y:=1 to High(M[0]) do begin
+              if APattern[x] = C0[y] then
+                M[x][y] := M[x - 1][y - 1]
+              else
+                M[x][y] := 1 + MinIntValue([M[x    ][y - 1],
+                                            M[x - 1][y    ],
+                                            M[x - 1][y - 1]]);
+            end;
 
-      L := M[x-1,y];
-      //'?' can match no chars
-      if C[x] <> '?' then Inc(L, W_X);
+          //classify by penalty
+          //Penalty is the Edit Distance (# of missing or invalid characters)
+          P := M[High(M), High(M[0])];
+          if (P = 0) then
+            Result := mcYes
+          else if P <= (C0.Length-1)/2 then
+            Result := mcAlmost
+          else
+            Result := mcNo;
 
-      D := M[x-1,y-1];
-      //'?' matches any char
-      //if not (C[x] in [C0[y], '?']) then Inc(D, W_D);
-      if not (CharInSet(C[x], [C0[y], '?'])) then Inc(D, W_D);
+          //partial match for matching any substring within the call
+          if (Result = mcNo) and C0.Contains(APattern) then
+            begin
+              Result := mcAlmost;
+              P := C0.Length - APattern.Length;
+            end;
 
-      M[x,y] := MinIntValue([T,D,L]);
+          // confidence = 100 * correct chars / total length
+          case Result of
+            mcYes: CallConfidence := 100;
+            mcAlmost: CallConfidence := 100 * (C0.Length - P) div C0.Length;
+            mcNo: CallConfidence := 0;
+          end;
+        end;
+
+      LastCallCheck := Result;
+      if ACallConfidencePtr <> nil then ACallConfidencePtr^ := CallConfidence;
     end;
 
-  P := M[High(M), High(M[0])];
-
-  if (P = 0) then
-    Result := mcYes
-  else if (((Length(C0) <= 4) and (Length(C0) - P >= 3)) or
-       ((Length(C0) > 4) and (Length(C0) - P >= 4))) then
-    Result := mcAlmost
-  else
-    Result := mcNo;
-
-  //callsign-specific corrections
-
-  if (not Ini.Lids) and (Length(C) = 2) and (Result = mcAlmost) then Result := mcNo;
-
-  //partial and wildcard match result in 0 penalty but are not exact matches
-  if (Result = mcYes) then
-    if (Length(C) <> Length(C0)) or (Pos('?', C) > 0)
-      then Result := mcAlmost;
-
-  //partial match too short
-  if Length(StringReplace(C, '?', '', [rfReplaceAll])) < 2 then Result := mcNo;
-
   //accept a wrong call, or reject the correct one
-  if ARandomResult and Ini.Lids and (Length(C) > 3) then
-    case Result of
-      mcYes: if Random < 0.01 then Result := mcAlmost;   // LID rejects correct call; sends <HisCall>
-      mcAlmost: if Random < 0.04 then Result := mcYes;   // LID accepts a wrong call; doesn't correct a partial call
-      end;
+  if ARandomResult and Ini.Lids and (Length(APattern) > 3) then
+    begin
+      case Result of
+        mcYes: if Random < 0.01 then
+          begin
+            // LID rejects correct call; sends <HisCall>
+            Result := mcAlmost;
+            if ACallConfidencePtr <> nil then
+              ACallConfidencePtr^ := 100 * (C0.Length-1) div C0.Length;
+          end;
+        mcAlmost: if Random < 0.04 then
+          begin
+            // LID accepts a wrong call; doesn't correct a partial call
+            Result := mcYes;
+            if ACallConfidencePtr <> nil then
+              ACallConfidencePtr^ := 100;
+          end;
+        end;
+    end;
+end;
+
+
 end;
 
 

--- a/Log.pas
+++ b/Log.pas
@@ -886,7 +886,7 @@ begin
     for i:=Tst.Stations.Count-1 downto 0 do
       if Tst.Stations[i] is TDxStation then
         with Tst.Stations[i] as TDxStation do
-          if ((MyCall = Qso.Call) or (Oper.IsMyCall(Qso.Call, False) = mcAlmost)) then
+          if Oper.CallConfidenceCheck(Qso.Call, False) in [mcYes, mcAlmost] then
           begin
             Qso.TrueWpm := WpmAsText();
             Break;
@@ -897,7 +897,7 @@ begin
       if Tst.Stations[i] is TDxStation then
         with Tst.Stations[i] as TDxStation do
           if (Oper.State = osDone) and
-             ((MyCall = Qso.Call) or (Oper.IsMyCall(Qso.Call, False) = mcAlmost)) then
+            (Oper.CallConfidenceCheck(Qso.Call, False) in [mcYes, mcAlmost]) then
             begin
               DataToLastQso; //grab "True" data and delete this dx station!
               Tst.ResetQsoState;

--- a/Test/DxOperTest.pas
+++ b/Test/DxOperTest.pas
@@ -1,0 +1,440 @@
+unit DxOperTest;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  TCallCheckResult = (mcNo, mcYes, mcAlmost);
+  TIni = record
+    LIDs: boolean;
+  end;
+
+  [TestFixture]
+  TestDxOperIsMyCall = class
+  var
+    DbgBreak: boolean;
+    Penalty: Integer;
+    Call: String;
+    LastCheckedCall: String;
+    LastCallCheck: TCallCheckResult;
+    CallConfidence: Integer;  // confidence-level of partial call match (0-100%).
+                              // set by IsMyCall.
+
+    Ini: TIni;
+
+  protected
+    function IsMyCall(const APattern: string;
+      ARandomResult: boolean;
+      ACallConfidencePtr: PInteger = nil): TCallCheckResult;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
+
+    [Test(True)]
+    [Category('Wildcard')]
+    [TestCase('Wild.11',  'AA0AA, W?,     N')]
+    [TestCase('Wild.11',  'AA0AA, W?,     N')]
+    [TestCase('Wild.1',   'AA0AA, AA0?,   P')]
+    [TestCase('Wild.2',   'AA0AA, AA0??,  P')]
+    [TestCase('Wild.3',   'AA0AA, ??0??,  P')]
+    [TestCase('Wild.4',   'AA0AA, ??0AA,  P')]
+    [TestCase('Wild.5',   'AA0AA, A?0?A,  P')]
+    [TestCase('Wild.6',   'AA0AA, ?A0A?,  P')]
+    [TestCase('Wild.7',   'AA0AA, A?0?,   P')]
+    [TestCase('Wild.8',   'AA0AA, AA?,    P')]
+    [TestCase('Wild.9',   'AA0AA, A?,     P')]
+    [TestCase('Wild.10',  'AA0AA, ?,      P')]  // interesting. If '?' is sent, we want all stations to almost match
+    [TestCase('Wild.11',  'AA0AA, W?,     N')]
+    [TestCase('Wild.12',  'AA0AA, W7?,    N')]
+    [TestCase('Wild.13',  'AA0AA, W7S?,   N')]
+    [TestCase('Wild.14',  'AA0AA, W7SS?,  N')]
+    [TestCase('Wild.15',  'AA0AA, W7SST?, N')]
+    [TestCase('Wild.16',  'AA0AA, W7SST?, N')]
+
+    [Test(True)]
+    [Category('1x1 Calls')]
+    [TestCase('1x1.1',   'W7S,    W7S,    Y')]
+    [TestCase('1x1.2',   'W7S,    A0X,    N')]
+    [TestCase('1x1.3',   'W7S,    W7,     P')]
+    [TestCase('1x1.4',   'W7S,    W7X,    P')]
+    [TestCase('1x1.5',   'W7S,    W7XX,   N')]
+    [TestCase('1x1.6',   'W7S,    W7XXX,  N')]
+    [TestCase('1x1.7',   'W7S,    W6S,    P')]
+    [TestCase('1x1.8',   'W7S,    W6X,    N')]
+    [TestCase('1x1.9',   'W7S,    A7S,    P')]
+    [TestCase('1x1.10',  'W7S,    W7SSS,  N')]
+    [TestCase('1x1.11',  'W7S,    W7S,    Y')]
+    [TestCase('1x1.12',  'W7S,    W7S,    Y')]
+
+    [Category('1x2 Calls')]
+    [TestCase('1x2.1',   'W7SS,   W7SS,   Y')]
+    [TestCase('1x2.2',   'W7SS,   W7S,    P')]
+    [TestCase('1x2.3',   'W7SS,   W7,     P')]
+    [TestCase('1x2.4',   'W7SS,   W7SST,  P')]
+    [TestCase('1x2.5',   'W7SS,   A7SS,   P')]
+    [TestCase('1x2.6',   'W7SS,   A7SST,  N')]
+    [TestCase('1x2.7',   'W7SS,   S,      P')]
+    [TestCase('1x2.8',   'W7SS,   SS,     P')]
+    [TestCase('1x2.9',   'W7SS,   7SS,    P')]
+    [TestCase('1x2.10',  'W7SS,   W7SS,   Y')]
+    [TestCase('1x2.11',  'W7AU,   W7AB,   P')]
+
+    [Category('1x3 Calls')]
+    [TestCase('1x3.1',   'W7SST,  W7SST,  Y')]
+    [TestCase('1x3.1b',  'W7SST,  W7SSTT, P')]
+    [TestCase('1x3.2',   'W7SST,  W7,     P')]
+    [TestCase('1x3.3',   'W7SST,  W7S,    P')]
+    [TestCase('1x3.4',   'W7SST,  W7SS,   P')]
+    [TestCase('1x3.5',   'W7SST,  W7SSS,  P')]
+    [TestCase('1x3.6',   'W7SST,  A7SST,  P')]
+    [TestCase('1x3.7',   'W7SST,  W7ABC,  N')]
+    [TestCase('1x3.8',   'W7SST,  T,      P')]
+    [TestCase('1x3.8',   'W7SST,  ST,     P')]
+    [TestCase('1x3.9',   'W7SST,  SST,    P')]
+    [TestCase('1x3.10',  'W7SST,  7SS,    P')]
+    [TestCase('1x3.11',  'W7SST,  W7XST,  P')]
+    [TestCase('1x3.12',  'W7SST,  W7??T,  P')]
+
+    [Category('1x3/9 Calls')]
+    [TestCase('1x3/9.1',   'W7SST/9,  W7SST/9,  Y')]
+    [TestCase('1x3/9.1b',  'W7SST/9,  W7SSTT/9, P')]
+    [TestCase('1x3/9.1c',  'W7SST/9,  W7SST/8, P')]
+    [TestCase('1x3/9.2',   'W7SST/9,  W7,     P')]
+    [TestCase('1x3/9.3',   'W7SST/9,  W7S,    P')]
+    [TestCase('1x3/9.4',   'W7SST/9,  W7SS,   P')]
+    [TestCase('1x3/9.5',   'W7SST/9,  W7SSS,  P')]
+    [TestCase('1x3/9.6',   'W7SST/9,  A7SST,  P')]
+    [TestCase('1x3/9.7',   'W7SST/9,  W7ABC,  N')]
+    [TestCase('1x3/9.8',   'W7SST/9,  T,      P')]
+    [TestCase('1x3/9.8',   'W7SST/9,  ST,     P')]
+    [TestCase('1x3/9.9',   'W7SST/9,  SST,    P')]
+    [TestCase('1x3/9.10',  'W7SST/9,  7SS,    P')]
+    [TestCase('1x3/9.11',  'W7SST/9,  W7XST,  P')]
+    [TestCase('1x3/9.12',  'W7SST/9,  W7??T,  P')]
+    [TestCase('1x3/9.13',  'W7SST/9,  W7??T?, P')]
+    [TestCase('1x3/9.14',  'W7SST/9,  W7??T/?,P')]
+    [TestCase('1x3/9.15',  'W7SST/9,  W7SST?, P')]
+    [TestCase('1x3/9.16',  'W7ABU/9,  W7AB,   P')]
+
+    [Category('2x2 Calls')]
+    [TestCase('2x2.1',   'AA0AA,  AA0AA,  Y')]
+    [TestCase('2x2.2',   'AA0AA,  AA0A,   P')]
+    [TestCase('2x2.3',   'AA0AA,  AA0,    P')]
+    [TestCase('2x2.4',   'AA0AA,  AA,     P')]
+    [TestCase('2x2.5',   'AA0AA,  A,      P')]
+    [TestCase('2x2.6',   'AA0AA,  A0AA,   P')]
+    [TestCase('2x2.7',   'AA0AA,  0AA,    P')]
+    [TestCase('2x2.8',   'AA0AA,  AA,     P')]
+    [TestCase('2x2.9',   'AA0AA,  A,      P')]
+    [TestCase('2x2.10',  'AA0AA,  A0A,    P')]
+    [TestCase('2x2.11',  'AA0AA,  0A,     P')]
+    [TestCase('2x2.12',  'AA0AA,  A0,     P')]
+    [TestCase('2x2.13',  'AA0AA,  AA7AA,  P')]
+    [TestCase('2x2.14',  'AA0AA,  AA7BB,  N')]
+    [TestCase('2x2.15',  'AA0AA,  AA7BBB, N')]
+    [TestCase('2x2.16',  'AA0AA,  AB7CD,  N')]
+    [TestCase('2x2.17',  'AA0AA,  AA0AA/7,  P')]
+    [TestCase('2x2.18',  'AA0AA,     FY/AA0AA, N')]  // 3 extra chars; 2 wrong chars allowed for 5 character call
+    [TestCase('2x2.19',  'AA0AA,     FY,       N')]
+    [TestCase('2x2.19',  'FY/AA0AA,  FY,       P')]
+    [TestCase('2x2.20',  'FY/AA0AA,  FY/,      P')]
+    [TestCase('2x2.21',  'FY/AA0AA,  FY/AA,    P')]
+
+    [Category('2x3 Calls')]
+    [TestCase('2x3.1',   'WN7SST, WN7SST, Y')]
+    [TestCase('2x3.2',   'WN7SST, WN,     P')]
+    [TestCase('2x3.3',   'WN7SST, WN7,    P')]
+    [TestCase('2x3.4',   'WN7SST, WN7S,   P')]
+    [TestCase('2x3.5',   'WN7SST, WN7SS,  P')]
+    [TestCase('2x3.6',   'WN7SST, WN7SSS, P')]
+    [TestCase('2x3.7',   'WN7SST, AN7SST, P')]
+    [TestCase('2x3.8',   'WN7SST, WN7ABC, N')]
+    [TestCase('2x3.9',   'WN7SST, T,      P')]
+    [TestCase('2x3.10',  'WN7SST, ST,     P')]
+    [TestCase('2x3.11',  'WN7SST, SST,    P')]
+    [TestCase('2x3.12',  'WN7SST, 7SS,    P')]
+    [TestCase('2x3.13',  'WN7SST, WN7XST, P')]
+    [TestCase('2x3.14',  'WN7SST, WN7??T, P')]
+    [TestCase('2x3.15',  'WN7SST, W7SST,  P')]
+    [TestCase('2x3.16',  'WN7SST, W7ST,   P')]
+    [TestCase('2x3.17',  'WN7SST, WN7ST,  P')]
+    [TestCase('2x3.18',  'WN7SST, W7AB,   N')]
+    [TestCase('2x3.19',  'WN7SST, W7ABC,  N')]
+    [TestCase('2x3.20',  'WN7SST, 7,      P')]
+
+    [Category('FY/2x3 Calls')]
+    [TestCase('FY/2x3.1',   'FY/WN7SST, FY/WN7SST, Y')]
+    [TestCase('FY/2x3.1b',  'FY/WN7SST, FY/WN7SST, Y')]
+    [TestCase('FY/2x3.2',   'FY/WN7SST, WN,     P')]
+    [TestCase('FY/2x3.3',   'FY/WN7SST, WN7,    P')]
+    [TestCase('FY/2x3.4',   'FY/WN7SST, WN7S,   P')]
+    [TestCase('FY/2x3.5',   'FY/WN7SST, WN7SS,  P')]
+    [TestCase('FY/2x3.6',   'FY/WN7SST, WN7SSS, P')]
+    [TestCase('FY/2x3.7',   'FY/WN7SST, AN7SST, P')]
+    [TestCase('FY/2x3.8',   'FY/WN7SST, WN7ABC, N')]
+    [TestCase('FY/2x3.9',   'FY/WN7SST, T,      P')]
+    [TestCase('FY/2x3.10',  'FY/WN7SST, ST,     P')]
+    [TestCase('FY/2x3.11',  'FY/WN7SST, SST,    P')]
+    [TestCase('FY/2x3.12',  'FY/WN7SST, 7SS,    P')]
+    [TestCase('FY/2x3.13',  'FY/WN7SST, WN7XST, P')]
+    [TestCase('FY/2x3.14',  'FY/WN7SST, WN7??T, P')]
+    [TestCase('FY/2x3.15',  'FY/WN7SST, W7SST,  P')]
+    [TestCase('FY/2x3.16',  'FY/WN7SST, W7ST,   N')]
+    [TestCase('FY/2x3.17',  'FY/WN7SST, WN7ST,  P')]
+    [TestCase('FY/2x3.18',  'FY/WN7SST, W7AB,   N')]
+    [TestCase('FY/2x3.19',  'FY/WN7SST, W7ABC,  N')]
+    [TestCase('FY/2x3.20',  'FY/WN7SST, FY,     P')]
+    [TestCase('FY/2x3.21',  'FY/WN7SST, FY?,    P')]
+    [TestCase('FY/2x3.22',  'FY/WN7SST, FY/WN7, P')]
+    [TestCase('FY/2x3.23',  'FY/WN7SST, FY/,    P')]
+    [TestCase('FY/2x3.24',  'FY/WN7SST, FY/W?7, P')]
+    [TestCase('FY/2x3.25',  'FY/WN7SST, FX/W7SST, P')]
+
+    [Category('2x3/9 Calls')]
+    [TestCase('2x3/9.1',   'WN7SST/9, WN7SST/9, Y')]
+    [TestCase('2x3/9.2',   'WN7SST/9, WN,     P')]
+    [TestCase('2x3/9.3',   'WN7SST/9, WN7,    P')]
+    [TestCase('2x3/9.4',   'WN7SST/9, WN7S,   P')]
+    [TestCase('2x3/9.5',   'WN7SST/9, WN7SS,  P')]
+    [TestCase('2x3/9.6',   'WN7SST/9, WN7SSS, P')]
+    [TestCase('2x3/9.7',   'WN7SST/9, AN7SST, P')]
+    [TestCase('2x3/9.8',   'WN7SST/9, WN7ABC, N')]
+    [TestCase('2x3/9.9',   'WN7SST/9, T,      P')]
+    [TestCase('2x3/9.10',  'WN7SST/9, ST,     P')]
+    [TestCase('2x3/9.11',  'WN7SST/9, SST,    P')]
+    [TestCase('2x3/9.12',  'WN7SST/9, 7SS,    P')]
+    [TestCase('2x3/9.13',  'WN7SST/9, WN7XST, P')]
+    [TestCase('2x3/9.14',  'WN7SST/9, WN7??T, P')]
+    [TestCase('2x3/9.15',  'WN7SST/9, W7SST,  P')]
+    [TestCase('2x3/9.16',  'WN7SST/9, W7ST,   N')]
+    [TestCase('2x3/9.17',  'WN7SST/9, WN7ST,  P')]
+    [TestCase('2x3/9.18',  'WN7SST/9, W7AB,   N')]
+    [TestCase('2x3/9.19',  'WN7SST/9, W7ABC,  N')]
+    [TestCase('2x3/9.20',  'WN7SST/9, FY,     N')]
+    [TestCase('2x3/9.21',  'WN7SST/9, FY?,    N')]
+    [TestCase('2x3/9.22',  'WN7SST/9, /9,     P')]
+    [TestCase('2x3/9.23',  'WN7SST/9, 9,      P')]
+    [TestCase('2x3/9.23b', 'WN7SST/9, 6,      N')]
+    [TestCase('2x3/9.23c', 'WN7SST/9, 7,      P')]
+    [TestCase('2x3/9.24',  'WN7SST/9, T/9,    P')]
+    [TestCase('2x3/9.25',  'WN7SST/9, SST/9,  P')]
+    [TestCase('2x3/9.26',  'WN7SST/9, 7SST/9, P')]
+    [TestCase('2x3/9.27',  'WN7SST/9, WN7?/9, N')]
+    [TestCase('2x3/9.28',  'WN7SST/9, WN7???/9, P')]
+
+    procedure RunTest(const ADxCall, AEnteredCall, AExpected: string);
+  end;
+
+implementation
+
+uses
+  Math,             // for MaxIntValue
+  TypInfo,          // for typeInfo
+  PerlRegEx,        // for regular expression support
+  System.SysUtils;
+
+function ToStr(const val : TCallCheckResult) : string; overload;
+begin
+  Result := GetEnumName(typeInfo(TCallCheckResult), Ord(val));
+end;
+
+procedure TestDxOperIsMyCall.SetupFixture;
+begin
+  LastCheckedCall := '';
+  LastCallCheck := mcNo;
+  CallConfidence := 0;
+  Ini.LIDs := False;
+end;
+
+procedure TestDxOperIsMyCall.TearDownFixture;
+begin
+end;
+
+procedure TestDxOperIsMyCall.RunTest(const ADxCall, AEnteredCall, AExpected: string);
+var
+  R, Expected: TCallCheckResult;
+  EnteredCall: String;
+  S, T: string;
+
+  procedure RunAlgo(var S: String; const EnteredCall:string;
+    Expected: TCallCheckResult);
+  var
+    R: TCallCheckResult;
+    Confidence: Integer;
+    T: String;
+  begin
+    LastCheckedCall := '';
+    LastCallCheck := mcNo;
+    CallConfidence := 0;
+    T := '';
+    R := IsMyCall(EnteredCall, False, @Confidence);
+    if R <> Expected then
+      begin
+    {$ifdef DEBUG}
+        DbgBreak := True;
+        //LastCheckedCall := '';
+        //R := IsMyCall(EnteredCall, False, @Confidence);
+        //LastCheckedCall := '';
+        //R := IsMyCall(EnteredCall, False, @Confidence);
+    {$endif}
+        T := format('    %s, Entered: ''%s'' --> %s, %s expected, P=%d.',
+          [Self.Call, EnteredCall, ToStr(R), ToStr(Expected), Self.Penalty]);
+        S := S + #10 + T;
+      end;
+  end;
+begin
+{$ifdef DEBUG}
+  DbgBreak := False;
+{$endif}
+  // TCallCheckResult = (mcNo, mcYes, mcAlmost);
+  case AExpected.Trim[1] of
+    'N': Expected := mcNo;
+    'Y': Expected := mcYes;
+    'P': Expected := mcAlmost;
+    else Assert.FailFmt('Invalid Expected value: %s; expecting N(mcNo), Y(mcYes), P(mcAlmost)', [AExpected]);
+  end;
+  Self.Call := ADxCall.Trim;
+  EnteredCall := AEnteredCall.Trim;
+
+  RunAlgo(S, EnteredCall, Expected);    // Revised RegEx and DP Algorithm (1.85.2)
+  if S <> '' then Assert.Fail(S);
+end;
+
+
+{
+  Below is a copy of TDxOperator.IsMyCall().
+  (This will be refactored in the future)
+}
+function TestDxOperIsMyCall.IsMyCall(const APattern: string;
+  ARandomResult: boolean;
+  ACallConfidencePtr: PInteger): TCallCheckResult;
+var
+  C0: string;
+  M: array of array of integer;
+  x, y: integer;
+  P: integer;
+  reg: TPerlRegEx;
+begin
+  C0 := Call;
+  reg := NIL;
+
+  Result := mcNo;
+
+  if LastCheckedCall = APattern then
+    begin
+      Result := LastCallCheck;
+      if ACallConfidencePtr <> nil then ACallConfidencePtr^ := CallConfidence;
+    end
+  else
+    begin
+      LastCheckedCall := APattern;
+
+      if APattern.Contains('?') then
+        try
+          reg := TPerlRegEx.Create();
+          if APattern.EndsWith('?') then
+            reg.RegEx := APattern.Replace('?','.') + '*'
+          else
+            reg.RegEx := APattern.Replace('?','.');
+          reg.Subject := C0;
+          if reg.Match then
+            begin
+              Result := mcAlmost;
+              // count incorrect characters
+              P := C0.Length - APattern.Replace('?', '', [rfReplaceAll]).Length;
+              Self.Penalty := p;
+              // confidence = 100 * correct chars / total length
+              CallConfidence := (100 * (C0.Length - P)) div C0.Length;
+            end
+          else
+            begin
+              Result := mcNo;
+              CallConfidence := 0;
+            end;
+        finally
+          FreeAndNil(reg);
+        end
+      else
+        begin
+          //dynamic programming algorithm to determine "Edit Distance", which is
+          //the number of character edits needed for the two strings to match.
+          SetLength(M, Length(APattern)+1, Length(C0)+1);
+          for x:=0 to High(M) do
+            M[x,0] := x;
+          for y:=0 to High(M[0]) do
+            M[0,y] := y;
+
+          for x:=1 to High(M) do
+            for y:=1 to High(M[0]) do begin
+              if APattern[x] = C0[y] then
+                M[x][y] := M[x - 1][y - 1]
+              else
+                M[x][y] := 1 + MinIntValue([M[x    ][y - 1],
+                                            M[x - 1][y    ],
+                                            M[x - 1][y - 1]]);
+            end;
+
+          //classify by penalty
+          //Penalty is the Edit Distance (# of missing or invalid characters)
+          P := M[High(M), High(M[0])];
+          Self.Penalty := M[High(M), High(M[0])];
+          if (P = 0) then
+            Result := mcYes
+          else if P <= (C0.Length-1)/2 then
+            Result := mcAlmost
+          else
+            Result := mcNo;
+
+          //partial match for matching any substring within the call
+          if (Result = mcNo) and C0.Contains(APattern) then
+            begin
+              Result := mcAlmost;
+              P := C0.Length - APattern.Length;
+              Self.Penalty := P;
+            end;
+
+          // confidence = 100 * correct chars / total length
+          case Result of
+            mcYes: CallConfidence := 100;
+            mcAlmost: CallConfidence := 100 * (C0.Length - P) div C0.Length;
+            mcNo: CallConfidence := 0;
+          end;
+        end;
+
+      LastCallCheck := Result;
+      if ACallConfidencePtr <> nil then ACallConfidencePtr^ := CallConfidence;
+    end;
+
+  //accept a wrong call, or reject the correct one
+  if ARandomResult and Ini.Lids and (Length(APattern) > 3) then
+    begin
+      case Result of
+        mcYes: if Random < 0.01 then
+          begin
+            // LID rejects correct call; sends <HisCall>
+            Result := mcAlmost;
+            if ACallConfidencePtr <> nil then
+              ACallConfidencePtr^ := 100 * (C0.Length-1) div C0.Length;
+//            DebugLn('DxOper.IsMyCall(%s): mcYes->mcAlmost, LID rejects correct call', [Call]);
+          end;
+        mcAlmost: if Random < 0.04 then
+          begin
+            // LID accepts a wrong call; doesn't correct a partial call
+            Result := mcYes;
+            if ACallConfidencePtr <> nil then
+              ACallConfidencePtr^ := 100;
+//            DebugLn('DxOper.IsMyCall(%s): mcAlmost->mcYes, LID accepts wrong call', [Call]);
+          end;
+        end;
+    end;
+end;
+
+
+initialization
+  TDUnitX.RegisterTestFixture(TestDxOperIsMyCall);
+
+end.

--- a/Test/UnitTests.dpr
+++ b/Test/UnitTests.dpr
@@ -22,7 +22,8 @@ uses
   LexerTest in 'LexerTest.pas',
   SSLexerTest in 'SSLexerTest.pas',
   MySSExchTest in 'MySSExchTest.pas',
-  SSExchParserTest in 'SSExchParserTest.pas';
+  SSExchParserTest in 'SSExchParserTest.pas',
+  DxOperTest in 'DxOperTest.pas';
 
 {$IFNDEF TESTINSIGHT}
 var

--- a/Test/UnitTests.dproj
+++ b/Test/UnitTests.dproj
@@ -54,6 +54,7 @@
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
         <DCC_UnitSearchPath>$(DUnitX);$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <SanitizedProjectName>UnitTests</SanitizedProjectName>
+        <DCC_Define>UNIT_TESTS;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_UsePackage>soapserver;IndySystem;MorseRunnerVcl;vclwinx;fmx;vclie;DbxCommonDriver;bindengine;vcldb;IndyIPCommon;VCLRESTComponents;FireDACCommonODBC;FireDACCommonDriver;appanalytics;IndyProtocols;vclx;IndyIPClient;dbxcds;vcledge;vclFireDAC;bindcompvclwinx;bindcomp;FireDACCommon;IndyCore;RESTBackendComponents;bindcompfmx;bindcompdbx;inetdb;rtl;FireDACMySQLDriver;FireDACSqliteDriver;DbxClientDriver;FireDACADSDriver;RESTComponents;soapmidas;DBXSqliteDriver;vcl;vclactnband;IndyIPServer;dsnapxml;fmxFireDAC;dbexpress;dsnapcon;adortl;DBXMySQLDriver;VclSmp;inet;vclimg;vcltouch;FireDACPgDriver;FireDAC;fmxase;inetdbxpress;xmlrtl;tethering;dbrtl;bindcompvcl;dsnap;fmxdae;CloudService;FireDACMSAccDriver;CustomIPTransport;fmxobj;bindcompvclsmp;soaprtl;vcldsnap;DBXInterBaseDriver;FireDACIBDriver;$(DCC_UsePackage)</DCC_UsePackage>
@@ -77,6 +78,10 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>(None)</Manifest_File>
+        <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
+        <DCC_Define>UNIT_TESTS=1;$(DCC_Define)</DCC_Define>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
@@ -98,6 +103,7 @@
         <DCCReference Include="SSLexerTest.pas"/>
         <DCCReference Include="MySSExchTest.pas"/>
         <DCCReference Include="SSExchParserTest.pas"/>
+        <DCCReference Include="DxOperTest.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -118,6 +124,10 @@
                 <Source>
                     <Source Name="MainSource">UnitTests.dpr</Source>
                 </Source>
+                <Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dcloffice2k280.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dclofficexp280.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
+                </Excluded_Packages>
             </Delphi.Personality>
             <Deployment Version="4">
                 <DeployFile LocalName="$(BDS)\Redist\iossimulator\libcgunwind.1.0.dylib" Class="DependencyModule">


### PR DESCRIPTION
Here are my checkin notes. There are two checkins.

1)    Improve callsign comparison function
    
    - Issue #326 (part 1 of 2 changes)
    - TDxOperator.IsMyCall had several problems. these have been fixed.
    - In 2018, the callsign match function was modified to better
      handle longer callsigns. However, this change affected
      3-character callsigns.
    - this change implements an improved algorithm using
      a) regular expression pattern matching to handle '?' wildcards,
      b) dynamic programming implementation of the Edit Distance algorithm.
         Edit Distance represents number of wrong or missing characters.
    - This new implementation fixes shortcomings in both the original
      and 2018 implementations.
    - Introduce notion of a caller Confidence factor showing the confidence
      of callsign match:
        Confidence = 100 * correct_char_cnt / total_char_cnt
      For example: Given call W7SST and search string 'W7ST',
        Confidence = 100 * 4 / 5 = 80%
    - This confidence factor will be used to select the best matches
      from several partial callsign matches.

2)    Improve handling of multiple partial callsign matches
    
    - Issue #326 (part 2 of 2 changes)
    - add TDxOperator.CallConfidence to hold individual partial callsign
      match value. This allows the best callsign match to have the highest
      confidence. When multiple stations are calling, only the station with
      the highest confidence value will answer the user.
    - CallConfidence = 100 * #correct_characters / #total_characters.
    - CallConfidence is computed after user sends HisCall.
    - Calls to compare callsigns are now made with TDxOper.CallConfidenceCheck().
      This new function will return partial calls whose CallConfidence value
      meets or exceeds the minimum threshold level computed across all active
      stations.

[Here](https://1drv.ms/u/c/353d3bde42947823/EaRoBIsuUKpGvvu28CEe-ucBO30e4by38I94v6K1Iik7dw?e=DBNAkp) is a link to a test build containing this fix (and the other change requests).