### PR TITLE
fix end-of-session qso finalization

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -16,8 +16,10 @@ type
   TContest = class
   private
     LastLoadCallsign : String;  // used to minimize call history file reloads
+    EndSessionDrainDeadlineBlock: Integer;
 
     function DxCount: integer;
+    function ShouldDrainEndSessionQso: Boolean;
     procedure SwapFilters;
 
   protected
@@ -144,6 +146,7 @@ begin
   QsoCountSinceStationID := 0;
   StationIdRate := Ini.StationIdRate;
   BFarnsworthEnabled := false;
+  EndSessionDrainDeadlineBlock := -1;
 
   Init;
 end;
@@ -169,7 +172,47 @@ begin
   LastLoadCallsign := '';
   QsoCountSinceStationID := 0;
   BFarnsworthEnabled := false;
+  EndSessionDrainDeadlineBlock := -1;
   CallerStartDelayInBlocks := SecondsToBlocks(Ini.SingleCallStartDelay/1000) + 5;
+end;
+
+
+function TContest.ShouldDrainEndSessionQso: Boolean;
+const
+  END_SESSION_DRAIN_SECONDS = 15;
+
+  function HasPendingEndSessionQso: Boolean;
+  var
+    i: Integer;
+  begin
+    Result := (QsoList <> nil) and
+              (QsoList[High(QsoList)].TrueCall = '') and
+              (msgTU in Me.Msg);
+    if not Result then
+      Exit;
+
+    for i := Stations.Count-1 downto 0 do
+      if Stations[i] is TDxStation then
+        with Stations[i] as TDxStation do
+          if Oper.CallConfidenceCheck(QsoList[High(QsoList)].Call, False)
+            in [mcYes, mcAlmost] then
+            Exit;
+
+    Result := False;
+  end;
+
+begin
+  Result := HasPendingEndSessionQso;
+  if not Result then
+    begin
+    EndSessionDrainDeadlineBlock := -1;
+    Exit;
+    end;
+
+  if EndSessionDrainDeadlineBlock < 0 then
+    EndSessionDrainDeadlineBlock := BlockNumber + SecondsToBlocks(END_SESSION_DRAIN_SECONDS);
+
+  Result := BlockNumber <= EndSessionDrainDeadlineBlock;
 end;
 
 
@@ -688,6 +731,7 @@ var
   i, Stn: integer;
   Bfo: Single;
   Smg, Rfg: Single;
+  TimeExpired: Boolean;
 begin
   //minimize audio output delay
   SetLength(Result, 1);
@@ -833,7 +877,10 @@ begin
   if Ini.RunMode = rmPileUp then
     MainForm.Panel4.Caption := Format('Pile-Up:  %d', [DxCount]);
 
-  if (RunMode = rmSingle) and (DxCount = 0) and
+  TimeExpired := BlocksToSeconds(BlockNumber) >= Duration * 60;
+
+  if (not TimeExpired) and
+     (RunMode = rmSingle) and (DxCount = 0) and
      (BlockNumber > CallerStartDelayInBlocks) then begin
      Me.Msg := [msgCq]; //no need to send cq in this mode
      Stations.AddCaller.ProcessEvent(evMeFinished);
@@ -850,15 +897,21 @@ begin
 {$endif}
   end
   else
-    if (RunMode = rmHst) and (DxCount < Activity) then begin
+    if (not TimeExpired) and
+       (RunMode = rmHst) and (DxCount < Activity) then begin
       Me.Msg := [msgCq];
       for i:=DxCount+1 to Activity do
         Stations.AddCaller.ProcessEvent(evMeFinished);
     end;
 
 
-  if (BlocksToSeconds(BlockNumber) >= (Duration * 60)) or FStopPressed then
+  if TimeExpired or FStopPressed then
     begin
+    if TimeExpired and (not FStopPressed) and ShouldDrainEndSessionQso then
+      Exit;
+
+    EndSessionDrainDeadlineBlock := -1;
+
     if RunMode = rmHst then
       begin
       MainForm.Run(rmStop);
@@ -917,7 +970,8 @@ begin
     OnStationIDSent;
 
   //the stations heard my CQ and want to call
-  if (not (RunMode in [rmSingle, RmHst])) then
+  if (not (RunMode in [rmSingle, RmHst])) and
+     (BlocksToSeconds(BlockNumber) < Duration * 60) then
     if (msgCQ in Me.Msg) or
        ((QsoList <> nil) and ((msgTU in Me.Msg) or (msgMyCall in Me.Msg))) then
        begin


### PR DESCRIPTION
Fixes an end-of-session edge case #327 where a QSO saved right on the clock could still be left as NIL because the simulator stopped before the DX station had one last chance to settle its state.

It now allows up to 15 extra seconds only to finish the already-saved TU/finalisation path, and it stops adding new callers once the contest time has expired. This grace time only applies after the QSO is already saved and the user is in the final TU path. It is not extra operating time for completing an unfinished QSO; any other path will stop the clock as usual.