### PR TITLE
Refactor with Src/Core/AppPaths.pas to centralize filesystem paths

### DIFF
--- a/ACAG.pas
+++ b/ACAG.pas
@@ -45,6 +45,7 @@ type
 implementation
 
 uses
+  AppPaths,
   SysUtils, Classes;
 
 function TACAG.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -69,7 +70,7 @@ begin
   try
     CallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'JARL_ACAG.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('JARL_ACAG.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/ALLJA.pas
+++ b/ALLJA.pas
@@ -45,6 +45,7 @@ type
 implementation
 
 uses
+  AppPaths,
   SysUtils, Classes;
 
 function TALLJA.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -69,7 +70,7 @@ begin
   try
     CallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'JARL_ALLJA.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('JARL_ALLJA.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/ArrlDx.pas
+++ b/ArrlDx.pas
@@ -51,6 +51,7 @@ implementation
 uses
   SysUtils, DXCC, CallLst,
   ExchFields,
+  AppPaths,
   Ini, Main;
 
 
@@ -118,7 +119,7 @@ begin
   try
     ArrlDxCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'ARRLDXCW_USDX.txt');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('ARRLDXCW_USDX.txt'));
 
     for i:= 0 to slst.Count-1 do begin
       tl.DelimitedText := slst.Strings[i];

--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -94,6 +94,7 @@ uses
   Dialogs,      // for ShowMessage
   Vcl.Clipbrd,  // for TClipBoard
 {$endif}
+  AppPaths,
   DXCC;
 
 var
@@ -221,7 +222,7 @@ begin
   try
     FdCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'FDGOTA.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('FDGOTA.TXT'));
 
     // Pass 1 - find and process all club stations (class A, C or F).
     //        - deffer all home/portable stations w/ a club name to Pass 2.

--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -73,6 +73,7 @@ uses
   PerlRegEx,      // for regular expression support
   Ini,            // for ActiveContest
   ArrlSections,   // SectionsTbl
+  AppPaths,
   DXCC;
 
 function TSweepstakes.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -97,7 +98,7 @@ begin
   rec := nil;
 
   try
-    slst.LoadFromFile(ParamStr(1) + 'SSCW.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('SSCW.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       tl.DelimitedText := slst.Strings[i];

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -45,7 +45,8 @@ type
 implementation
 
 uses
-    SysUtils, DXCC;
+  AppPaths,
+  SysUtils, DXCC;
 
 function TCWOPS.LoadCallHistory(const AUserCallsign : string) : boolean;
 const
@@ -71,7 +72,7 @@ begin
     try
         CWOPSList.Clear;
 
-        slst.LoadFromFile(ParamStr(1) + 'CWOPS.LIST');
+        slst.LoadFromFile(TAppPaths.ContestDataFile('CWOPS.LIST'));
 
         for i:= 0 to slst.Count-1 do begin
             if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/CWSST.pas
+++ b/CWSST.pas
@@ -47,6 +47,7 @@ implementation
 
 uses
     Math,
+    AppPaths,
     SysUtils, StrUtils, DXCC;
 
 function TCWSST.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -73,7 +74,7 @@ begin
     try
         CWSSTList.Clear;
 
-        slst.LoadFromFile(ParamStr(1) + 'K1USNSST.txt');
+        slst.LoadFromFile(TAppPaths.ContestDataFile('K1USNSST.txt'));
         slst.Sort;
 
         for i:= 0 to slst.Count-1 do begin

--- a/CallLst.pas
+++ b/CallLst.pas
@@ -29,6 +29,7 @@ type
 implementation
 
 uses
+  AppPaths,
   SysUtils, Ini;
 
 function CompareCalls(Item1, Item2: Pointer): Integer;
@@ -57,7 +58,7 @@ var
 begin
   Calls.Clear;
 
-  FileName := ExtractFilePath(ParamStr(0)) + 'Master.dta';
+  FileName := ExtractFilePath(TAppPaths.ContestDataFile('Master.dta'));
   if not FileExists(FileName) then Exit;
 
   with TFileStream.Create(FileName, fmOpenRead) do

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -48,6 +48,7 @@ end;
 implementation
 
 uses
+  AppPaths,
   SysUtils, Classes, DXCC;
 
 function TCqWw.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -73,7 +74,7 @@ begin
   try
     CqWwCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'CQWWCW.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('CQWWCW.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/DXCC.pas
+++ b/DXCC.pas
@@ -39,6 +39,7 @@ var
 implementation
 
 uses
+    AppPaths,
     SysUtils, Contnrs, CallsignUtils;
 
 procedure TDXCC.LoadDxCCList;
@@ -51,7 +52,7 @@ begin
     tl:= TStringList.Create;
     try
         DXCCList:= TObjectList<TDXCCRec>.Create;
-        slst.LoadFromFile(ParamStr(1) + 'DXCC.LIST');
+        slst.LoadFromFile(TAppPaths.ContestDataFile('DXCC.LIST'));
 
         // The search algorithm walks this list in reverse order.
         for i:= 0 to slst.Count-1 do begin

--- a/IaruHf.pas
+++ b/IaruHf.pas
@@ -50,6 +50,7 @@ implementation
 
 uses
   SysUtils, PerlRegEx, DXCC, CallLst,
+  AppPaths,
   Ini, Main;
 
 
@@ -105,7 +106,7 @@ begin
   try
     IaruHfCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'IARU_HF.txt');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('IARU_HF.txt'));
 
     for i:= 0 to slst.Count-1 do begin
       tl.DelimitedText := slst.Strings[i];

--- a/MorseRunner.dpr
+++ b/MorseRunner.dpr
@@ -52,6 +52,7 @@ uses
   Lexer in 'Util\Lexer.pas',
   ArrlSections in 'Util\ArrlSections.pas',
   CallsignUtils in 'Util\CallsignUtils.pas',
+  AppPaths in 'Src\Core\AppPaths.pas',
   SSExchParser in 'Util\SSExchParser.pas';
 
 {$R *.RES}

--- a/MorseRunner.dproj
+++ b/MorseRunner.dproj
@@ -171,6 +171,7 @@
         <DCCReference Include="Util\Lexer.pas"/>
         <DCCReference Include="Util\ArrlSections.pas"/>
         <DCCReference Include="Util\CallsignUtils.pas"/>
+        <DCCReference Include="Src\Core\AppPaths.pas"/>
         <DCCReference Include="Util\SSExchParser.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -56,6 +56,7 @@ implementation
 uses
   SysUtils, Classes, Contnrs, PerlRegEx,
   ExchFields,
+  AppPaths,
   Ini, DXCC, Contest;
 
 function TNcjNaQp.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -92,7 +93,7 @@ begin
   try
     NaQpCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'NAQPCW.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('NAQPCW.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/Src/Core/AppPaths.pas
+++ b/Src/Core/AppPaths.pas
@@ -1,0 +1,248 @@
+unit AppPaths;
+
+interface
+
+type
+  {
+    TAppPaths centralizes all filesystem paths used by the application
+    and test infrastructure.
+
+    Responsibilities
+    ----------------
+    - Detect development vs installed runtime layout
+    - Provide canonical application directories
+    - Provide contest data file locations
+    - Provide shared test data locations
+    - Provide writable temporary test file locations
+    - Cache resolved paths for efficiency and consistency
+
+    Directory Conventions
+    ---------------------
+    Development Layout
+      RepositoryRoot\
+        Src\
+        Test\
+        ...
+
+      Contest data files:
+        Src\Domain\Contests\Data\
+
+      Test data files:
+        Test\Data\
+
+      Temporary test files:
+        Test\Temp\
+
+    Installed Layout
+      ApplicationDirectory\
+        Executable.exe
+        ContestData\
+
+    Notes
+    -----
+    - All directory paths returned by TAppPaths include a trailing path delimiter.
+    - File-returning functions return fully-qualified file paths.
+    - Temporary test directories are automatically created on demand.
+    - TempTestFile('') creates a (potential) unique temporary file name.
+
+    Design Notes
+    ------------
+    TAppPaths is intended to be application-wide infrastructure and should
+    remain independent of contest-specific logic.
+
+    The class caches resolved filesystem locations after first initialization
+    to avoid repeated filesystem probing during runtime and unit testing.
+
+    Developed with the assistance of OpenAI/ChatGPT.
+  }
+  TAppPaths = record
+  private
+    class var
+      FInitialized: Boolean;
+      FExecutableDir: string;
+      FRepositoryRootDir: string;
+      FContestDataDir: string;
+      FTestDataDir: string;
+      FTempTestDir: string;
+      FIsInstalledLayout: Boolean;
+
+    class procedure Initialize; static;
+
+  public
+    class function IsInstalledLayout: Boolean; static;
+
+    class function ExecutableDir: string; static;
+    class function RepositoryRootDir: string; static;
+
+    class function ContestDataDir: string; static;
+    class function ContestDataFile(const FileName: string): string; static;
+
+    class function TestDataDir: string; static;
+    class function TestDataFile(const FileName: string): string; static;
+
+    class function TempTestDir: string; static;
+    class function TempTestFile(const FileName: string = ''): string; static;
+    class function CreateTempTestFile(const Extension: string = '.tmp'): string; static;
+
+    class procedure ResetForTesting; static;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.IOUtils;
+
+class procedure TAppPaths.Initialize;
+begin
+  if FInitialized then
+    Exit;
+
+  Randomize;
+
+  // Executable location
+  TAppPaths.FExecutableDir := IncludeTrailingPathDelimiter(
+    ExtractFilePath(ParamStr(0)));
+
+  // Detect repository layout
+  if TDirectory.Exists(TPath.Combine(FExecutableDir, '.git')) and
+     TDirectory.Exists(TPath.Combine(FExecutableDir, 'VCL')) and
+     TDirectory.Exists(TPath.Combine(FExecutableDir, 'Util')) and
+     TFile.Exists(TPath.Combine(FExecutableDir, 'Main.pas')) then
+    TAppPaths.FRepositoryRootDir := FExecutableDir
+  else
+    TAppPaths.FRepositoryRootDir := '';
+
+  // Detect installed layout
+  if TDirectory.Exists(TPath.Combine(FExecutableDir, 'ContestData')) then
+    TAppPaths.FIsInstalledLayout := True
+{$IFDEF FUTURE_CONTEST_DATA_SUBDIR}
+  else if TDirectory.Exists(
+    TPath.Combine([FRepositoryRootDir, 'Src', 'Domain', 'Contests', 'Data'])) then
+    TAppPaths.FIsInstalledLayout := False
+{$ELSE}
+  else if not FRepositoryRootDir.IsEmpty then
+    TAppPaths.FIsInstalledLayout := False
+{$ENDIF}
+  else
+    raise Exception.Create('Invalid configuration');
+
+  // location of contest history files
+{$IFDEF FUTURE_CONTEST_DATA_SUBDIR}
+  if FIsInstalledLayout then
+    FContestDataDir := IncludeTrailingPathDelimiter(
+      TPath.Combine(FExecutableDir, 'ContestData'))
+  else
+    FContestDataDir := IncludeTrailingPathDelimiter(
+      TPath.Combine(
+        [FRepositoryRootDir, 'Src', 'Domain', 'Contests', 'Data']));
+  FContestDataDir := IncludeTrailingPathDelimiter(FContestDataDir);
+{$ELSE}
+  TAppPaths.FContestDataDir := TAppPaths.FExecutableDir;
+{$ENDIF}
+
+  TAppPaths.FInitialized := True;
+end;
+
+class procedure TAppPaths.ResetForTesting;
+begin
+  TAppPaths.FInitialized := False;
+end;
+
+class function TAppPaths.IsInstalledLayout: Boolean;
+begin
+  Initialize;
+  Result := FIsInstalledLayout;
+end;
+
+class function TAppPaths.ExecutableDir: string;
+begin
+  Initialize;
+  Result := FExecutableDir;
+end;
+
+class function TAppPaths.RepositoryRootDir: string;
+begin
+  Initialize;
+  Result := FRepositoryRootDir;
+end;
+
+class function TAppPaths.ContestDataDir: string;
+begin
+  Initialize;
+  Result := FContestDataDir;
+end;
+
+class function TAppPaths.ContestDataFile(const FileName: string): string;
+begin
+  Result := TPath.Combine(ContestDataDir, FileName);
+end;
+
+class function TAppPaths.TestDataDir: string;
+begin
+  if FTestDataDir.IsEmpty then
+    FTestDataDir := IncludeTrailingPathDelimiter(
+      TPath.Combine([RepositoryRootDir,'Test', 'Data']));
+
+  Result := FTestDataDir;
+end;
+
+class function TAppPaths.TestDataFile(const FileName: string): string;
+begin
+  Result := TPath.Combine(TestDataDir, FileName);
+end;
+
+class function TAppPaths.TempTestDir: string;
+begin
+  if FTempTestDir.IsEmpty then
+    FTempTestDir := IncludeTrailingPathDelimiter(
+      TPath.Combine([RepositoryRootDir, 'Test', 'Temp']));
+
+  ForceDirectories(FTempTestDir);
+
+  Result := FTempTestDir;
+end;
+
+{
+  Returns a writable temporary test file path.
+
+  If FileName is empty, a potentially unique temporary file path
+  is contructed under TempTestDir, but the file is not created.
+  Since regression tests are not threaded, name collisions are very unlikely.
+
+  If FileName is supplied, the path is constructed under
+  TempTestDir but the file is not created.
+}
+class function TAppPaths.TempTestFile(const FileName: string = ''): string;
+begin
+  if FileName.IsEmpty then
+  begin
+    repeat
+      Result := TPath.Combine(
+        TempTestDir,
+        Format('tmp%.4x.tmp', [Random($10000)]));
+    until not TFile.Exists(Result);
+  end
+  else
+    Result := TPath.Combine(TempTestDir, FileName);
+end;
+
+class function TAppPaths.CreateTempTestFile(
+  const Extension: string): string;
+var
+  Ext: string;
+begin
+  Ext := Extension;
+  if (not Ext.IsEmpty) and (Ext[1] <> '.') then
+    Ext := '.' + Ext;
+
+  repeat
+    Result := TPath.Combine(
+      TempTestDir,
+      ChangeFileExt(Format('tmp%.4x.tmp', [Random($10000)]), Ext));
+  until not TFile.Exists(Result);
+
+  TFile.WriteAllText(Result, '');
+end;
+
+end.

--- a/Test/Core/Test.AppPaths.pas
+++ b/Test/Core/Test.AppPaths.pas
@@ -1,0 +1,232 @@
+unit Test.AppPaths;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  TAppPathsTests = class
+  public
+    [Test]
+    procedure RepositoryRootDir_Is_Not_Empty;
+
+    [Test]
+    procedure All_Directories_Have_Trailing_Delimiter;
+
+    [Test]
+    procedure ContestDataDir_Is_Under_AppRoot;
+
+    [Test]
+    procedure ContestDataFile_Appends_FileName;
+
+    [Test]
+    procedure ContestDataFile_Does_Not_Duplicate_Separators;
+
+    [Test]
+    procedure TestDataDir_Is_Under_AppRoot;
+
+    [Test]
+    procedure TestDataFile_Appends_FileName;
+
+    [Test]
+    procedure TempTestDir_Is_Created;
+
+    [Test]
+    procedure TempTestDir_Is_Writable;
+
+    [Test]
+    procedure TempTestDir_Is_Under_AppRoot;
+
+    [Test]
+    procedure TempTestFile_Appends_FileName;
+
+    [Test]
+    procedure TempTestFile_Empty_FileName_Creates_Unique_File;
+
+    [Test]
+    procedure CreateTempTestFile_Is_Empty_File;
+
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  AppPaths;
+
+procedure TAppPathsTests.RepositoryRootDir_Is_Not_Empty;
+begin
+  Assert.IsFalse(TAppPaths.RepositoryRootDir.IsEmpty);
+end;
+
+procedure TAppPathsTests.All_Directories_Have_Trailing_Delimiter;
+begin
+  Assert.IsTrue(TAppPaths.RepositoryRootDir.EndsWith(PathDelim));
+  Assert.IsTrue(TAppPaths.ContestDataDir.EndsWith(PathDelim));
+  Assert.IsTrue(TAppPaths.TestDataDir.EndsWith(PathDelim));
+  Assert.IsTrue(TAppPaths.TempTestDir.EndsWith(PathDelim));
+end;
+
+procedure TAppPathsTests.ContestDataDir_Is_Under_AppRoot;
+begin
+  Assert.IsTrue(TAppPaths.ContestDataDir.StartsWith(TAppPaths.ExecutableDir));
+
+{$IFDEF FUTURE_CONTEST_DATA_SUBDIR}
+  Assert.IsTrue(TAppPaths.ContestDataDir.Contains('ContestData'));
+{$ELSE}
+  Assert.AreEqual(TAppPaths.ExecutableDir, TAppPaths.ContestDataDir);
+{$ENDIF}
+end;
+
+procedure TAppPathsTests.ContestDataFile_Appends_FileName;
+var
+  Path: string;
+begin
+  Path := TAppPaths.ContestDataFile('FDGOTA.txt');
+
+  Assert.IsTrue(Path.EndsWith('FDGOTA.txt'));
+end;
+
+procedure TAppPathsTests.ContestDataFile_Does_Not_Duplicate_Separators;
+var
+  Path: string;
+begin
+  Path := TAppPaths.ContestDataFile('sample.txt');
+
+  Assert.IsFalse(Path.Contains('\\'),
+    'Path should not contain duplicate separators.');
+end;
+
+procedure TAppPathsTests.TestDataDir_Is_Under_AppRoot;
+var
+  Path, ExpectedTail: string;
+begin
+  Path := TAppPaths.TestDataDir;
+
+  Assert.IsTrue(Path.StartsWith(TAppPaths.RepositoryRootDir),
+    format('%s: should start with RepositoryRootDir',[Path]));
+
+  ExpectedTail := IncludeTrailingPathDelimiter(TPath.Combine('Test', 'Data'));
+  Assert.IsTrue(Path.EndsWith(ExpectedTail),
+    format('%s: should end with %s', [Path, ExpectedTail]));
+end;
+
+procedure TAppPathsTests.TestDataFile_Appends_FileName;
+var
+  Path: string;
+begin
+  Path := TAppPaths.TestDataFile('sample.csv');
+
+  Assert.IsTrue(Path.EndsWith('sample.csv'));
+end;
+
+procedure TAppPathsTests.TempTestDir_Is_Created;
+var
+  Dir: string;
+begin
+  Dir := TPath.Combine([TAppPaths.RepositoryRootDir, 'Test', 'Temp']);
+
+  if TDirectory.Exists(Dir) then
+    TDirectory.Delete(Dir, True);
+
+  Assert.IsFalse(TDirectory.Exists(Dir));
+
+  Dir := TAppPaths.TempTestDir;
+
+  Assert.IsTrue(
+    TDirectory.Exists(Dir),
+    'Temp test directory should be auto-created.');
+end;
+
+procedure TAppPathsTests.TempTestDir_Is_Writable;
+var
+  Dir: string;
+  FileName: string;
+begin
+  Dir := TAppPaths.TempTestDir;
+
+  FileName := TPath.Combine(Dir, 'write-test.tmp');
+
+  try
+    TFile.WriteAllText(FileName, 'test');
+
+    Assert.IsTrue(TFile.Exists(FileName));
+  finally
+    DeleteFile(FileName);
+  end;
+end;
+
+procedure TAppPathsTests.TempTestDir_Is_Under_AppRoot;
+var
+  Path, ExpectedTail: string;
+begin
+  Path := TAppPaths.TempTestDir;
+
+  ExpectedTail := IncludeTrailingPathDelimiter(TPath.Combine('Test', 'Temp'));
+  Assert.IsTrue(Path.StartsWith(TAppPaths.RepositoryRootDir));
+  Assert.IsTrue(Path.EndsWith(ExpectedTail),
+    format('%s: should end with %s', [Path, ExpectedTail]));
+end;
+
+procedure TAppPathsTests.TempTestFile_Appends_FileName;
+var
+  Path: string;
+begin
+  Path := TAppPaths.TempTestFile('temp.csv');
+
+  Assert.IsTrue(Path.EndsWith('temp.csv'));
+end;
+
+procedure TAppPathsTests.TempTestFile_Empty_FileName_Creates_Unique_File;
+var
+  FileName1: string;
+  FileName2: string;
+begin
+  FileName1 := TAppPaths.TempTestFile('');
+  FileName2 := TAppPaths.TempTestFile('');
+
+  try
+    Assert.IsFalse(FileName1.IsEmpty);
+    Assert.IsFalse(FileName2.IsEmpty);
+
+    Assert.AreNotEqual(FileName1, FileName2);
+
+    Assert.IsTrue(FileName1.StartsWith(TAppPaths.TempTestDir));
+    Assert.IsTrue(FileName2.StartsWith(TAppPaths.TempTestDir));
+
+  finally
+    DeleteFile(FileName1);
+    DeleteFile(FileName2);
+  end;
+end;
+
+procedure TAppPathsTests.CreateTempTestFile_Is_Empty_File;
+var
+  FileName: string;
+  Contents: string;
+begin
+  FileName := TAppPaths.CreateTempTestFile('txt');
+
+  try
+    Assert.IsTrue(
+      TFile.Exists(FileName),
+      'Temporary file should exist.');
+
+    Contents := TFile.ReadAllText(FileName);
+
+    Assert.AreEqual(
+      '',
+      Contents,
+      'Temporary file should initially be empty.');
+  finally
+    DeleteFile(FileName);
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TAppPathsTests);
+
+end.

--- a/Test/UnitTests.dpr
+++ b/Test/UnitTests.dpr
@@ -27,6 +27,8 @@ uses
   MySSExchTest in 'MySSExchTest.pas',
   SSExchParserTest in 'SSExchParserTest.pas',
   DxccListTest in 'DxccListTest.pas',
+  AppPaths in '..\Src\Core\AppPaths.pas',
+  Test.AppPaths in 'Core\Test.AppPaths.pas',
   DxOperTest in 'DxOperTest.pas';
 
 {$IFNDEF TESTINSIGHT}

--- a/Test/UnitTests.dproj
+++ b/Test/UnitTests.dproj
@@ -107,6 +107,8 @@
         <DCCReference Include="MySSExchTest.pas"/>
         <DCCReference Include="SSExchParserTest.pas"/>
         <DCCReference Include="DxccListTest.pas"/>
+        <DCCReference Include="Core\Test.AppPaths.pas"/>
+        <DCCReference Include="..\Src\Core\AppPaths.pas"/>
         <DCCReference Include="DxOperTest.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>


### PR DESCRIPTION
- TAppPaths centralizes all filesystem paths used by the application and test infrastructure.
- Converted all contest file access to use TAppPaths.ContestDataFile.

This change prepares us for future reorganization of both our source tree and distribution/installation directory organization. It introduces API to represent the call history file directory and other directories.