### PR TITLE
Fix ARRL DX contest lack of calls by removing UserText column

### DIFF
--- a/ARRLDXCW_USDX.txt
+++ b/ARRLDXCW_USDX.txt
@@ -1,4 +1,4 @@
-!!Order!!,Call,Name,State,Power,UserText,
+!!Order!!,Call,Name,State,Power,
 #
 # ARRL International (For DX and US side)
 # ARRLDXCW


### PR DESCRIPTION
People are complaining that if you're a VE/K station in the ARRL DX contest, then you get a lot of dupes. The problem is that the code rejects any line in the file that doesn't have the right number of fields, determined by the `!!Order!!` lines. However most of the calls don't have that final field so they don't get rejected.

Removing the column from the `Order` line means it won't care about having that UserText column for the purposes of deciding if a line is good or not.