### PR TITLE
Fix issue where DxStn will keep sending after TU

### DIFF
--- a/DxStn.pas
+++ b/DxStn.pas
@@ -193,6 +193,20 @@ begin
             TimeOut := Oper.GetSendDelay; //reply or switch to standby
             State := stPreparingToSend;
           end;
+        end
+      // special case where user is sending 'TU' with a partial callsign
+      else if State = stSending then
+        begin
+          { Special case where the user has sent an incorrect/partial callsign
+            and this DxStation/DxOperator is re-sending their correct callsign.
+            However, the user just sent 'TU', indicating that they have
+            finished the QSO and moving on to the next caller. In this
+            case, we want this DxStation to finish the QSO (by setting their
+            Oper.State = osDone). Once complete, this station will stop
+            sending, the log will be updated and report the incorrect callsign.
+          }
+          if (Oper.State = osNeedCall) and (msgTU in Tst.Me.Msg) then
+            Oper.MsgReceived(Tst.Me.Msg);
         end;
 
     evMeStarted:


### PR DESCRIPTION
- Issue #403
- Special case where the user has sent an incorrect/partial callsign and this DxStation/DxOperator is re-sending their correct callsign.
- However, the user just sent 'TU', indicating that they have finished the QSO and moving on to the next caller. In this case, we want this DxStation to finish the QSO (by setting their Oper.State = osDone).
- Once complete, this station will stop sending, the log will be updated to report the incorrect callsign.

[Here](https://1drv.ms/u/c/353d3bde42947823/EaRoBIsuUKpGvvu28CEe-ucBO30e4by38I94v6K1Iik7dw?e=DBNAkp) is a link to a test build containing this fix (and the other change requests).