### PR TITLE
Calling station will exit QSO when caller and user are both sending

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -514,8 +514,20 @@ begin
     end;
   end;
 
-  if (not Ini.Lids) and (AMsg = [msgGarbage]) then State := osNeedPrevEnd;
-
+  //msgGarbage is received when Station was sending and missed part/all of the message
+  if (not Ini.Lids) and (AMsg = [msgGarbage]) then
+    case State of
+      osNeedPrevEnd: ;            // waiting for CQ/TU after prior QSO finishes
+      osNeedQso: MorePatience;    // waiting for callsign (full or partial)
+      osNeedNr: MorePatience;     // has call, waiting for Exch
+      osNeedCall: MorePatience;   // has Exch, waiting for call correction
+      osNeedCallNr: MorePatience; // waiting for call and Exch
+      osNeedEnd: ;                // waiting for TU
+      osDone: ;                   // QSO complete; no state change
+      osFailed: ;                 // QSO failed; no state change
+      else
+        State := osNeedPrevEnd;
+    end;
 
   if State <> osNeedPrevEnd then DecPatience;
 end;


### PR DESCRIPTION
- Issue #405
- Originally, if a Dx Station is sending while the user is sending, the sending station would exit the QSO and wait for a new QSO cycle to begin.
- Now, the Dx Station will remain in the QSO and not disappear from the QSO.
- This has also been considered a form of ghosting.

[Here](https://1drv.ms/u/c/353d3bde42947823/EaRoBIsuUKpGvvu28CEe-ucBO30e4by38I94v6K1Iik7dw?e=DBNAkp) is a link to a test build containing this fix (and the other change requests).