### PR TITLE
Improve response after operator sends corrected callsign

### DIFF
--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -88,6 +88,7 @@ implementation
 uses
   SysUtils, Classes,
   Ini,
+  Math,
   System.Generics.Collections,
 {$ifdef DISTRIBUTION_REPORT}
   Dialogs,      // for ShowMessage
@@ -422,7 +423,7 @@ begin
   case AMsg of
     msgCQ: SendText(AStn, 'CQ FD <my>');
     msgNrQm:
-      case Random(5) of
+      case Floor(AStn.R1*5) of
         0,1: SendText(AStn, 'NR?');
         2: SendText(AStn, 'SECT?');
         3: SendText(AStn, 'CLASS?');

--- a/CWSST.pas
+++ b/CWSST.pas
@@ -46,6 +46,7 @@ type
 implementation
 
 uses
+    Math,
     SysUtils, StrUtils, DXCC;
 
 function TCWSST.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -188,11 +189,10 @@ begin
   case AMsg of
     msgCQ: SendText(AStn, 'CQ SST <my>'); // sent by MyStation
     msgNrQm: // sent by calling station (DxStation)
-      case Random(5) of
+      case Floor(AStn.R1*4) of
         0,1: SendText(AStn, 'NR?');
         2:   SendText(AStn, 'NAME?');
         3:   SendText(AStn, 'ST?');
-        4:   SendText(AStn, 'AGN?');
        end;
     msgTU:  // TU message sent by MyStation
        SendText(AStn, 'TU <my>');

--- a/Readme.txt
+++ b/Readme.txt
@@ -330,6 +330,7 @@ VERSION HISTORY
 Version 1.85.3 (June 2025)
   Bug Fix Release
   - Send Station ID after 3 QSOs in Pile-Up or WPX Competition modes (#421) (W7SST)
+  - Improve response after operator sends corrected callsign (#420) (W7SST)
 
 Version 1.85.2 (April 2025)
   Bug Fix Release

--- a/Station.pas
+++ b/Station.pas
@@ -69,10 +69,10 @@ type
                       // TStation.Tick() calls ProcessEvent(evTimeout) whenever
                       // Timeout decrements to zero.
     NrWithError: boolean;
-    R1 : Single;    // holds a Random number; used in NrAsText
     procedure Init;
     function NrAsText: string;
   public
+    R1 : Single;            // holds a Random number; used in NrAsText, SendMsg
     Amplitude: Single;
     WpmS: integer;          // Words per minute, sending speed (set by UI)
     WpmC: integer;          // Words per minute, character speed (set via .INI)


### PR DESCRIPTION
Improve response after operator sends corrected callsign
- While the operator is correcting a callsign and sends a few partial callsign corrections using (F5 key), the calling station would sometimes respond with 'AGN'. This was confusing to the operator because it seems like the calling station is asking for their callsign again. In reality, the calling station is waiting for the operator's exchange to be sent.
- To remove the confusion, the calling station will now request the operator's exchange (by sending 'NR?', 'SECT?', 'NAME?', etc). This will be sent twice followed by a few 'AGN' messages.
- Issue #420