### PR TITLE
Make F8 NIL reliably dismiss unwanted callers

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -911,6 +911,8 @@ var
   z: integer;
   Dx : integer;
   Msg: TStationMessages;
+  Call: string;
+  Active: Boolean;
 begin
   Msg := [];
 
@@ -948,9 +950,14 @@ begin
   if msgHisCall in Tst.Me.Msg then
     Stations.FindBestMatches(Tst.Me.HisCall);
 
-  if msgNil in Me.Msg then
+  if Ini.NilInstantRemove and (msgNil in Me.Msg) then
     begin
-      Stations.DropCallerForNil;
+      if Stations.DropCallerForNil(Call, Active) then
+        if Active or (RunMode = rmSingle) then
+          begin
+            MainForm.sbar.Font.Color := clDefault;
+            MainForm.sbar.Caption := 'Skipped ' + Call;
+          end;
       Msg := Me.Msg;
       Me.Msg := [msgGarbage];
     end;
@@ -1002,4 +1009,3 @@ end;
 
 
 end.
-

--- a/Contest.pas
+++ b/Contest.pas
@@ -910,7 +910,10 @@ var
   i: integer;
   z: integer;
   Dx : integer;
+  Msg: TStationMessages;
 begin
+  Msg := [];
+
   // reset Station ID counter after sending a CQ or 3 consecutive QSOs
   if (msgCQ in Me.Msg) or
      ((msgTU in Me.Msg) and (QsoCountSinceStationID >= StationIdRate)) then
@@ -945,9 +948,19 @@ begin
   if msgHisCall in Tst.Me.Msg then
     Stations.FindBestMatches(Tst.Me.HisCall);
 
+  if msgNil in Me.Msg then
+    begin
+      Stations.DropCallerForNil;
+      Msg := Me.Msg;
+      Me.Msg := [msgGarbage];
+    end;
+
   //tell callers that I finished sending
   for i:=Stations.Count-1 downto 0 do
     Stations[i].ProcessEvent(evMeFinished);
+
+  if Msg <> [] then
+    Me.Msg := Msg;
 end;
 
 

--- a/Ini.pas
+++ b/Ini.pas
@@ -254,6 +254,7 @@ var
   Qsb: boolean = false;
   Flutter: boolean = false;
   Lids: boolean = false;
+  NilInstantRemove: boolean = true;
   NoActivityCnt: integer=0;
   NoStopActivity: integer=0;
   GetWpmUsesGaussian: boolean = false;
@@ -456,6 +457,7 @@ begin
       StationIdRate := ReadInteger(SEC_SET, 'StationIdRate', StationIdRate);
       SingleCallStartDelay := ReadInteger(SEC_SET, 'SingleCallStartDelay', SingleCallStartDelay);
       SingleCallStartDelay := Max(0, Min(SingleCallStartDelay, 2500));
+      NilInstantRemove := ReadBool(SEC_SET, 'NilInstantRemove', NilInstantRemove);
 
       // [Debug]
       DebugExchSettings := ReadBool(SEC_DBG, 'DebugExchSettings', DebugExchSettings);
@@ -540,6 +542,7 @@ begin
       WriteInteger(SEC_SET, 'ShowExchangeSummary', ShowExchangeSummary);
       WriteInteger(SEC_SET, 'StationIdRate', StationIdRate);
       WriteInteger(SEC_SET, 'SingleCallStartDelay', SingleCallStartDelay);
+      WriteBool(SEC_SET, 'NilInstantRemove', NilInstantRemove);
 
     finally
       Free;
@@ -655,4 +658,3 @@ end;
 
 
 end.
-

--- a/Main.dfm
+++ b/Main.dfm
@@ -1423,6 +1423,11 @@ object MainForm: TMainForm
         Caption = 'LIDS'
         OnClick = LIDS1Click
       end
+      object NilInstantRemove1: TMenuItem
+        Caption = 'NIL instantly removes caller'
+        Checked = True
+        OnClick = NilInstantRemove1Click
+      end
       object Activity1: TMenuItem
         Caption = 'Activity'
         object N11: TMenuItem

--- a/Main.dfm
+++ b/Main.dfm
@@ -1423,11 +1423,6 @@ object MainForm: TMainForm
         Caption = 'LIDS'
         OnClick = LIDS1Click
       end
-      object NilInstantRemove1: TMenuItem
-        Caption = 'NIL instantly removes caller'
-        Checked = True
-        OnClick = NilInstantRemove1Click
-      end
       object Activity1: TMenuItem
         Caption = 'Activity'
         object N11: TMenuItem
@@ -1520,6 +1515,11 @@ object MainForm: TMainForm
       object Operator1: TMenuItem
         Caption = 'HST Operator'
         OnClick = Operator1Click
+      end
+      object NilInstantRemove1: TMenuItem
+        Caption = 'NIL Instantly Removes Caller'
+        Checked = True
+        OnClick = NilInstantRemove1Click
       end
       object mnuShowCallsignInfo: TMenuItem
         Caption = 'Show Callsign Info'

--- a/Main.pas
+++ b/Main.pas
@@ -177,6 +177,7 @@ type
     QSB1: TMenuItem;
     Flutter1: TMenuItem;
     LIDS1: TMenuItem;
+    NilInstantRemove1: TMenuItem;
     Activity1: TMenuItem;
     N11: TMenuItem;
     N21: TMenuItem;
@@ -291,6 +292,7 @@ type
     procedure SelfMonClick(Sender: TObject);
     procedure Settings1Click(Sender: TObject);
     procedure LIDS1Click(Sender: TObject);
+    procedure NilInstantRemove1Click(Sender: TObject);
     procedure CWMaxRxSpeedClick(Sender: TObject);
     procedure CWMinRxSpeedClick(Sender: TObject);
     procedure NRDigitsClick(Sender: TObject);
@@ -2553,6 +2555,7 @@ begin
   QSB1.Checked := Ini.Qsb;
   Flutter1.Checked := Ini.Flutter;
   LIDS1.Checked := Ini.Lids;
+  NilInstantRemove1.Checked := Ini.NilInstantRemove;
 end;
 
 
@@ -2703,6 +2706,13 @@ begin
 end;
 
 
+procedure TMainForm.NilInstantRemove1Click(Sender: TObject);
+begin
+  with Sender as TMenuItem do Checked := not Checked;
+  Ini.NilInstantRemove := NilInstantRemove1.Checked;
+end;
+
+
 procedure TMainForm.ListView2CustomDrawSubItem(Sender: TCustomListView;
   Item: TListItem; SubItem: Integer; State: TCustomDrawState;
   var DefaultDraw: Boolean);
@@ -2780,4 +2790,3 @@ begin
 end;
 
 end.
-

--- a/StnColl.pas
+++ b/StnColl.pas
@@ -24,6 +24,7 @@ type
     function AddCaller: TStation;
     function AddQrn: TStation;
     function AddQrm: TStation;
+    function DropCallerForNil: Boolean;
 
     procedure FindBestMatches(const AEnteredCall: String);
 
@@ -100,6 +101,56 @@ function TStations.AddQrm: TStation;
 begin
   Result := TQrmStation.CreateStation;
   Result.Collection := Self;
+end;
+
+
+function TStations.DropCallerForNil: Boolean;
+var
+  i: Integer;
+  DxStn, Target: TDxStation;
+
+  procedure Pick(ADxStn: TDxStation);
+  begin
+    if (Target = nil) or (ADxStn.Amplitude > Target.Amplitude) then
+      Target := ADxStn;
+  end;
+
+begin
+  Target := nil;
+
+  for i:=Self.Count-1 downto 0 do
+    if Self[i] is TDxStation then
+      begin
+        DxStn := Self[i] as TDxStation;
+        if DxStn.Oper.State in [osNeedNr, osNeedCall, osNeedCallNr, osNeedEnd] then
+          Pick(DxStn);
+      end;
+
+  if Target = nil then
+    for i:=Self.Count-1 downto 0 do
+      if Self[i] is TDxStation then
+        begin
+          DxStn := Self[i] as TDxStation;
+          if DxStn.State = stSending then
+            Pick(DxStn);
+        end;
+
+  if Target = nil then
+    for i:=Self.Count-1 downto 0 do
+      if Self[i] is TDxStation then
+        begin
+          DxStn := Self[i] as TDxStation;
+          if DxStn.Oper.State in [osNeedQso, osNeedPrevEnd] then
+            Pick(DxStn);
+        end;
+
+  Result := Target <> nil;
+  if Result then
+    begin
+      Target.Envelope := nil;
+      Target.Oper.State := osFailed;
+      Target.Free;
+    end;
 end;
 
 

--- a/StnColl.pas
+++ b/StnColl.pas
@@ -24,7 +24,7 @@ type
     function AddCaller: TStation;
     function AddQrn: TStation;
     function AddQrm: TStation;
-    function DropCallerForNil: Boolean;
+    function DropCallerForNil(out ACall: string; out AActive: Boolean): Boolean;
 
     procedure FindBestMatches(const AEnteredCall: String);
 
@@ -104,26 +104,31 @@ begin
 end;
 
 
-function TStations.DropCallerForNil: Boolean;
+function TStations.DropCallerForNil(out ACall: string; out AActive: Boolean): Boolean;
 var
   i: Integer;
   DxStn, Target: TDxStation;
 
-  procedure Pick(ADxStn: TDxStation);
+  procedure Pick(ADxStn: TDxStation; AAct: Boolean);
   begin
     if (Target = nil) or (ADxStn.Amplitude > Target.Amplitude) then
+    begin
       Target := ADxStn;
+      AActive := AAct;
+    end;
   end;
 
 begin
   Target := nil;
+  ACall := '';
+  AActive := False;
 
   for i:=Self.Count-1 downto 0 do
     if Self[i] is TDxStation then
       begin
         DxStn := Self[i] as TDxStation;
         if DxStn.Oper.State in [osNeedNr, osNeedCall, osNeedCallNr, osNeedEnd] then
-          Pick(DxStn);
+          Pick(DxStn, True);
       end;
 
   if Target = nil then
@@ -132,7 +137,7 @@ begin
         begin
           DxStn := Self[i] as TDxStation;
           if DxStn.State = stSending then
-            Pick(DxStn);
+            Pick(DxStn, False);
         end;
 
   if Target = nil then
@@ -141,12 +146,13 @@ begin
         begin
           DxStn := Self[i] as TDxStation;
           if DxStn.Oper.State in [osNeedQso, osNeedPrevEnd] then
-            Pick(DxStn);
+            Pick(DxStn, False);
         end;
 
   Result := Target <> nil;
   if Result then
     begin
+      ACall := Target.MyCall;
       Target.Envelope := nil;
       Target.Oper.State := osFailed;
       Target.Free;
@@ -189,4 +195,3 @@ end;
 
 
 end.
-


### PR DESCRIPTION
This changes F8/NIL from a polite suggestion into an explicit operator command. F8/NIL now actively removes the current caller while engaged in a QSO, skips the current caller in Single call mode, or removes the loudest caller in pileup mode. I have tested it in IARU, WPX and WW contest types, in pile-ups and single calls.

Previously, NIL could take several attempts to make a caller go away, especially while the caller was still in the early `osNeedQso` state. That made it rather poor as an escape hatch: the button said NIL, the caller heard _maybe later_, and everyone had a worse afternoon. The mechanism in the background used a random _patience_ metric, which went down with every failed attempt, until the caller hit zero.

I stopped writing Pascal around high school, so please forgive any transgressions.

## What Changed

- Added `Settings → NIL instantly removes caller`, enabled by default.
- When enabled, NIL removes one targeted caller immediately. Yes, including during _his_ transmission.
- The target priority is:
  1. active QSO/correction caller
  2. loudest currently transmitting caller
  3. waiting caller
- If NIL skips an active QSO/correction caller, or a caller in Single Call mode, the status bar shows `Skipped CALL`.
- Skipped callers are not logged and do not affect score, rate, serials, or QSO counters.

## Impact

This keeps the change deliberately narrow: no log-row semantics, no new scoring behaviour, no status-bar error state, and no attempt to make NIL do six clever things before breakfast.

Users who prefer the old patience-based NIL behaviour can turn the new setting off.

Fixes: #441, #448

<img width="731" height="558" alt="image" src="https://github.com/user-attachments/assets/30a872fa-c25d-45ff-9c7c-e8f15e625f19" />
