### PR TITLE
Fix ghosting station after starting a QSO

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -462,7 +462,8 @@ begin
 
       mcNo:
         if State = osNeedQso then State := osNeedPrevEnd
-        else if State in [osNeedNr, osNeedCall, osNeedCallNr] then State := osFailed
+        else if State in [osNeedNr, osNeedCall, osNeedCallNr] then
+          State := osNeedPrevEnd
         else if State = osNeedEnd then State := osDone;
      end;
 


### PR DESCRIPTION
- Issue #404
- When a simulated station is participating in a QSO and has started to exchange QSO information with the user and then receives a different callsign, the station will standby and wait for a new QSO cycle to being.
- In the prior version, this station would disappear. This has been referred to as caller ghosting.

[Here](https://1drv.ms/u/c/353d3bde42947823/EaRoBIsuUKpGvvu28CEe-ucBO30e4by38I94v6K1Iik7dw?e=DBNAkp) is a link to a test build containing this fix (and the other change requests).