### PR TITLE
Improve Station ID after 3 QSOs, add StationIdRate keyword

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -415,7 +415,7 @@ begin
     msgTU:
       // send station ID after 3 consecutive QSOs (the comparison below uses
       // 2 since the counter is incremented after 'TU <my>' has been sent).
-      if not (RunMode in [rmHST, rmSingle]) and (StationIdRate > 0) and
+      if (RunMode in [rmPileup, rmWpx]) and (StationIdRate > 0) and
         (QsoCountSinceStationID >= (StationIdRate-1))
         then SendText(AStn, 'TU <my>')
         else SendText(AStn, 'TU');

--- a/Contest.pas
+++ b/Contest.pas
@@ -21,11 +21,9 @@ type
     procedure SwapFilters;
 
   protected
-  const
-    STATION_ID_RATE = 3;  // send Station ID after 3 consecutive QSOs
-
   var
     QsoCountSinceStationID: Integer;  // QSOs since last CQ or Station ID
+    StationIdRate: Integer;       // number of QSOs between a CQ or Station ID
     BFarnsworthEnabled : Boolean; // enables Farnsworth timing (e.g. SST Contest)
 
     constructor Create;
@@ -143,6 +141,7 @@ begin
   NoActivityCnt :=0;
   LastLoadCallsign := '';
   QsoCountSinceStationID := 0;
+  StationIdRate := Ini.StationIdRate;
   BFarnsworthEnabled := false;
 
   Init;
@@ -416,7 +415,8 @@ begin
     msgTU:
       // send station ID after 3 consecutive QSOs (the comparison below uses
       // 2 since the counter is incremented after 'TU <my>' has been sent).
-      if (RunMode <> rmHST) and (QsoCountSinceStationID >= (STATION_ID_RATE-1))
+      if not (RunMode in [rmHST, rmSingle]) and (StationIdRate > 0) and
+        (QsoCountSinceStationID >= (StationIdRate-1))
         then SendText(AStn, 'TU <my>')
         else SendText(AStn, 'TU');
     msgMyCall: SendText(AStn, '<my>');
@@ -910,7 +910,7 @@ var
 begin
   // reset Station ID counter after sending a CQ or 3 consecutive QSOs
   if (msgCQ in Me.Msg) or
-     ((msgTU in Me.Msg) and (QsoCountSinceStationID >= STATION_ID_RATE)) then
+     ((msgTU in Me.Msg) and (QsoCountSinceStationID >= StationIdRate)) then
     OnStationIDSent;
 
   //the stations heard my CQ and want to call

--- a/Ini.pas
+++ b/Ini.pas
@@ -245,6 +245,7 @@ var
   SubmitHiScoreURL: string= '';
   PostMethod: string = '';
   ShowCallsignInfo: integer= 1;
+  StationIdRate: Integer = 0;
   Activity: integer = 2;
   Qrn: boolean = false;
   Qrm: boolean = false;
@@ -439,6 +440,7 @@ begin
       RitStepIncr := Max(-500, Min(500, RitStepIncr));
       ShowCheckSection := ReadInteger(SEC_SET, 'ShowCheckSection', ShowCheckSection);
       ShowExchangeSummary := ReadInteger(SEC_SET, 'ShowExchangeSummary', ShowExchangeSummary);
+      StationIdRate := ReadInteger(SEC_SET, 'StationIdRate', StationIdRate);
 
       // [Debug]
       DebugExchSettings := ReadBool(SEC_DBG, 'DebugExchSettings', DebugExchSettings);
@@ -521,6 +523,7 @@ begin
       WriteInteger(SEC_SET, 'RitStepIncr', RitStepIncr);
       WriteInteger(SEC_SET, 'ShowCheckSection', ShowCheckSection);
       WriteInteger(SEC_SET, 'ShowExchangeSummary', ShowExchangeSummary);
+      WriteInteger(SEC_SET, 'StationIdRate', StationIdRate);
 
     finally
       Free;

--- a/Ini.pas
+++ b/Ini.pas
@@ -245,7 +245,7 @@ var
   SubmitHiScoreURL: string= '';
   PostMethod: string = '';
   ShowCallsignInfo: integer= 1;
-  StationIdRate: Integer = 0;
+  StationIdRate: Integer = 3;
   Activity: integer = 2;
   Qrn: boolean = false;
   Qrm: boolean = false;

--- a/Readme.txt
+++ b/Readme.txt
@@ -194,15 +194,16 @@ CONFIGURATION
 
     Send Station ID after N consecutive QSOs
       The user's Station ID will be sent after N consecutive QSOs without
-      sending the Station ID. The Station ID will be sent along with the 'TU'
-      message after every N-th QSO (e.g. 'TU <call>').
-      This feature was originally introduced in version 1.85.2. User feedback
-      recommended that this feature is not desirable in Single Call mode.
-      A keyword has been added to specify the number of QSOs between each
-      Station ID. By default, the value N is set to zero (disabled).
-      You can add the following keyword to the MorseRunner.ini file:
+      sending the Station ID. This will occur when running either Pile-Up mode
+      or WPX Competion mode; it is disabled in Single-Call or HST modes.
+      The Station ID will be added to the 'TU' message after every N-th QSO
+      (e.g. 'TU <call>').  A keyword has been added to specify the number of QSOs
+      between each Station ID. By default, the Station ID will be sent every 3 QSOs.
+      To change this value, you can add the following keyword to the MorseRunner.ini
+      file:
           [Settings]
           StationIdRate=N
+      Settings this value to 0 will disable this feature.
 
 
   Responses
@@ -328,7 +329,7 @@ VERSION HISTORY
 
 Version 1.85.3 (June 2025)
   Bug Fix Release
-  - Disable automatic Station ID after 3 QSOs (#421) (W7SST)
+  - Send Station ID after 3 QSOs in Pile-Up or WPX Competition modes (#421) (W7SST)
 
 Version 1.85.2 (April 2025)
   Bug Fix Release

--- a/Readme.txt
+++ b/Readme.txt
@@ -2,7 +2,7 @@
                               Contest Simulator
                                   freeware
 
-                Version 1.85.2 - ARRL Sweepstakes Contest
+                Version 1.85.3 - ARRL Sweepstakes Contest
             The sixth release of the Morse Runner Community Edition
 
                Copyright (C) 2004-2016 Alex Shovkoplyas, VE3NEA
@@ -192,6 +192,18 @@ CONFIGURATION
       bar (default) or optionally in the label/caption above the exchange entry
       field. Please see the contest rules section below for more information.
 
+    Send Station ID after N consecutive QSOs
+      The user's Station ID will be sent after N consecutive QSOs without
+      sending the Station ID. The Station ID will be sent along with the 'TU'
+      message after every N-th QSO (e.g. 'TU <call>').
+      This feature was originally introduced in version 1.85.2. User feedback
+      recommended that this feature is not desirable in Single Call mode.
+      A keyword has been added to specify the number of QSOs between each
+      Station ID. By default, the value N is set to zero (disabled).
+      You can add the following keyword to the MorseRunner.ini file:
+          [Settings]
+          StationIdRate=N
+
 
   Responses
     There are five basic responses that you can receive:
@@ -313,6 +325,10 @@ SUBMITTING YOUR SCORE
   File -> View Score menu command.
 
 VERSION HISTORY
+
+Version 1.85.3 (June 2025)
+  Bug Fix Release
+  - Disable automatic Station ID after 3 QSOs (#421) (W7SST)
 
 Version 1.85.2 (April 2025)
   Bug Fix Release


### PR DESCRIPTION
Send Station ID after 3 QSOs in Pile-Up and WPX Competion modes; add StationIdRate keyword

- User feedback recommended that this feature was not desired
  during training and Single Call mode.
- Feature is enabled for Pile-Up and WPX Competition modes.
- Feature is disabled for Single Calls mode and HST Competition.
- Added StationIdRate=<N> keyword to MorseRunner.ini file under the [Settings] section.
  - When N = 0, Call ID is disabled.
  - When N > 0, then Call ID will be sent every N QSOs.
- Default value is 3.