### PR TITLE
update release notes for 1.85.2 release

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -316,15 +316,21 @@ VERSION HISTORY
 
 Version 1.85.2 (April 2025)
   Bug Fix Release
-  - DxStation now sends callsign correction only after user sends partial callsign (#382) (W7SST)
+  - Calling station now sends callsign correction only after user sends partial callsign (#382) (W7SST)
   - Send Station ID after 3 consecutive QSOs (#247) (W7SST)
   - Fix program hang when using QRM Band Condition (#379) (W7SST)
   - Fix NIL log error after incomplete callsign is sent and later corrected (#399) (W7SST)
-  - Improve handling of short callsigns causing stations to not respond (#326) (W7SST)
+  - Improve handling of short or partial callsigns causing stations to not respond (#326) (W7SST)
+  - Fix issue where caller may keep sending after user sends TU (#403) (W7SST)
+  - Fix ghosting station after starting a QSO (#404) (W7SST)
+  - Calling station may exit QSO when caller and user are both sending (#405) (W7SST)
+  - Do not simulate multiple stations with same callsign (#406) (W7SST)
+  - Fix case where caller may respond only one time (#407) (W7SST)
+  - Select leading '?' in Call edit field (#408) (W7SST)
 
-  Contest-specific improvements...
-  - NAQP - DX Stations are now included in simulation (#353) (W7SST)
-  - NAQP - Update call history file
+  Contest-specific Improvements...
+  - NCJ NAQP - DX Stations are now included in simulation (#353) (W7SST)
+  - NCJ NAQP - Update call history file
   - ARRL DX - Update call history file
   - K1USN Slow Speed Test - Update call history file
 
@@ -345,7 +351,7 @@ Version 1.85.1 (October 2024)
   - Fix memory leak (W7SST)
 
   General
-  - Removed 100-person subsciption limit for user's group on groups.io
+  - Removed 100-person subscription limit for user's group on groups.io
 
 Version 1.85 (September 2024)
   - Add ARRL Sweepstakes Contest (W7SST)


### PR DESCRIPTION
Hi Scott,
This is hopefully the last change for this release.

Can you also take a look at the [v1.85.2 Release page](https://github.com/w7sst/MorseRunner/releases) (currently a draft). If you make any changes, be sure to hit `Save draft` at the bottom, but please do not hit publish.

Thank you,
73 Mike

@scotthibbs 