### PR TITLE
Station gives report before I got the call and give my report

### DIFF
--- a/DxOper.pas
+++ b/DxOper.pas
@@ -424,10 +424,10 @@ begin
         try
           reg := TPerlRegEx.Create();
           if APattern.EndsWith('?') then
-            reg.RegEx := APattern.Replace('?','.') + '*'
+            reg.RegEx := UTF8String(APattern.Replace('?','.') + '*')
           else
-            reg.RegEx := APattern.Replace('?','.');
-          reg.Subject := C0;
+            reg.RegEx := UTF8String(APattern.Replace('?','.'));
+          reg.Subject := UTF8String(C0);
           if reg.Match then
             begin
               Result := mcAlmost;
@@ -711,8 +711,17 @@ begin
           2,3: Result := msgMyCall;     // <my>
           4: Result := msgMyCall2;      // <my> <my>
           5: begin
-              Result := msgMyCallNr1;   // <my> <exch>
-              CorrectedCallAndExchSent := true;
+              if LIDs and (R2 < 0.88) then   // 0.88-0.8333 = 4.67%
+                begin
+                  // LIDS will occasionally send their exchange even though
+                  // they have have not yet copied the CQ Station's exchange.
+                  Result := msgMyCallNr1;   // <my> <exch>
+                  CorrectedCallAndExchSent := true;
+                end
+              else if R2 < 0.95 then    // 0.95 - 0.8333 = 11.67%
+                Result := msgMyCall     // <my>
+              else                      // 1.0  - 0.95 = 5%
+                Result := msgMyCall2;   // <my> <my>
              end;
         end
     else //osNeedEnd:

--- a/Readme.txt
+++ b/Readme.txt
@@ -329,6 +329,7 @@ VERSION HISTORY
 
 Version 1.85.4 (April 2026)
   Bug Fix Release
+  - Station gives report before I got the call and give my report (#434) (W7SST)
   - ARRL DX - MR quickly reports duplicate contacts (#437) (W7SST)
   - CQ WPX - MR sends the SCP version, VER20251126, as a callsign (#440) (W7SST)
 


### PR DESCRIPTION
- The calling station was sending their report before the user sends their report. This was different than expected contest behavior.
- To fix this, the percentage of occurrence was reduced to ~5%.
- This behavior is now sent only with the LID switch enabled.
- fixes #434

[Here is a link](https://1drv.ms/u/c/353d3bde42947823/IQDMPEoXK-F7RKxOP1JrtJWcAatJju-06PEYXNlPSRCqhDY?e=rislhV) to a preliminary build containing this fix. Let me know if you are able to test this.