### PR TITLE
416 JARL ACAG - Number exchange field is too narrow

### DIFF
--- a/Ini.pas
+++ b/Ini.pas
@@ -73,6 +73,7 @@ type
   TErrMessageCallback = reference to procedure(const aMsg : string);
 
 const
+  UndefSimContest : TSimContest = TSimContest(-1);
   UndefExchType1 : TExchange1Type = TExchange1Type(-1);
   UndefExchType2 : TExchange2Type = TExchange2Type(-1);
 

--- a/Main.dfm
+++ b/Main.dfm
@@ -158,7 +158,7 @@ object MainForm: TMainForm
     object Label2: TLabel
       Left = 140
       Top = 12
-      Width = 19
+      Width = 20
       Height = 15
       Caption = 'RST'
     end
@@ -746,6 +746,7 @@ object MainForm: TMainForm
         Height = 20
         Hint = '-15.0 dB'
         ShowHint = True
+        HintStep = 0
         Margin = 5
         Value = 0.750000000000000000
         Overloaded = False
@@ -926,7 +927,7 @@ object MainForm: TMainForm
       object Label17: TLabel
         Left = 12
         Top = 47
-        Width = 51
+        Width = 50
         Height = 15
         Caption = 'Exchange'
       end

--- a/Main.pas
+++ b/Main.pas
@@ -326,6 +326,9 @@ type
     procedure ConfigureExchangeFields;
     procedure SetMyExch1(const AExchType: TExchange1Type; const Avalue: string);
     procedure SetMyExch2(const AExchType: TExchange2Type; const Avalue: string);
+    procedure SaveRecvFieldSizes;
+    procedure RestoreRecvFields;
+    procedure ResizeRecvFields;
     procedure ProcessSpace;
     procedure SendMsg(AMsg: TStationMessage);
     procedure ProcessEnter;
@@ -381,10 +384,11 @@ const
 
 var
   MainForm: TMainForm;
+  SavedContest: TSimContest = TSimContest(-1);  // used to restore Exch Field sizes
   SaveEdit1Width: integer = 0;
+  SaveEdit3Width: integer = 0;
   SaveLabel3Left: integer = 0;
   SaveEdit3Left: integer = 0;
-  SaveEdit3Width: integer = 0;
 
   { debug switches - set via .INI file or compile-time switches (above) }
   BDebugExchSettings: boolean;    // display parsed Exchange field settings
@@ -1144,17 +1148,20 @@ begin
   // clear input fields prior to deleting Contest object.
   WipeBoxes;
 
+  // restore Recv Exchange field sizing prior to deleting Contest object.
+  RestoreRecvFields;
+
   // clear any status messages
   sbar.Caption := '';
   sbar.Font.Color := clDefault;
   sbar.Visible := mnuShowCallsignInfo.Checked;
 
-  assert(ContestDefinitions[AContestNum].T = AContestNum,
-    'Contest definitions are out of order');
-
   // drop prior contest
   if Assigned(Tst) then
     FreeAndNil(Tst);
+
+  assert(ContestDefinitions[AContestNum].T = AContestNum,
+    'Contest definitions are out of order');
 
   Ini.SimContest := AContestNum;
   Ini.ActiveContest := @ContestDefinitions[AContestNum];
@@ -1244,19 +1251,9 @@ begin
         sbar.Caption := '';
       end;
 
-    // restore Edit3 if not ARRL Sweepstakes
-    if (SimContest <> scArrlSS) and (SaveEdit3Left <> 0) then
-      begin
-        Edit1.Width := SaveEdit1Width;
-        Label3.Left := SaveLabel3Left;
-        Edit3.Left := SaveEdit3Left;
-        Edit3.Width := SaveEdit3Width;
-        Label2.Show;
-        Edit2.Show;
-        SaveLabel3Left := 0;
-        SaveEdit3Left := 0;
-        SaveEdit3Width := 0;
-      end;
+    // restore Exchange fields if current contest has changed since last run
+    if (SimContest <> SavedContest) and (SaveEdit3Left <> 0) then
+      RestoreRecvFields;
 
     // set contest-specific sent exchange values
     SetMyExch1(SentExchTypes.Exch1, sl[0]);
@@ -1371,6 +1368,9 @@ var
 begin
   // Load Received exchange field types
   RecvExchTypes:= Tst.GetRecvExchTypes(skMyStation, Tst.Me.MyCall, Trim(Edit1.Text));
+
+  // apply contest-specific exchange field sizing and positioning
+  ResizeRecvFields;
 
   // Optional Contest Exchange label and field
   Visible := AExchangeLabel <> '';
@@ -1568,26 +1568,6 @@ begin
       end;
     etSSCheckSection:
       begin
-        if SaveEdit3Left = 0 then
-          begin
-            // retain current field sizes
-            SaveEdit1Width := Edit1.Width;
-            SaveLabel3Left := Label3.Left;
-            SaveEdit3Left := Edit3.Left;
-            SaveEdit3Width := Edit3.Width;
-
-            // hide Exch1 (Edit2)
-            Edit2.Hide;
-            Label2.Hide;
-
-            // reduce Edit1 width; shift Exch Field 2 to the left and grow
-            var Reduce1: integer := (SaveEdit1Width * 4) div 9;
-            Label3.Left := Label3.Left - (Label3.Left - Label2.Left) - Reduce1;
-            Edit3.Left := Edit2.Left - Reduce1;
-            Edit3.Width := Edit3.Width + (SaveEdit3Left - Edit2.Left + Reduce1 + 15);
-            Edit1.Width := Edit1.Width - Reduce1;
-          end;
-
         Ini.UserExchange2[SimContest] := Avalue; // <check> <sect> (e.g. 72 OR)
         Tst.Me.Exch2 := Avalue;
         if BDebugExchSettings then
@@ -1600,6 +1580,61 @@ begin
       assert(false, Format('Unsupported exchange 2 type: %s.', [ToStr(AExchType)]));
   end;
   Tst.Me.SentExchTypes.Exch2 := AExchType;
+end;
+
+
+procedure TMainForm.SaveRecvFieldSizes;
+begin
+  SaveEdit1Width := Edit1.Width;
+  SaveEdit3Width := Edit3.Width;
+  SaveLabel3Left := Label3.Left;
+  SaveEdit3Left := Edit3.Left;
+  SavedContest := Ini.SimContest;
+end;
+
+
+procedure TMainForm.RestoreRecvFields;
+begin
+  if SaveEdit3Left <> 0 then
+  begin
+    Edit1.Width := SaveEdit1Width;
+    Edit3.Width := SaveEdit3Width;
+    Label3.Left := SaveLabel3Left;
+    Edit3.Left := SaveEdit3Left;
+
+    Label2.Show;
+    Edit2.Show;
+
+    SaveEdit1Width := 0;
+    SaveEdit3Width := 0;
+    SaveLabel3Left := 0;
+    SaveEdit3Left := 0;
+    SavedContest := UndefSimContest;
+  end;
+end;
+
+
+procedure TMainForm.ResizeRecvFields;
+begin
+  case SimContest of
+    scArrlSS:
+      if SaveEdit3Left = 0 then
+      begin
+        // retain current field sizes
+        SaveRecvFieldSizes;
+
+        // hide Exch1 (Edit2)
+        Edit2.Hide;
+        Label2.Hide;
+
+        // reduce Edit1 width; shift Exch Field 2 to the left and grow
+        var Reduce1: integer := (SaveEdit1Width * 4) div 9;
+        Label3.Left := Label3.Left - (Label3.Left - Label2.Left) - Reduce1;
+        Edit3.Left := Edit2.Left - Reduce1;
+        Edit3.Width := Edit3.Width + (SaveEdit3Left - Edit2.Left + Reduce1 + 15);
+        Edit1.Width := Edit1.Width - Reduce1;
+      end;
+  end;
 end;
 
 

--- a/Main.pas
+++ b/Main.pas
@@ -386,6 +386,7 @@ var
   MainForm: TMainForm;
   SavedContest: TSimContest = TSimContest(-1);  // used to restore Exch Field sizes
   SaveEdit1Width: integer = 0;
+  SaveEdit2Width: integer = 0;
   SaveEdit3Width: integer = 0;
   SaveLabel3Left: integer = 0;
   SaveEdit3Left: integer = 0;
@@ -1586,6 +1587,7 @@ end;
 procedure TMainForm.SaveRecvFieldSizes;
 begin
   SaveEdit1Width := Edit1.Width;
+  SaveEdit2Width := Edit2.Width;
   SaveEdit3Width := Edit3.Width;
   SaveLabel3Left := Label3.Left;
   SaveEdit3Left := Edit3.Left;
@@ -1598,6 +1600,7 @@ begin
   if SaveEdit3Left <> 0 then
   begin
     Edit1.Width := SaveEdit1Width;
+    Edit2.Width := SaveEdit2Width;
     Edit3.Width := SaveEdit3Width;
     Label3.Left := SaveLabel3Left;
     Edit3.Left := SaveEdit3Left;
@@ -1606,6 +1609,7 @@ begin
     Edit2.Show;
 
     SaveEdit1Width := 0;
+    SaveEdit2Width := 0;
     SaveEdit3Width := 0;
     SaveLabel3Left := 0;
     SaveEdit3Left := 0;
@@ -1615,6 +1619,8 @@ end;
 
 
 procedure TMainForm.ResizeRecvFields;
+const
+  PAD = 1;
 begin
   case SimContest of
     scArrlSS:
@@ -1633,6 +1639,24 @@ begin
         Edit3.Left := Edit2.Left - Reduce1;
         Edit3.Width := Edit3.Width + (SaveEdit3Left - Edit2.Left + Reduce1 + 15);
         Edit1.Width := Edit1.Width - Reduce1;
+      end;
+    scAllJa, scAcag:
+      if SaveEdit3Left = 0 then
+      begin
+        // retain current field sizes
+        SaveRecvFieldSizes;
+
+        // Update Exch1 and Exch2 field widths using field lengths
+        var L1: Integer := Exchange1Settings[RecvExchTypes.Exch1].L + PAD;
+        var L2: Integer := Exchange2Settings[RecvExchTypes.Exch2].L + PAD;
+        var CharWidth: Single := (SaveEdit2Width + SaveEdit3Width) / (L1 + L2);
+        Edit2.Width := Round(CharWidth * L1);
+        Edit3.Width := Round(CharWidth * L2);
+
+        // Adjust Exch2's left edge
+        var Delta: Integer := SaveEdit2Width - Edit2.Width;
+        Label3.Left := Label3.Left - Delta;
+        Edit3.Left := Edit3.Left - Delta;
       end;
   end;
 end;

--- a/Readme.txt
+++ b/Readme.txt
@@ -338,6 +338,7 @@ Version 1.85.3 (June 2025)
   - ARRL FD - Update call history file
   - ARRL DX - Use 'ATT' for 100 Watts in Power exchange field (#392) (W7SST)
   - ARRL DX - Update call history file
+  - JARL ACAG - Widen Number exchange field to display long exchange (#416) (W7SST)
 
   Additional Details...
     Delay first callsign sent when running Single Calls mode (#424)


### PR DESCRIPTION
I increased the width of the `Number` exchange field for both JARL ACAG and JARL ALLJA Contests.

**Before**
![Image](https://github.com/user-attachments/assets/d7ba9577-8880-4699-9352-7ddec8278573)

**After**
![Image](https://github.com/user-attachments/assets/e0755a4f-8698-46f9-bc23-ee6ba0d59771)

**Changes**
1. Refactored existing code to better support dynamic changes to exchange field width.
2. Added new code to change the width of the `Number` exchange field.