### PR TITLE
Audio recording path

### DIFF
--- a/Ini.pas
+++ b/Ini.pas
@@ -268,6 +268,7 @@ var
 
   MonLevel: Integer = 0;             // Self Monitor Level in dB; range [-60,0]
   SaveWav: boolean = false;
+  RecordingFolder: string = '';
   FarnsworthCharRate: integer = 25;
   AllStationsWpmS: integer = 0;      // force all stations to this Wpm
   CallsFromKeyer: boolean = false;
@@ -445,6 +446,7 @@ begin
       MonLevel := V;
       MainForm.VolumeSlider1.Db := MonLevel;
       SaveWav := ReadBool(SEC_STN, 'SaveWav', SaveWav);
+      RecordingFolder := ReadString(SEC_STN, 'RecordingFolder', RecordingFolder);
 
       // [Settings]
       FarnsworthCharRate := ReadInteger(SEC_SET, 'FarnsworthCharacterRate', FarnsworthCharRate);
@@ -531,6 +533,7 @@ begin
       // [Station]
       WriteInteger(SEC_STN, 'SelfMonVolume', MonLevel);
       WriteBool(SEC_STN, 'SaveWav', SaveWav);
+      WriteString(SEC_STN, 'RecordingFolder', RecordingFolder);
 
       // [Settings]
       WriteInteger(SEC_SET, 'FarnsworthCharacterRate', FarnsworthCharRate);
@@ -655,4 +658,3 @@ end;
 
 
 end.
-

--- a/Main.dfm
+++ b/Main.dfm
@@ -983,6 +983,10 @@ object MainForm: TMainForm
         Caption = 'Audio Recording Enabled'
         OnClick = AudioRecordingEnabled1Click
       end
+      object ChooseAudioRecordingFolder1: TMenuItem
+        Caption = 'Choose Audio Recording Folder...'
+        OnClick = ChooseAudioRecordingFolder1Click
+      end
       object PlayRecordedAudio1: TMenuItem
         Caption = 'Play Recorded Audio'
         Enabled = False

--- a/Main.pas
+++ b/Main.pas
@@ -325,7 +325,7 @@ type
     UserExchangeDirty: boolean; // SetMyExchange is called after exchange edits
     CWSpeedDirty: boolean;      // SetWpm is called after CW Speed edits
     RitLocal: integer;          // tracks incremented RIT Value
-    function EnsureRecordingFolder: Boolean;
+    function EnsureRecordingFolder(ReportError: Boolean = True): Boolean;
     function RecordingFileName: string;
     function CreateContest(AContestId : TSimContest) : TContest;
     procedure ConfigureExchangeFields;
@@ -411,7 +411,7 @@ uses
   IARUHF, ARRLSS,
   MorseKey, FarnsKeyer, CallLst,
   SysUtils, ShellApi, Crc32, Idhttp, Math, IniFiles,
-  Dialogs, System.UITypes, TypInfo, ScoreDlg, Log, PerlRegEx, StrUtils,
+  Dialogs, Vcl.FileCtrl, System.UITypes, TypInfo, ScoreDlg, Log, PerlRegEx, StrUtils,
   DateUtils, ShlObj;
 
 {$R *.DFM}
@@ -435,7 +435,7 @@ begin
 end;
 
 
-function TMainForm.EnsureRecordingFolder: Boolean;
+function TMainForm.EnsureRecordingFolder(ReportError: Boolean): Boolean;
 var
   ProfilePath: array[0..MAX_PATH] of Char;
 begin
@@ -454,7 +454,7 @@ begin
     Result := False;
   end;
 
-  if not Result then
+  if not Result and ReportError then
     Application.MessageBox(
       PChar(Format('Unable to create audio recording folder:'#13'%s',
         [Ini.RecordingFolder])),
@@ -2134,9 +2134,22 @@ begin
 
     if Ini.SaveWav then
     begin
-      if not EnsureRecordingFolder then Exit;
-      AlWavFile1.FileName := RecordingFileName;
-      AlWavFile1.OpenWrite;
+      if not EnsureRecordingFolder then
+        Ini.SaveWav := False
+      else
+      begin
+        AlWavFile1.FileName := RecordingFileName;
+        try
+          AlWavFile1.OpenWrite;
+        except
+          Ini.SaveWav := False;
+          Application.MessageBox(PChar(Format(
+            'Audio recording could not be started in %s.'#13#13 +
+            'The session will start without audio recording. ' +
+            'Try choosing another folder.', [Ini.RecordingFolder])),
+            'Audio Recording Error', MB_OK or MB_ICONERROR);
+        end;
+      end;
     end;
   end;
 
@@ -2672,23 +2685,59 @@ end;
 
 
 procedure TMainForm.ChooseAudioRecordingFolder1Click(Sender: TObject);
-begin
-  if not EnsureRecordingFolder then Exit;
+var
+  SavedFolder, InitialFolder: string;
+  TempFile: array[0..MAX_PATH] of Char;
 
-  with TFileOpenDialog.Create(Self) do
-    try
-      Title := 'Choose Audio Recording Folder';
-      Options := [fdoPickFolders, fdoPathMustExist, fdoForceFileSystem];
-      DefaultFolder := Ini.RecordingFolder;
-      FileName := Ini.RecordingFolder;
-      if Execute then
-      begin
-        Ini.RecordingFolder := FileName;
-        Ini.SaveWav := True;
-      end;
-    finally
-      Free;
+  function SelectRecordingFolder(var Folder: string): Boolean;
+  begin
+    if CheckWin32Version(6) then
+      with TFileOpenDialog.Create(Self) do
+        try
+          Title := 'Choose Audio Recording Folder';
+          Options := [fdoPickFolders, fdoPathMustExist, fdoForceFileSystem];
+          DefaultFolder := Folder;
+          FileName := Folder;
+          Result := Execute;
+          if Result then Folder := FileName;
+        finally
+          Free;
+        end
+    else
+    begin
+      // xp only because we somehow still support this?
+      Result := SelectDirectory('Choose Audio Recording Folder', '', Folder,
+        [sdNewUI, sdNewFolder], Self);
     end;
+  end;
+
+begin
+  SavedFolder := Ini.RecordingFolder;
+  if not EnsureRecordingFolder(False) then
+  begin
+    Ini.RecordingFolder := '';
+    EnsureRecordingFolder(False);
+  end;
+  InitialFolder := Ini.RecordingFolder;
+  if not DirectoryExists(InitialFolder) then
+    InitialFolder := ExtractFileDir(InitialFolder);
+  Ini.RecordingFolder := SavedFolder;
+
+  while SelectRecordingFolder(InitialFolder) do
+  begin
+    if Windows.GetTempFileName(PChar(InitialFolder), 'MRC', 0,
+      PChar(@TempFile[0])) <> 0 then
+    begin
+      Windows.DeleteFile(PChar(@TempFile[0]));
+      Ini.RecordingFolder := InitialFolder;
+      Ini.SaveWav := True;
+      Exit;
+    end;
+    Application.MessageBox(PChar(Format(
+      'Audio recording is not available in %s.'#13#13 +
+      'Try choosing another folder.', [InitialFolder])),
+      'Audio Recording Error', MB_OK or MB_ICONERROR);
+  end;
 end;
 
 

--- a/Main.pas
+++ b/Main.pas
@@ -199,6 +199,7 @@ type
     PlayRecordedAudio1: TMenuItem;
     N8: TMenuItem;
     AudioRecordingEnabled1: TMenuItem;
+    ChooseAudioRecordingFolder1: TMenuItem;
     Panel11: TPanel;
     ListView1: TListView;
     Operator1: TMenuItem;
@@ -288,6 +289,7 @@ type
     procedure File1Click(Sender: TObject);
     procedure PlayRecordedAudio1Click(Sender: TObject);
     procedure AudioRecordingEnabled1Click(Sender: TObject);
+    procedure ChooseAudioRecordingFolder1Click(Sender: TObject);
     procedure SelfMonClick(Sender: TObject);
     procedure Settings1Click(Sender: TObject);
     procedure LIDS1Click(Sender: TObject);
@@ -321,6 +323,8 @@ type
     UserExchangeDirty: boolean; // SetMyExchange is called after exchange edits
     CWSpeedDirty: boolean;      // SetWpm is called after CW Speed edits
     RitLocal: integer;          // tracks incremented RIT Value
+    function EnsureRecordingFolder: Boolean;
+    function RecordingFileName: string;
     function CreateContest(AContestId : TSimContest) : TContest;
     procedure ConfigureExchangeFields;
     procedure SetMyExch1(const AExchType: TExchange1Type; const Avalue: string);
@@ -402,7 +406,8 @@ uses
   IARUHF, ARRLSS,
   MorseKey, FarnsKeyer, CallLst,
   SysUtils, ShellApi, Crc32, Idhttp, Math, IniFiles,
-  Dialogs, System.UITypes, TypInfo, ScoreDlg, Log, PerlRegEx, StrUtils;
+  Dialogs, System.UITypes, TypInfo, ScoreDlg, Log, PerlRegEx, StrUtils,
+  DateUtils, ShlObj;
 
 {$R *.DFM}
 
@@ -423,6 +428,76 @@ begin
     (MainForm.RecvExchTypes.Exch1 = etRST));
   Result := MainForm.RecvExchTypes.Exch1 = etRST;
 end;
+
+
+function TMainForm.EnsureRecordingFolder: Boolean;
+var
+  ProfilePath: array[0..MAX_PATH] of Char;
+begin
+  if Ini.RecordingFolder.IsEmpty and
+    (SHGetFolderPath(0, CSIDL_PROFILE, 0, SHGFP_TYPE_CURRENT,
+      PChar(@ProfilePath[0])) = S_OK) then
+    Ini.RecordingFolder := IncludeTrailingPathDelimiter(
+      PChar(@ProfilePath[0])) + 'Morse Runner CE Recordings';
+
+  Result := False;
+  try
+    if not Ini.RecordingFolder.IsEmpty then
+      Result := DirectoryExists(Ini.RecordingFolder) or
+        ForceDirectories(Ini.RecordingFolder);
+  except
+    Result := False;
+  end;
+
+  if not Result then
+    Application.MessageBox(
+      PChar(Format('Unable to create audio recording folder:'#13'%s',
+        [Ini.RecordingFolder])),
+      'Error', MB_OK or MB_ICONERROR);
+end;
+
+
+function FileNamePart(const Value: string): string;
+var
+  C: Char;
+begin
+  Result := '';
+  for C in Value do
+    if CharInSet(C, ['A'..'Z', 'a'..'z', '0'..'9']) then
+      Result := Result + C
+    else if not Result.IsEmpty and (Result[Length(Result)] <> '-') then
+      Result := Result + '-';
+
+  while not Result.IsEmpty and (Result[Length(Result)] = '-') do
+    Delete(Result, Length(Result), 1);
+end;
+
+
+function TMainForm.RecordingFileName: string;
+var
+  BaseName, CallPart, ContestName, ContestPart: string;
+  I, ParenPos: Integer;
+begin
+  CallPart := FileNamePart(Ini.Call);
+
+  ContestName := ActiveContest.Name;
+  ParenPos := Pos('(', ContestName);
+  if ParenPos > 0 then Delete(ContestName, ParenPos, MaxInt);
+  ContestPart := LowerCase(FileNamePart(ContestName));
+
+  BaseName := IncludeTrailingPathDelimiter(Ini.RecordingFolder) +
+    FormatDateTime('yyyy-mm-dd--hh-nn-ss',
+      TTimeZone.Local.ToUniversalTime(Now)) + 'Z--' +
+    CallPart + '--' + ContestPart;
+  Result := BaseName + '.wav';
+  I := 2;
+  while FileExists(Result) do
+  begin
+    Result := Format('%s--%d.wav', [BaseName, I]);
+    Inc(I);
+  end;
+end;
+
 
 procedure TMainForm.FormCreate(Sender: TObject);
 begin
@@ -469,6 +544,9 @@ begin
         MB_OK or MB_ICONERROR);
     end
   );
+
+  if Ini.SaveWav and not EnsureRecordingFolder then
+    Ini.SaveWav := False;
 
   // populate and sort SimContestCombo after reading .ini file settings
   SimContestComboRefresh;
@@ -2002,6 +2080,13 @@ begin
     // load call history and other contest-specific setup before starting
     if not Tst.OnContestPrepareToStart(Ini.Call, ExchangeEdit.Text) then
       Exit;
+
+    if Ini.SaveWav then
+    begin
+      if not EnsureRecordingFolder then Exit;
+      AlWavFile1.FileName := RecordingFileName;
+      AlWavFile1.OpenWrite;
+    end;
   end;
 
   BStop := Value = rmStop;
@@ -2126,11 +2211,6 @@ begin
       }
     if AlWavFile1.IsOpen then
       AlWavFile1.Close;
-  end
-  else begin
-    AlWavFile1.FileName := ChangeFileExt(ParamStr(0), '.wav');
-    if SaveWav then
-      AlWavFile1.OpenWrite;
   end;
 
   AlSoundOut1.Enabled := not BStop;
@@ -2519,23 +2599,42 @@ begin
   Stp := RunMode = rmStop;
 
   AudioRecordingEnabled1.Enabled := Stp;
-  PlayRecordedAudio1.Enabled := Stp and FileExists(ChangeFileExt(ParamStr(0), '.wav'));
+  ChooseAudioRecordingFolder1.Enabled := Stp;
+  PlayRecordedAudio1.Enabled := Stp and FileExists(AlWavFile1.FileName);
 
   AudioRecordingEnabled1.Checked := Ini.SaveWav;
 end;
 
 procedure TMainForm.PlayRecordedAudio1Click(Sender: TObject);
-var
-  FileName: string;
 begin
-  FileName := ChangeFileExt(ParamStr(0), '.wav');
-  ShellExecute(GetDesktopWindow, 'open', PChar(FileName), '', '', SW_SHOWNORMAL);
+  ShellExecute(GetDesktopWindow, 'open', PChar(AlWavFile1.FileName), '', '', SW_SHOWNORMAL);
 end;
 
 
 procedure TMainForm.AudioRecordingEnabled1Click(Sender: TObject);
 begin
-  Ini.SaveWav := not Ini.SaveWav;
+  if Ini.SaveWav then
+    Ini.SaveWav := False
+  else
+    Ini.SaveWav := EnsureRecordingFolder;
+end;
+
+
+procedure TMainForm.ChooseAudioRecordingFolder1Click(Sender: TObject);
+begin
+  if not EnsureRecordingFolder then Exit;
+
+  with TFileOpenDialog.Create(Self) do
+    try
+      Title := 'Choose Audio Recording Folder';
+      Options := [fdoPickFolders, fdoPathMustExist, fdoForceFileSystem];
+      DefaultFolder := Ini.RecordingFolder;
+      FileName := Ini.RecordingFolder;
+      if Execute then
+        Ini.RecordingFolder := FileName;
+    finally
+      Free;
+    end;
 end;
 
 
@@ -2780,4 +2879,3 @@ begin
 end;
 
 end.
-

--- a/Main.pas
+++ b/Main.pas
@@ -2682,7 +2682,10 @@ begin
       DefaultFolder := Ini.RecordingFolder;
       FileName := Ini.RecordingFolder;
       if Execute then
+      begin
         Ini.RecordingFolder := FileName;
+        Ini.SaveWav := True;
+      end;
     finally
       Free;
     end;

--- a/Readme.txt
+++ b/Readme.txt
@@ -14,7 +14,7 @@
 
 JOIN OUR COMMUNITY
   You are invited to join our community effort.
-  For more information on the Morse Runner Community Edition project,
+  For more information on the Morse Runner Community Edition (MRCE) project,
   please visit https://github.com/w7sst/MorseRunner#readme.
   Feedback can be left in our discussions area.
 
@@ -124,10 +124,11 @@ CONFIGURATION
           that a zero value will disable this feature and is not recommended.
           HST Competition mode ignores this setting and defaults to 50Hz/Step.
 
-    Audio Recording Enabled - You can record yourself under "File" menu
-      "Audio Recording Enabled". When this menu option is checked, MR saves
-      the audio as "MorseRunner.wav" in the same folder. If this file already
-      exists, MR overwrites it.
+    Audio Recording - Under File, "Choose Audio Recording Folder..." selects
+      a persistent folder and enables recording. MRCE defaults to "Morse Runner
+      CE Recordings" in your user folder. "Audio Recording Enabled" switches
+      recording on or off. Each session gets a separate WAV file named with its
+      UTC start time, your call sign and contest, preserving earlier recordings.
 
     Audio buffer size
       You can adjust the audio buffer size by changing the BufSize value in the
@@ -211,7 +212,11 @@ CONFIGURATION
        1. Nothing
           If calling CQ, no one heard you call CQ again.
           If you responded to someone and you got silence, the call sent was incorrect.
-          Send F8 NIL (Not In Log) to have them respond again and/or restart the pile-up.
+          To abandon the QSO, send F8 NIL (Not In Log). By default, "NIL
+          Instantly Removes Caller" under Settings makes MRCE remove one targeted
+          caller immediately. Disable it for more realistic behaviour, which may
+          require several NIL messages and cost QSO time; the default favours
+          training over realism.
        2. Corrected Call
           If you sent a partial call or if you were off a little they may respond with
           "de" (from) and their call or just their call again. Sometimes just the call


### PR DESCRIPTION
Adds a configurable audio recording folder, defaulting to the user profile and persisted in the INI. Each run receives a sanitised UTC/callsign/contest filename. Once a folder is selected, recording is automatic while armed.

Folder selection is write-tested and recovers from stale paths. WAV-open failures disable recording without aborting the session; Win 7+ uses the common dialog, with the legacy folder selector reserved for XP. Closes #259.

I've taken a bit of liberty around the original requirement - instead of popping up the common dialog every time, the user only chooses it once. The path is persisted and his only task is enabling recording. Sharing the files with WR7Q should require now less effort from both sides.

<img width="440" height="244" alt="image" src="https://github.com/user-attachments/assets/497977f9-b1b7-4618-b069-5e0b370b3c1f" />
