### PR TITLE
Refactor call history reader

### DIFF
--- a/ACAG.pas
+++ b/ACAG.pas
@@ -45,6 +45,7 @@ type
 implementation
 
 uses
+  AppPaths,
   SysUtils, Classes;
 
 function TACAG.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -69,7 +70,7 @@ begin
   try
     CallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'JARL_ACAG.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('JARL_ACAG.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/ALLJA.pas
+++ b/ALLJA.pas
@@ -45,6 +45,7 @@ type
 implementation
 
 uses
+  AppPaths,
   SysUtils, Classes;
 
 function TALLJA.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -69,7 +70,7 @@ begin
   try
     CallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'JARL_ALLJA.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('JARL_ALLJA.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/ArrlDx.pas
+++ b/ArrlDx.pas
@@ -1,3 +1,8 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
 unit ARRLDX;
 
 {$ifdef FPC}
@@ -42,6 +47,9 @@ implementation
 uses
   SysUtils, DXCC, CallLst,
   ExchFields,
+  ContestFileFormat,
+  ContestFileReader,        // for TRecordConsumer<>
+  ArrlDx.Reader,
   AppPaths,
   Ini, Main;
 
@@ -65,102 +73,28 @@ end;
 // load call history file iff user's callsign has changed.
 // for US/CA calls, load DX callsigns; for DX calls, load US/CA calls.
 function TArrlDx.LoadCallHistory(const AUserCallsign: string) : boolean;
-const
-  DelimitChar: char = ',';
 var
-  slst, tl: TStringList;
-  i: integer;
-  rec: TArrlDxCallRec;
-  CallInx, StateInx, PowerInx, UserTextInx: integer;
-
-  { Find the named string. Throw an exception if required field is missing. }
-  function FindIndex(const AFieldName: String; ARequiredField: Boolean) : Integer;
-  begin
-    Result := tl.IndexOf(AFieldName);
-    assert((Result >= 0) or not ARequiredField);
-    if ARequiredField and (Result = -1) then
-      raise Exception.CreateFmt(
-        'Invalid call history file: ''!!Order!!'' record is missing required ''%s'' field. Line %d, File "%s"',
-        [AFieldName, i+1, ParamStr(1) + 'ARRLDXCW_USDX.txt']);
-  end;
-
-  { Returns the field value for the specified column index.
-    If the index is invalid or the column is missing, an empty string is returned.
-    Leading and trailing whitespace is removed.
-  }
-  function GetValue(ColumnInx: Integer): String;
-  begin
-    if Cardinal(ColumnInx) < Cardinal(tl.Count) then
-      Result := tl[ColumnInx].Trim
-    else
-      Result := '';
-  end;
-
+  Reader: TArrlDxContestFileReader;
+  FileName: String;
 begin
-  slst:= TStringList.Create;
-  tl:= TStringList.Create;
-  tl.Delimiter := DelimitChar;
-  tl.StrictDelimiter := True;
-  rec := nil;
-  CallInx := -1;
-  StateInx := -1;
-  PowerInx := -1;
-  UserTextInx := -1;
+  Reader := TArrlDxContestFileReader.Create(Self.HomeCallIsLocal);
 
   try
     ArrlDxCallList.Clear;
 
-    slst.LoadFromFile(TAppPaths.ContestDataFile('ARRLDXCW_USDX.txt'));
+    FileName := 'ARRLDXCW_USDX.txt';
 
-    for i:= 0 to slst.Count-1 do begin
-      tl.DelimitedText := slst.Strings[i];
+    Reader.ReadFile(TAppPaths.ContestDataFile(FileName),
+      procedure(rec: TArrlDxCallRec)
+      begin
+        ArrlDxCallList.Add(rec);
+      end);
 
-      // skip empty or comment lines
-      if (tl.Count = 0) or tl[0].TrimLeft.StartsWith('#') then continue;
-
-      if (tl[0] = '!!Order!!') then
-        begin
-          // !!Order!!,Call,Name,State,Power,UserText,  // Dx Stations
-          // !!Order!!,Call,Name,State,                 // US Stations
-          tl.Delete(0); // shifts others down by one
-
-          // DX sends Call,Power
-          // W/VE sends Call,State
-          CallInx := FindIndex('Call', True);
-          StateInx := FindIndex('State', False);
-          PowerInx := FindIndex('Power', False);
-          UserTextInx := FindIndex('UserText', False);
-
-          continue;
-        end;
-
-      if rec = nil then
-        rec := TArrlDxCallRec.Create;
-
-      rec.Call := GetValue(CallInx).ToUpper;
-      rec.State := GetValue(StateInx).ToUpper;
-      rec.Power := GetValue(PowerInx).ToUpper;
-      rec.UserText := GetValue(UserTextInx);
-
-      if rec.Call.IsEmpty then continue;
-
-      // W/VE stations work only DX stations (those with non-empty Power field);
-      // DX Stations work only W/VE stations (those with non-empty State field)
-      if (    HomeCallIsLocal and not rec.Power.IsEmpty) or
-         (not HomeCallIsLocal and not rec.State.IsEmpty) then
-        begin
-          ArrlDxCallList.Add(rec);
-          rec := nil;
-        end;
-    end;
-
+    ArrlDxCallList.Sort(Self.Comparer);
     Result := True;
 
   finally
-    if rec <> nil then rec.Free;
-    slst.Free;
-    tl.Free;
-
+    Reader.Free;
   end;
 end;
 

--- a/ArrlDx.pas
+++ b/ArrlDx.pas
@@ -8,19 +8,10 @@ interface
 
 uses
   Generics.Defaults, Generics.Collections, Classes, DualExchContest, DxStn,
+  ArrlDx.Types,
   Log;
 
 type
-  TArrlDxCallRec = class
-  public
-    Call: string;     // call sign
-    State: string;    // State/Province (US/Canada)
-    Power: string;    // Power (DX Stations)
-    UserText: string; // club name
-    function GetString: string; // returns <State>|<Power> [UserText]
-    class function compareCall(const left, right: TArrlDxCallRec) : integer; static;
-  end;
-
   TArrlDx = class(TDualExchContest)
   private
     ArrlDxCallList: TObjectList<TArrlDxCallRec>;
@@ -371,20 +362,6 @@ begin
            Exit;
        end;
    end;
-end;
-
-
-class function TArrlDxCallRec.compareCall(const left, right: TArrlDxCallRec) : integer;
-begin
-  Result := CompareStr(left.Call, right.Call);
-end;
-
-
-function TArrlDxCallRec.GetString: string; // returns <State>|<Power> [UserText]
-begin
-  Result := Format(' - %s%s', [State, Power]);
-  if UserText <> '' then
-    Result := Result + ' ' + UserText;
 end;
 
 

--- a/ArrlDx.pas
+++ b/ArrlDx.pas
@@ -51,6 +51,7 @@ implementation
 uses
   SysUtils, DXCC, CallLst,
   ExchFields,
+  AppPaths,
   Ini, Main;
 
 
@@ -118,7 +119,7 @@ begin
   try
     ArrlDxCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'ARRLDXCW_USDX.txt');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('ARRLDXCW_USDX.txt'));
 
     for i:= 0 to slst.Count-1 do begin
       tl.DelimitedText := slst.Strings[i];

--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -94,6 +94,7 @@ uses
   Dialogs,      // for ShowMessage
   Vcl.Clipbrd,  // for TClipBoard
 {$endif}
+  AppPaths,
   DXCC;
 
 var
@@ -221,7 +222,7 @@ begin
   try
     FdCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'FDGOTA.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('FDGOTA.TXT'));
 
     // Pass 1 - find and process all club stations (class A, C or F).
     //        - deffer all home/portable stations w/ a club name to Pass 2.

--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -73,6 +73,7 @@ uses
   PerlRegEx,      // for regular expression support
   Ini,            // for ActiveContest
   ArrlSections,   // SectionsTbl
+  AppPaths,
   DXCC;
 
 function TSweepstakes.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -97,7 +98,7 @@ begin
   rec := nil;
 
   try
-    slst.LoadFromFile(ParamStr(1) + 'SSCW.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('SSCW.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       tl.DelimitedText := slst.Strings[i];

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -45,7 +45,8 @@ type
 implementation
 
 uses
-    SysUtils, DXCC;
+  AppPaths,
+  SysUtils, DXCC;
 
 function TCWOPS.LoadCallHistory(const AUserCallsign : string) : boolean;
 const
@@ -71,7 +72,7 @@ begin
     try
         CWOPSList.Clear;
 
-        slst.LoadFromFile(ParamStr(1) + 'CWOPS.LIST');
+        slst.LoadFromFile(TAppPaths.ContestDataFile('CWOPS.LIST'));
 
         for i:= 0 to slst.Count-1 do begin
             if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/CWSST.pas
+++ b/CWSST.pas
@@ -47,6 +47,7 @@ implementation
 
 uses
     Math,
+    AppPaths,
     SysUtils, StrUtils, DXCC;
 
 function TCWSST.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -73,7 +74,7 @@ begin
     try
         CWSSTList.Clear;
 
-        slst.LoadFromFile(ParamStr(1) + 'K1USNSST.txt');
+        slst.LoadFromFile(TAppPaths.ContestDataFile('K1USNSST.txt'));
         slst.Sort;
 
         for i:= 0 to slst.Count-1 do begin

--- a/CallLst.pas
+++ b/CallLst.pas
@@ -29,6 +29,7 @@ type
 implementation
 
 uses
+  AppPaths,
   SysUtils, Ini;
 
 function CompareCalls(Item1, Item2: Pointer): Integer;
@@ -57,7 +58,7 @@ var
 begin
   Calls.Clear;
 
-  FileName := ExtractFilePath(ParamStr(0)) + 'Master.dta';
+  FileName := ExtractFilePath(TAppPaths.ContestDataFile('Master.dta'));
   if not FileExists(FileName) then Exit;
 
   with TFileStream.Create(FileName, fmOpenRead) do

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -48,6 +48,7 @@ end;
 implementation
 
 uses
+  AppPaths,
   SysUtils, Classes, DXCC;
 
 function TCqWw.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -73,7 +74,7 @@ begin
   try
     CqWwCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'CQWWCW.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('CQWWCW.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/DXCC.pas
+++ b/DXCC.pas
@@ -39,6 +39,7 @@ var
 implementation
 
 uses
+    AppPaths,
     SysUtils, Contnrs, CallsignUtils;
 
 procedure TDXCC.LoadDxCCList;
@@ -51,7 +52,7 @@ begin
     tl:= TStringList.Create;
     try
         DXCCList:= TObjectList<TDXCCRec>.Create;
-        slst.LoadFromFile(ParamStr(1) + 'DXCC.LIST');
+        slst.LoadFromFile(TAppPaths.ContestDataFile('DXCC.LIST'));
 
         // The search algorithm walks this list in reverse order.
         for i:= 0 to slst.Count-1 do begin

--- a/IaruHf.pas
+++ b/IaruHf.pas
@@ -50,6 +50,7 @@ implementation
 
 uses
   SysUtils, PerlRegEx, DXCC, CallLst,
+  AppPaths,
   Ini, Main;
 
 
@@ -105,7 +106,7 @@ begin
   try
     IaruHfCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'IARU_HF.txt');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('IARU_HF.txt'));
 
     for i:= 0 to slst.Count-1 do begin
       tl.DelimitedText := slst.Strings[i];

--- a/MorseRunner.dpr
+++ b/MorseRunner.dpr
@@ -54,6 +54,9 @@ uses
   CallsignUtils in 'Util\CallsignUtils.pas',
   AppPaths in 'Src\Core\AppPaths.pas',
   ArrlDx.Types in 'Src\Domain\Contests\ArrlDx.Types.pas',
+  ContestFileReader in 'Src\Persistence\ContestFileReader.pas',
+  ContestFileFormat in 'Src\Persistence\ContestFileFormat.pas',
+  ArrlDx.Reader in 'Src\Persistence\Contests\ArrlDx.Reader.pas',
   SSExchParser in 'Util\SSExchParser.pas';
 
 {$R *.RES}

--- a/MorseRunner.dpr
+++ b/MorseRunner.dpr
@@ -52,6 +52,7 @@ uses
   Lexer in 'Util\Lexer.pas',
   ArrlSections in 'Util\ArrlSections.pas',
   CallsignUtils in 'Util\CallsignUtils.pas',
+  AppPaths in 'Src\Core\AppPaths.pas',
   SSExchParser in 'Util\SSExchParser.pas';
 
 {$R *.RES}

--- a/MorseRunner.dpr
+++ b/MorseRunner.dpr
@@ -53,6 +53,7 @@ uses
   ArrlSections in 'Util\ArrlSections.pas',
   CallsignUtils in 'Util\CallsignUtils.pas',
   AppPaths in 'Src\Core\AppPaths.pas',
+  ArrlDx.Types in 'Src\Domain\Contests\ArrlDx.Types.pas',
   SSExchParser in 'Util\SSExchParser.pas';
 
 {$R *.RES}

--- a/MorseRunner.dproj
+++ b/MorseRunner.dproj
@@ -171,6 +171,7 @@
         <DCCReference Include="Util\Lexer.pas"/>
         <DCCReference Include="Util\ArrlSections.pas"/>
         <DCCReference Include="Util\CallsignUtils.pas"/>
+        <DCCReference Include="Src\Core\AppPaths.pas"/>
         <DCCReference Include="Util\SSExchParser.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/MorseRunner.dproj
+++ b/MorseRunner.dproj
@@ -172,6 +172,7 @@
         <DCCReference Include="Util\ArrlSections.pas"/>
         <DCCReference Include="Util\CallsignUtils.pas"/>
         <DCCReference Include="Src\Core\AppPaths.pas"/>
+        <DCCReference Include="Src\Domain\Contests\ArrlDx.Types.pas"/>
         <DCCReference Include="Util\SSExchParser.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/MorseRunner.dproj
+++ b/MorseRunner.dproj
@@ -173,6 +173,9 @@
         <DCCReference Include="Util\CallsignUtils.pas"/>
         <DCCReference Include="Src\Core\AppPaths.pas"/>
         <DCCReference Include="Src\Domain\Contests\ArrlDx.Types.pas"/>
+        <DCCReference Include="Src\Persistence\ContestFileReader.pas"/>
+        <DCCReference Include="Src\Persistence\ContestFileFormat.pas"/>
+        <DCCReference Include="Src\Persistence\Contests\ArrlDx.Reader.pas"/>
         <DCCReference Include="Util\SSExchParser.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -56,6 +56,7 @@ implementation
 uses
   SysUtils, Classes, Contnrs, PerlRegEx,
   ExchFields,
+  AppPaths,
   Ini, DXCC, Contest;
 
 function TNcjNaQp.LoadCallHistory(const AUserCallsign : string) : boolean;
@@ -92,7 +93,7 @@ begin
   try
     NaQpCallList.Clear;
 
-    slst.LoadFromFile(ParamStr(1) + 'NAQPCW.TXT');
+    slst.LoadFromFile(TAppPaths.ContestDataFile('NAQPCW.TXT'));
 
     for i:= 0 to slst.Count-1 do begin
       if (slst.Strings[i].StartsWith('!!Order!!')) then continue;

--- a/Src/Core/AppPaths.pas
+++ b/Src/Core/AppPaths.pas
@@ -1,0 +1,248 @@
+unit AppPaths;
+
+interface
+
+type
+  {
+    TAppPaths centralizes all filesystem paths used by the application
+    and test infrastructure.
+
+    Responsibilities
+    ----------------
+    - Detect development vs installed runtime layout
+    - Provide canonical application directories
+    - Provide contest data file locations
+    - Provide shared test data locations
+    - Provide writable temporary test file locations
+    - Cache resolved paths for efficiency and consistency
+
+    Directory Conventions
+    ---------------------
+    Development Layout
+      RepositoryRoot\
+        Src\
+        Test\
+        ...
+
+      Contest data files:
+        Src\Domain\Contests\Data\
+
+      Test data files:
+        Test\Data\
+
+      Temporary test files:
+        Test\Temp\
+
+    Installed Layout
+      ApplicationDirectory\
+        Executable.exe
+        ContestData\
+
+    Notes
+    -----
+    - All directory paths returned by TAppPaths include a trailing path delimiter.
+    - File-returning functions return fully-qualified file paths.
+    - Temporary test directories are automatically created on demand.
+    - TempTestFile('') creates a (potential) unique temporary file name.
+
+    Design Notes
+    ------------
+    TAppPaths is intended to be application-wide infrastructure and should
+    remain independent of contest-specific logic.
+
+    The class caches resolved filesystem locations after first initialization
+    to avoid repeated filesystem probing during runtime and unit testing.
+
+    Developed with the assistance of OpenAI/ChatGPT.
+  }
+  TAppPaths = record
+  private
+    class var
+      FInitialized: Boolean;
+      FExecutableDir: string;
+      FRepositoryRootDir: string;
+      FContestDataDir: string;
+      FTestDataDir: string;
+      FTempTestDir: string;
+      FIsInstalledLayout: Boolean;
+
+    class procedure Initialize; static;
+
+  public
+    class function IsInstalledLayout: Boolean; static;
+
+    class function ExecutableDir: string; static;
+    class function RepositoryRootDir: string; static;
+
+    class function ContestDataDir: string; static;
+    class function ContestDataFile(const FileName: string): string; static;
+
+    class function TestDataDir: string; static;
+    class function TestDataFile(const FileName: string): string; static;
+
+    class function TempTestDir: string; static;
+    class function TempTestFile(const FileName: string = ''): string; static;
+    class function CreateTempTestFile(const Extension: string = '.tmp'): string; static;
+
+    class procedure ResetForTesting; static;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.IOUtils;
+
+class procedure TAppPaths.Initialize;
+begin
+  if FInitialized then
+    Exit;
+
+  Randomize;
+
+  // Executable location
+  TAppPaths.FExecutableDir := IncludeTrailingPathDelimiter(
+    ExtractFilePath(ParamStr(0)));
+
+  // Detect repository layout
+  if TDirectory.Exists(TPath.Combine(FExecutableDir, '.git')) and
+     TDirectory.Exists(TPath.Combine(FExecutableDir, 'VCL')) and
+     TDirectory.Exists(TPath.Combine(FExecutableDir, 'Util')) and
+     TFile.Exists(TPath.Combine(FExecutableDir, 'Main.pas')) then
+    TAppPaths.FRepositoryRootDir := FExecutableDir
+  else
+    TAppPaths.FRepositoryRootDir := '';
+
+  // Detect installed layout
+  if TDirectory.Exists(TPath.Combine(FExecutableDir, 'ContestData')) then
+    TAppPaths.FIsInstalledLayout := True
+{$IFDEF FUTURE_CONTEST_DATA_SUBDIR}
+  else if TDirectory.Exists(
+    TPath.Combine([FRepositoryRootDir, 'Src', 'Domain', 'Contests', 'Data'])) then
+    TAppPaths.FIsInstalledLayout := False
+{$ELSE}
+  else if not FRepositoryRootDir.IsEmpty then
+    TAppPaths.FIsInstalledLayout := False
+{$ENDIF}
+  else
+    raise Exception.Create('Invalid configuration');
+
+  // location of contest history files
+{$IFDEF FUTURE_CONTEST_DATA_SUBDIR}
+  if FIsInstalledLayout then
+    FContestDataDir := IncludeTrailingPathDelimiter(
+      TPath.Combine(FExecutableDir, 'ContestData'))
+  else
+    FContestDataDir := IncludeTrailingPathDelimiter(
+      TPath.Combine(
+        [FRepositoryRootDir, 'Src', 'Domain', 'Contests', 'Data']));
+  FContestDataDir := IncludeTrailingPathDelimiter(FContestDataDir);
+{$ELSE}
+  TAppPaths.FContestDataDir := TAppPaths.FExecutableDir;
+{$ENDIF}
+
+  TAppPaths.FInitialized := True;
+end;
+
+class procedure TAppPaths.ResetForTesting;
+begin
+  TAppPaths.FInitialized := False;
+end;
+
+class function TAppPaths.IsInstalledLayout: Boolean;
+begin
+  Initialize;
+  Result := FIsInstalledLayout;
+end;
+
+class function TAppPaths.ExecutableDir: string;
+begin
+  Initialize;
+  Result := FExecutableDir;
+end;
+
+class function TAppPaths.RepositoryRootDir: string;
+begin
+  Initialize;
+  Result := FRepositoryRootDir;
+end;
+
+class function TAppPaths.ContestDataDir: string;
+begin
+  Initialize;
+  Result := FContestDataDir;
+end;
+
+class function TAppPaths.ContestDataFile(const FileName: string): string;
+begin
+  Result := TPath.Combine(ContestDataDir, FileName);
+end;
+
+class function TAppPaths.TestDataDir: string;
+begin
+  if FTestDataDir.IsEmpty then
+    FTestDataDir := IncludeTrailingPathDelimiter(
+      TPath.Combine([RepositoryRootDir,'Test', 'Data']));
+
+  Result := FTestDataDir;
+end;
+
+class function TAppPaths.TestDataFile(const FileName: string): string;
+begin
+  Result := TPath.Combine(TestDataDir, FileName);
+end;
+
+class function TAppPaths.TempTestDir: string;
+begin
+  if FTempTestDir.IsEmpty then
+    FTempTestDir := IncludeTrailingPathDelimiter(
+      TPath.Combine([RepositoryRootDir, 'Test', 'Temp']));
+
+  ForceDirectories(FTempTestDir);
+
+  Result := FTempTestDir;
+end;
+
+{
+  Returns a writable temporary test file path.
+
+  If FileName is empty, a potentially unique temporary file path
+  is contructed under TempTestDir, but the file is not created.
+  Since regression tests are not threaded, name collisions are very unlikely.
+
+  If FileName is supplied, the path is constructed under
+  TempTestDir but the file is not created.
+}
+class function TAppPaths.TempTestFile(const FileName: string = ''): string;
+begin
+  if FileName.IsEmpty then
+  begin
+    repeat
+      Result := TPath.Combine(
+        TempTestDir,
+        Format('tmp%.4x.tmp', [Random($10000)]));
+    until not TFile.Exists(Result);
+  end
+  else
+    Result := TPath.Combine(TempTestDir, FileName);
+end;
+
+class function TAppPaths.CreateTempTestFile(
+  const Extension: string): string;
+var
+  Ext: string;
+begin
+  Ext := Extension;
+  if (not Ext.IsEmpty) and (Ext[1] <> '.') then
+    Ext := '.' + Ext;
+
+  repeat
+    Result := TPath.Combine(
+      TempTestDir,
+      ChangeFileExt(Format('tmp%.4x.tmp', [Random($10000)]), Ext));
+  until not TFile.Exists(Result);
+
+  TFile.WriteAllText(Result, '');
+end;
+
+end.

--- a/Src/Domain/Contests/ArrlDx.Types.pas
+++ b/Src/Domain/Contests/ArrlDx.Types.pas
@@ -1,0 +1,35 @@
+unit ArrlDx.Types;
+
+interface
+
+type
+  TArrlDxCallRec = class
+  public
+    Call: string;     // call sign
+    State: string;    // State/Province (US/Canada)
+    Power: string;    // Power (DX Stations)
+    UserText: string; // club name
+    function GetString: string; // returns <State>|<Power> [UserText]
+    class function compareCall(const left, right: TArrlDxCallRec) : integer; static;
+  end;
+
+implementation
+
+uses
+  System.SysUtils;
+
+class function TArrlDxCallRec.compareCall(const left, right: TArrlDxCallRec) : integer;
+begin
+  Result := CompareStr(left.Call, right.Call);
+end;
+
+
+function TArrlDxCallRec.GetString: string; // returns <State>|<Power> [UserText]
+begin
+  Result := Format(' - %s%s', [State, Power]);
+  if UserText <> '' then
+    Result := Result + ' ' + UserText;
+end;
+
+
+end.

--- a/Src/Persistence/ContestFileFormat.pas
+++ b/Src/Persistence/ContestFileFormat.pas
@@ -1,0 +1,139 @@
+unit ContestFileFormat;
+
+interface
+
+uses
+  System.Classes;
+
+type
+  TContestFileFormat = (
+    cffUnknown,
+    cffN1MMCsv,
+    cffArrlTsv
+  );
+
+  TContestFileFormats = set of TContestFileFormat;
+
+  TContestFileFormatInfo = record
+    Format: TContestFileFormat;
+    Description: String;
+    Delimiter: Char;
+    SupportsDynamicHeaders: Boolean;
+  end;
+
+  function DetectFormat(const Lines: TStrings): TContestFileFormatInfo;
+
+  { Does this row represent a format-defined header/directive? }
+  function IsFormatHeaderDirective(
+    const Format: TContestFileFormat;
+    const Fields: TStrings): Boolean;
+
+  procedure ParseFields(
+    const Line: string;
+    const FormatInfo: TContestFileFormatInfo;
+    Fields: TStrings);
+
+  function GetValue(const Fields: TStrings; ColumnInx: Integer): string;
+
+implementation
+
+uses
+  System.SysUtils;
+
+function DetectFormat(const Lines: TStrings): TContestFileFormatInfo;
+var
+  i: Integer;
+  S: string;
+begin
+  Result.Format := cffUnknown;
+  Result.Description := 'an Unknown';
+  Result.Delimiter := #0;
+  Result.SupportsDynamicHeaders := False;
+
+  for i := 0 to Lines.Count - 1 do
+  begin
+    S := Lines[i].Trim;
+
+    // skip blank lines
+    if S.IsEmpty then
+      Continue;
+
+    // skip comments
+    if S.StartsWith('#') then
+      Continue;
+
+    // N1MM CSV format
+    if S.StartsWith('!!Order!!,') then
+    begin
+      Result.Format := cffN1MMCsv;
+      Result.Description := 'N1MM Call History';
+      Result.Delimiter := ',';
+      Result.SupportsDynamicHeaders := True;
+      Exit;
+    end;
+
+    // ARRL TSV format
+    if S.StartsWith('cabrillo_id'#9) then
+    begin
+      Result.Format := cffArrlTsv;
+      Result.Description := 'ARRL Score Summary';
+      Result.Delimiter := #9;
+      Result.SupportsDynamicHeaders := False;
+      Exit;
+    end;
+
+    // unknown first data line
+    Break;
+  end;
+end;
+
+
+function IsFormatHeaderDirective(
+  const Format: TContestFileFormat;
+  const Fields: TStrings): Boolean;
+begin
+  Result := False;
+
+  if Fields.Count = 0 then
+    Exit;
+
+  case Format of
+    cffN1MMCsv:
+      Result := SameText(Fields[0], '!!Order!!');
+
+    cffArrlTsv:
+      Result := SameText(Fields[0], 'cabrillo_id');
+  end;
+end;
+
+
+procedure ParseFields(
+  const Line: string;
+  const FormatInfo: TContestFileFormatInfo;
+  Fields: TStrings);
+begin
+  Fields.Clear;
+
+  // CSV and TSV use different delimiters.
+  Fields.StrictDelimiter := True;
+  Fields.Delimiter := FormatInfo.Delimiter;
+
+  Fields.DelimitedText := Line;
+end;
+
+
+{ Returns the field value for the specified column index.
+  If the index is invalid or the column is missing, an empty string is returned.
+  Leading and trailing whitespace is removed.
+}
+function GetValue(
+  const Fields: TStrings;
+  ColumnInx: Integer): string;
+begin
+  if Cardinal(ColumnInx) < Cardinal(Fields.Count) then
+    Result := Fields[ColumnInx].Trim
+  else
+    Result := '';
+end;
+
+end.

--- a/Src/Persistence/ContestFileReader.pas
+++ b/Src/Persistence/ContestFileReader.pas
@@ -1,0 +1,670 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
+unit ContestFileReader;
+
+interface
+
+uses
+  System.Classes,
+  System.SysUtils,
+  System.Generics.Collections,
+  ContestFileFormat;
+
+type
+  {
+    Consumes a record produced by TContestFileReader.
+    Ownership of Rec is transferred to the consumer.
+
+    The consumer may:
+      - Store the record
+      - Process the record immediately
+      - Free the record
+
+    If the consumer retains the record, it becomes responsible
+    for eventually freeing it.
+    If the consumer doesn't retain the record, it must immediately free it.
+  }
+  TRecordConsumer<TCallRec> = reference to procedure(Rec: TCallRec);
+
+{
+  Generic contest data file reader.
+
+  Responsibilities:
+    - Detect file format and parse input files.
+    - Iterate files, sections, and data rows.
+    - Maintain file/line context for diagnostics.
+    - Build column maps from section headers.
+    - Support optional field bindings.
+    - Create, populate, and filter call records.
+    - Deliver accepted call records via consumer.
+
+  Derived classes typically implement one of two approaches:
+
+    1) Explicit parsing
+       - Override ParseSectionHeader() to extract column indexes.
+         When overriding, be sure to call the base class to populate FColumnMap.
+       - Override ParseRow() to populate row fields manually.
+
+    2) Binding-based parsing
+       - Override ConfigureBindings() and call AddBinding().
+       - Use the default ParseRow() implementation.
+
+  Record ownership:
+    Records are created by the reader and passed to the consumer.
+    Ownership transfers to the consumer, which is responsible for
+    storing or freeing the record as appropriate.
+
+  Example:
+    Reader.ReadFile(FileName,
+      procedure(Rec: TCallRec)
+      begin
+        CallList.Add(Rec);   // consumer now owns the record
+      end);
+
+  Developed with the assistance of OpenAI/ChatGPT.
+}
+TContestFileReader<TCallRec: class, constructor> = class
+  protected type
+    TValueBinder<TCallRec> = reference to procedure(const Value: string; Rec: TCallRec);
+
+    TBindingDefinition<TCallRec> = record
+      ColumnName: string;
+      Required: Boolean;
+      Apply: TValueBinder<TCallRec>;
+    end;
+
+    TCompiledBinding<TCallRec> = record
+      ColumnIndex: Integer;
+      Apply: TValueBinder<TCallRec>;
+    end;
+
+    TColumnMap = class
+    private
+      FMap: TDictionary<string, Integer>;
+    public
+      constructor Create(const Fields: TStrings);
+      destructor Destroy; override;
+      function IndexOf(const ColumnName: string): Integer;
+      function Contains(const ColumnName: string): Boolean;
+    end;
+
+  private
+    FSupportedFormats: TContestFileFormats;
+    FFileName: string;    // name of current file being read
+    FIndex: Integer;      // 0-based index of the current line within the file
+    FLine: string;        // copy of current line being processed by ReadFile()
+    FStopReading: Boolean;
+
+    {
+      Master set of bindings supplied through AddDefaultBinding.
+
+      Active bindings are rebuilt from this list whenever a header
+      is encountered. This allows readers to support multiple
+      !!Order!! directives and changing column layouts.
+    }
+    FDefaultBindings: TList<TBindingDefinition<TCallRec>>;
+    FBindingDefinitions: TList<TBindingDefinition<TCallRec>>;
+    FCompiledBindings: TList<TCompiledBinding<TCallRec>>;
+
+    function GetLineNumber: Integer;
+    procedure CompileBindings;
+    procedure ValidateFormat(const FormatInfo: TContestFileFormatInfo);
+    function FindField(const FieldName: string; RequiredField: Boolean): Integer;
+
+  protected
+    FColumnMap: TColumnMap;
+
+    { Infrastructure... }
+
+    function RequireField(const FieldName: string): Integer;
+    function OptionalField(const FieldName: string): Integer;
+
+    { Normalize header fields (e.g. remove !!Order!!, for N1MM formats }
+    procedure NormalizeHeaderFields(
+          const Format: TContestFileFormat;
+          const Fields: TStrings);
+
+    procedure BuildColumnMap(const Fields: TStrings);
+
+    procedure ClearBindings;
+
+    procedure AddBinding(
+      const ColumnName: string;
+      Required: Boolean;
+      const Binder: TValueBinder<TCallRec>);
+
+    procedure ExecuteBindings(const Fields: TStrings; Rec: TCallRec);
+
+    property FileName: string read FFileName;
+    property LineNumber: Integer read GetLineNumber;
+    property Line: string read FLine;
+
+    { Extension Points... }
+
+    function CreateRecord: TCallRec; virtual;
+
+    procedure StopReading;
+
+    {
+      Handle non-data lines.
+
+      Return True if the line was consumed and normal row
+      processing should not occur.
+
+      Typical uses include:
+        - Blank lines
+        - Comments
+        - Reader directives
+        - Debugging commands
+    }
+    function HandleLine(const Line: string): Boolean; virtual;
+
+    { Return True if Fields represents a section header. }
+    function IsHeaderDirective(
+      const Format: TContestFileFormat;
+      const Fields: TStrings): Boolean; virtual;
+
+    { Configure optional column bindings. }
+    procedure ConfigureBindings; virtual;
+
+    {
+      Called whenever a new header directive is encountered.
+
+      Base implementation:
+        1) Builds FColumnMap from the normalized header fields.
+        2) Clears any previous bindings.
+        3) Calls ConfigureBindings().
+        4) Compiles bindings against the current header.
+
+      Derived classes may override to:
+        * Cache contest-specific column indexes.
+        * Validate required columns.
+        * Configure section-specific behavior.
+
+      For N1MM files this method may be called multiple times as
+      additional !!Order!! directives are encountered.
+
+      IMPORTANT:
+      Derived implementations MUST call inherited FIRST.
+
+      The base implementation initializes:
+        - FColumnMap
+        - binding state
+        - compiled bindings
+
+      Calling RequireField/OptionalField before inherited is invalid
+      and will raise an exception.
+
+      IMPORTANT:
+        Override without calling inherited only when intentionally
+        replacing the entire header-processing pipeline.
+
+      Example:
+        inherited ParseSectionHeader(Format, Fields);
+
+        FCallInx := RequireField('Call');
+        FStateInx := OptionalField('State');
+        FPowerInx := OptionalField('Power');
+    }
+    procedure ParseSectionHeader(
+      const Format: TContestFileFormat;
+      const Fields: TStrings); virtual;
+
+    { Populate Record from Fields. }
+    procedure ParseRow(const Fields: TStrings; Rec: TCallRec); virtual;
+
+    { Normalize data record }
+    procedure NormalizeRecord(Rec: TCallRec); virtual;
+
+    { Return True if call Record should be emitted. }
+    function KeepRecord(const Rec: TCallRec): Boolean; virtual;
+
+  public
+    constructor Create(SupportedFormats: TContestFileFormats);
+    destructor Destroy; override;
+
+    {
+      Registers a binding that will be applied whenever a header
+      is encountered.
+
+      Default bindings are intended for simple readers that do not
+      derive from TContestFileReader and therefore do not override
+      ConfigureBindings.
+
+      When a new header is processed, the active bindings are rebuilt
+      from the current set of default bindings.
+
+      Derived readers typically override ConfigureBindings and use
+      AddBinding instead.
+    }
+    procedure AddDefaultBinding(
+      const ColumnName: string;
+      Required: Boolean;
+      const Binder: TValueBinder<TCallRec>);
+
+    { File processing... }
+
+    procedure ReadFile(
+      const FileName: string;
+      Consumer: TRecordConsumer<TCallRec>);
+
+    procedure ReadFiles(
+      const FileNames: array of string;
+      Consumer: TRecordConsumer<TCallRec>);
+
+    property SupportedFormats: TContestFileFormats read FSupportedFormats;
+  end;
+
+implementation
+
+{ TContestFileReader<TCallRec>.THeaderMap }
+
+constructor TContestFileReader<TCallRec>.TColumnMap.Create(const Fields: TStrings);
+var
+  i: Integer;
+begin
+  FMap := TDictionary<String, Integer>.Create;
+  for i := 0 to Fields.Count-1 do
+    FMap.AddOrSetValue(UpperCase(Fields[i]), i);
+end;
+
+destructor TContestFileReader<TCallRec>.TColumnMap.Destroy;
+begin
+  FMap.Free;
+  inherited;
+end;
+
+function TContestFileReader<TCallRec>.TColumnMap.IndexOf(const ColumnName: string): Integer;
+begin
+  if not FMap.TryGetValue(UpperCase(ColumnName), Result) then
+    Result := -1;
+end;
+
+function TContestFileReader<TCallRec>.TColumnMap.Contains(const ColumnName: string): Boolean;
+begin
+  Result := FMap.ContainsKey(UpperCase(ColumnName));
+end;
+
+
+{ TContestFileReader<TCallRec> }
+
+constructor TContestFileReader<TCallRec>.Create(
+  SupportedFormats: TContestFileFormats);
+begin
+  inherited Create;
+
+  FSupportedFormats := SupportedFormats;
+  FColumnMap := nil;
+  FDefaultBindings := TList<TBindingDefinition<TCallRec>>.Create;
+  FBindingDefinitions := TList<TBindingDefinition<TCallRec>>.Create;
+  FCompiledBindings := TList<TCompiledBinding<TCallRec>>.Create;
+end;
+
+destructor TContestFileReader<TCallRec>.Destroy;
+begin
+  FCompiledBindings.Free;
+  FDefaultBindings.Free;
+  FBindingDefinitions.Free;
+  FColumnMap.Free;
+
+  inherited;
+end;
+
+function TContestFileReader<TCallRec>.GetLineNumber: Integer;
+begin
+  Result := FIndex + 1;
+end;
+
+
+procedure TContestFileReader<TCallRec>.AddDefaultBinding(
+  const ColumnName: string;
+  Required: Boolean;
+  const Binder: TValueBinder<TCallRec>);
+var
+  B: TBindingDefinition<TCallRec>;
+begin
+  B.ColumnName := ColumnName;
+  B.Required := Required;
+  B.Apply := Binder;
+
+  FDefaultBindings.Add(B);
+end;
+
+
+function TContestFileReader<TCallRec>.IsHeaderDirective(
+  const Format: TContestFileFormat;
+  const Fields: TStrings): Boolean;
+begin
+  Result := ContestFileFormat.IsFormatHeaderDirective(Format, Fields);
+end;
+
+
+{ Normalize headers by removing '!!Order!!' from N1MM call history files }
+procedure TContestFileReader<TCallRec>.NormalizeHeaderFields(
+  const Format: TContestFileFormat;
+  const Fields: TStrings);
+begin
+  case Format of
+    cffN1MMCsv:
+      if (Fields.Count > 0) and SameText(Fields[0], '!!Order!!') then
+        Fields.Delete(0);
+  end;
+end;
+
+
+procedure TContestFileReader<TCallRec>.BuildColumnMap(const Fields: TStrings);
+begin
+  if Assigned(FColumnMap) then
+    FreeAndNil(FColumnMap);
+
+  FColumnMap := TColumnMap.Create(Fields);
+end;
+
+
+procedure TContestFileReader<TCallRec>.ClearBindings;
+begin
+  FCompiledBindings.Clear;
+  FBindingDefinitions.Clear;
+end;
+
+{
+  Registers a column binding.
+
+  Example:
+
+    AddBinding('Call', True,
+      procedure(const Value: string; Rec: TMyCallRec)
+      begin
+        Rec.Call := Value;
+      end);
+}
+procedure TContestFileReader<TCallRec>.AddBinding(
+  const ColumnName: string;
+  Required: Boolean;
+  const Binder: TValueBinder<TCallRec>);
+var
+  B: TBindingDefinition<TCallRec>;
+begin
+  B.ColumnName := ColumnName;
+  B.Required := Required;
+  B.Apply := Binder;
+
+  FBindingDefinitions.Add(B);
+end;
+
+{
+  Builds the active binding set for the current header.
+
+  The default implementation uses bindings previously registered
+  through AddDefaultBinding. Derived readers may override and
+  populate bindings using AddBinding.
+}
+procedure TContestFileReader<TCallRec>.ConfigureBindings;
+begin
+  // Default implementation uses externally supplied bindings.
+  FBindingDefinitions.Clear;
+  FBindingDefinitions.AddRange(FDefaultBindings);
+end;
+
+
+procedure TContestFileReader<TCallRec>.CompileBindings;
+var
+  Def: TBindingDefinition<TCallRec>;
+  Compiled: TCompiledBinding<TCallRec>;
+begin
+  FCompiledBindings.Clear;
+
+  for Def in FBindingDefinitions do
+  begin
+    Compiled.ColumnIndex := FColumnMap.IndexOf(Def.ColumnName);
+
+    if Def.Required and (Compiled.ColumnIndex = -1) then
+    begin
+      raise Exception.CreateFmt(
+        'Missing required field "%s". Line %d, File "%s"',
+        [Def.ColumnName, LineNumber, FileName]);
+    end;
+
+    Compiled.Apply := Def.Apply;
+    FCompiledBindings.Add(Compiled);
+  end;
+end;
+
+procedure TContestFileReader<TCallRec>.ExecuteBindings(
+  const Fields: TStrings;
+  Rec: TCallRec);
+var
+  B: TCompiledBinding<TCallRec>;
+begin
+  for B in FCompiledBindings do
+    B.Apply(GetValue(Fields, B.ColumnIndex), Rec);
+end;
+
+
+procedure TContestFileReader<TCallRec>.ParseSectionHeader(
+  const Format: TContestFileFormat;
+  const Fields: TStrings);
+begin
+  // Rebuild column map for the current section.
+  BuildColumnMap(Fields);
+
+  // Recompile bindings against the current header.
+  ClearBindings;
+  ConfigureBindings;
+  CompileBindings;
+end;
+
+
+function TContestFileReader<TCallRec>.RequireField(
+  const FieldName: string): Integer;
+begin
+  Result := FindField(FieldName, True);
+end;
+
+
+function TContestFileReader<TCallRec>.OptionalField(
+  const FieldName: string): Integer;
+begin
+  Result := FindField(FieldName, False);
+end;
+
+{
+  Returns the column index for FieldName in the current section header.
+
+  RequiredField = True
+    Missing columns raise an exception.
+
+  RequiredField = False
+    Missing columns return -1.
+
+  Used internally by RequireField() and OptionalField().
+
+  Requires ParseSectionHeader() infrastructure to have been initialized.
+}
+function TContestFileReader<TCallRec>.FindField(
+  const FieldName: string;
+  RequiredField: Boolean): Integer;
+begin
+  Assert(Assigned(FColumnMap),
+    'FColumnMap not initialized. ' +
+    'Did you forget inherited ParseSectionHeader()?');
+
+  Result := FColumnMap.IndexOf(FieldName);
+
+  if RequiredField and (Result = -1) then
+    raise Exception.CreateFmt(
+      'Invalid call history file: missing required field "%s". Line %d, File "%s"',
+      [FieldName, LineNumber, FileName]);
+end;
+
+procedure TContestFileReader<TCallRec>.StopReading;
+begin
+  FStopReading := True;
+end;
+
+function TContestFileReader<TCallRec>.HandleLine(const Line: string): Boolean;
+begin
+  Result := Line.IsEmpty or Line.StartsWith('#');
+end;
+
+function TContestFileReader<TCallRec>.CreateRecord: TCallRec;
+begin
+  Result := TCallRec.Create;
+end;
+
+procedure TContestFileReader<TCallRec>.ParseRow(const Fields: TStrings; Rec: TCallRec);
+begin
+  assert(FCompiledBindings.Count > 0,
+    Format('%s has no compiled bindings. ' +
+      'Override ParseRow() or call AddBinding() from ConfigureBindings().',
+      [ClassName]));
+
+  ExecuteBindings(Fields, Rec);
+end;
+
+procedure TContestFileReader<TCallRec>.NormalizeRecord(Rec: TCallRec);
+begin
+end;
+
+function TContestFileReader<TCallRec>.KeepRecord(const Rec: TCallRec): Boolean;
+begin
+  Result := True;
+end;
+
+{
+  Read multiple files in sequence.
+
+  ReadFile() is called for each filename using the same
+  callback instance.
+
+  This is useful for merging call history data from
+  multiple sources into a single destination.
+}
+procedure TContestFileReader<TCallRec>.ReadFiles(
+  const FileNames: array of string;
+  Consumer: TRecordConsumer<TCallRec>);
+var
+  FileName: string;
+begin
+  for FileName in FileNames do
+    ReadFile(FileName, Consumer);
+end;
+
+{
+  Read a single call history file.
+
+  For each accepted row:
+    1) CreateRecord() creates a new record instance.
+    2) ParseRow() populates the record.
+    3) NormalizeRecord() fixes up the record.
+    3) KeepRecord() determines whether the record is accepted.
+    4) Callback(Rec) is invoked.
+
+  Ownership of the record is transferred to the callback.
+
+  If the callback wishes to retain the record, it should store the
+  record in an owning container (such as TObjectList).
+
+  If the callback does not retain the record, it is responsible for
+  freeing it before returning.
+
+  Example:
+    Reader.ReadFile(FileName,
+      procedure(Rec: TArrl10mCallRec)
+      begin
+        CallList.Add(Rec);  // ownership transferred
+      end);
+}
+procedure TContestFileReader<TCallRec>.ReadFile(
+  const FileName: string;
+  Consumer: TRecordConsumer<TCallRec>);
+var
+  Lines: TStringList;
+  Fields: TStringList;
+  FormatInfo: TContestFileFormatInfo;
+  Rec: TCallRec;
+  i: Integer;
+begin
+  Lines := TStringList.Create;
+  Fields := TStringList.Create;
+  try
+    FFileName := FileName;
+    Lines.LoadFromFile(FileName);
+
+    FormatInfo := DetectFormat(Lines);
+    ValidateFormat(FormatInfo);
+
+    FStopReading := False;
+    for i := 0 to Lines.Count - 1 do
+    begin
+      if FStopReading then
+        Break;
+
+      FIndex := i;
+      FLine := Lines[i].Trim;
+
+      // skip empty or comment lines, handle debug hooks
+      if HandleLine(FLine) then
+        Continue;
+
+      // parse Line into Fields
+      ParseFields(FLine, FormatInfo, Fields);
+
+      if Fields.Count = 0 then
+        Continue;
+
+      // schema/header directive
+      if IsHeaderDirective(FormatInfo.Format, Fields) then
+      begin
+        NormalizeHeaderFields(FormatInfo.Format, Fields);
+
+        ParseSectionHeader(FormatInfo.Format, Fields);
+        Continue;
+      end;
+
+      Rec := CreateRecord;
+      try
+        // Populate Rec from Fields
+        ParseRow(Fields, Rec);
+
+        NormalizeRecord(Rec);
+
+        // Derived contests can filter records as needed
+        if not KeepRecord(Rec) then
+          Continue;
+
+        // Transfer ownership of Rec to the consumer.
+        Consumer(Rec);
+
+        // Ownership transferred.
+        Rec := nil;
+      finally
+        Rec.Free;
+      end;
+    end;
+  finally
+    FFileName := '';
+    FIndex := -1;
+    Fields.Free;
+    Lines.Free;
+  end;
+end;
+
+procedure TContestFileReader<TCallRec>.ValidateFormat(
+  const FormatInfo: TContestFileFormatInfo);
+begin
+  if FormatInfo.Format = cffUnknown then
+    raise Exception.CreateFmt(
+      'Unknown call history file format: "%s"',
+      [FileName]);
+
+  if not (FormatInfo.Format in FSupportedFormats) then
+    raise Exception.CreateFmt(
+      'File "%s" is in %s format, which is not supported by %s.',
+      [FileName, FormatInfo.Description, ClassName]);
+end;
+
+end.

--- a/Src/Persistence/Contests/ArrlDx.Reader.pas
+++ b/Src/Persistence/Contests/ArrlDx.Reader.pas
@@ -1,0 +1,111 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
+unit ArrlDx.Reader;
+
+interface
+
+uses
+  System.Classes,
+  ContestFileFormat,
+  ContestFileReader,
+  ArrlDx.Types;
+
+type
+  TArrlDxColumns = record
+    Call: Integer;
+    State: Integer;
+    Power: Integer;
+    UserText: Integer;
+  end;
+
+  TArrlDxContestFileReader = class(TContestFileReader<TArrlDxCallRec>)
+  private
+    FHomeCallIsLocal: boolean; // user's callsign is local to this contest
+    FCols: TArrlDxColumns;
+
+    procedure ResetColumns;
+
+  protected
+    procedure ParseSectionHeader(
+      const Format: TContestFileFormat;
+      const Fields: TStrings); override;
+
+    procedure ParseRow(
+      const Fields: TStrings;
+      Rec: TArrlDxCallRec); override;
+
+    function KeepRecord(const Rec: TArrlDxCallRec): Boolean; override;
+
+  public
+    constructor Create(AHomeCallIsLocal: Boolean);
+  end;
+
+implementation
+
+uses
+  System.SysUtils;
+
+constructor TArrlDxContestFileReader.Create(AHomeCallIsLocal: Boolean);
+begin
+  inherited Create([cffN1MMCsv]);
+
+  FHomeCallIsLocal := AHomeCallIsLocal;
+  ResetColumns;
+end;
+
+
+procedure TArrlDxContestFileReader.ResetColumns;
+begin
+  FCols.Call := -1;
+  FCols.State := -1;
+  FCols.Power := -1;
+  FCols.UserText := -1;
+end;
+
+
+procedure TArrlDxContestFileReader.ParseSectionHeader(
+  const Format: TContestFileFormat;
+  const Fields: TStrings);
+begin
+  inherited ParseSectionHeader(Format, Fields);
+
+  ResetColumns;
+
+  assert(Format = cffN1MMCsv);
+  assert(Fields[0] <> '!!Order!!', 'removed by NormalizeHeaderFields');
+
+  // !!Order!!,Call,Name,State,Power,UserText,  // Dx Stations
+  // !!Order!!,Call,Name,State,                 // US Stations
+  // DX sends Call,Power
+  // W/VE sends Call,State
+  FCols.Call := RequireField('Call');
+  FCols.State := OptionalField('State');
+  FCols.Power := OptionalField('Power');
+  FCols.UserText := OptionalField('UserText');
+end;
+
+procedure TArrlDxContestFileReader.ParseRow(
+  const Fields: TStrings;
+  Rec: TArrlDxCallRec);
+begin
+  Rec.Call := GetValue(Fields, FCols.Call).ToUpper;
+  Rec.State := GetValue(Fields, FCols.State).ToUpper;
+  Rec.Power := GetValue(Fields, FCols.Power).ToUpper;
+  Rec.UserText := GetValue(Fields, FCols.UserText);
+end;
+
+function TArrlDxContestFileReader.KeepRecord(const Rec: TArrlDxCallRec): Boolean;
+begin
+  if Rec.Call.IsEmpty then
+    Exit(False);
+
+  // W/VE stations work only DX stations (those with non-empty Power field);
+  // DX Stations work only W/VE stations (those with non-empty State field)
+  Result := (    FHomeCallIsLocal and not Rec.Power.IsEmpty) or
+            (not FHomeCallIsLocal and not Rec.State.IsEmpty);
+end;
+
+end.

--- a/Test/Core/Test.AppPaths.pas
+++ b/Test/Core/Test.AppPaths.pas
@@ -1,0 +1,232 @@
+unit Test.AppPaths;
+
+interface
+
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  TAppPathsTests = class
+  public
+    [Test]
+    procedure RepositoryRootDir_Is_Not_Empty;
+
+    [Test]
+    procedure All_Directories_Have_Trailing_Delimiter;
+
+    [Test]
+    procedure ContestDataDir_Is_Under_AppRoot;
+
+    [Test]
+    procedure ContestDataFile_Appends_FileName;
+
+    [Test]
+    procedure ContestDataFile_Does_Not_Duplicate_Separators;
+
+    [Test]
+    procedure TestDataDir_Is_Under_AppRoot;
+
+    [Test]
+    procedure TestDataFile_Appends_FileName;
+
+    [Test]
+    procedure TempTestDir_Is_Created;
+
+    [Test]
+    procedure TempTestDir_Is_Writable;
+
+    [Test]
+    procedure TempTestDir_Is_Under_AppRoot;
+
+    [Test]
+    procedure TempTestFile_Appends_FileName;
+
+    [Test]
+    procedure TempTestFile_Empty_FileName_Creates_Unique_File;
+
+    [Test]
+    procedure CreateTempTestFile_Is_Empty_File;
+
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.IOUtils,
+  AppPaths;
+
+procedure TAppPathsTests.RepositoryRootDir_Is_Not_Empty;
+begin
+  Assert.IsFalse(TAppPaths.RepositoryRootDir.IsEmpty);
+end;
+
+procedure TAppPathsTests.All_Directories_Have_Trailing_Delimiter;
+begin
+  Assert.IsTrue(TAppPaths.RepositoryRootDir.EndsWith(PathDelim));
+  Assert.IsTrue(TAppPaths.ContestDataDir.EndsWith(PathDelim));
+  Assert.IsTrue(TAppPaths.TestDataDir.EndsWith(PathDelim));
+  Assert.IsTrue(TAppPaths.TempTestDir.EndsWith(PathDelim));
+end;
+
+procedure TAppPathsTests.ContestDataDir_Is_Under_AppRoot;
+begin
+  Assert.IsTrue(TAppPaths.ContestDataDir.StartsWith(TAppPaths.ExecutableDir));
+
+{$IFDEF FUTURE_CONTEST_DATA_SUBDIR}
+  Assert.IsTrue(TAppPaths.ContestDataDir.Contains('ContestData'));
+{$ELSE}
+  Assert.AreEqual(TAppPaths.ExecutableDir, TAppPaths.ContestDataDir);
+{$ENDIF}
+end;
+
+procedure TAppPathsTests.ContestDataFile_Appends_FileName;
+var
+  Path: string;
+begin
+  Path := TAppPaths.ContestDataFile('FDGOTA.txt');
+
+  Assert.IsTrue(Path.EndsWith('FDGOTA.txt'));
+end;
+
+procedure TAppPathsTests.ContestDataFile_Does_Not_Duplicate_Separators;
+var
+  Path: string;
+begin
+  Path := TAppPaths.ContestDataFile('sample.txt');
+
+  Assert.IsFalse(Path.Contains('\\'),
+    'Path should not contain duplicate separators.');
+end;
+
+procedure TAppPathsTests.TestDataDir_Is_Under_AppRoot;
+var
+  Path, ExpectedTail: string;
+begin
+  Path := TAppPaths.TestDataDir;
+
+  Assert.IsTrue(Path.StartsWith(TAppPaths.RepositoryRootDir),
+    format('%s: should start with RepositoryRootDir',[Path]));
+
+  ExpectedTail := IncludeTrailingPathDelimiter(TPath.Combine('Test', 'Data'));
+  Assert.IsTrue(Path.EndsWith(ExpectedTail),
+    format('%s: should end with %s', [Path, ExpectedTail]));
+end;
+
+procedure TAppPathsTests.TestDataFile_Appends_FileName;
+var
+  Path: string;
+begin
+  Path := TAppPaths.TestDataFile('sample.csv');
+
+  Assert.IsTrue(Path.EndsWith('sample.csv'));
+end;
+
+procedure TAppPathsTests.TempTestDir_Is_Created;
+var
+  Dir: string;
+begin
+  Dir := TPath.Combine([TAppPaths.RepositoryRootDir, 'Test', 'Temp']);
+
+  if TDirectory.Exists(Dir) then
+    TDirectory.Delete(Dir, True);
+
+  Assert.IsFalse(TDirectory.Exists(Dir));
+
+  Dir := TAppPaths.TempTestDir;
+
+  Assert.IsTrue(
+    TDirectory.Exists(Dir),
+    'Temp test directory should be auto-created.');
+end;
+
+procedure TAppPathsTests.TempTestDir_Is_Writable;
+var
+  Dir: string;
+  FileName: string;
+begin
+  Dir := TAppPaths.TempTestDir;
+
+  FileName := TPath.Combine(Dir, 'write-test.tmp');
+
+  try
+    TFile.WriteAllText(FileName, 'test');
+
+    Assert.IsTrue(TFile.Exists(FileName));
+  finally
+    DeleteFile(FileName);
+  end;
+end;
+
+procedure TAppPathsTests.TempTestDir_Is_Under_AppRoot;
+var
+  Path, ExpectedTail: string;
+begin
+  Path := TAppPaths.TempTestDir;
+
+  ExpectedTail := IncludeTrailingPathDelimiter(TPath.Combine('Test', 'Temp'));
+  Assert.IsTrue(Path.StartsWith(TAppPaths.RepositoryRootDir));
+  Assert.IsTrue(Path.EndsWith(ExpectedTail),
+    format('%s: should end with %s', [Path, ExpectedTail]));
+end;
+
+procedure TAppPathsTests.TempTestFile_Appends_FileName;
+var
+  Path: string;
+begin
+  Path := TAppPaths.TempTestFile('temp.csv');
+
+  Assert.IsTrue(Path.EndsWith('temp.csv'));
+end;
+
+procedure TAppPathsTests.TempTestFile_Empty_FileName_Creates_Unique_File;
+var
+  FileName1: string;
+  FileName2: string;
+begin
+  FileName1 := TAppPaths.TempTestFile('');
+  FileName2 := TAppPaths.TempTestFile('');
+
+  try
+    Assert.IsFalse(FileName1.IsEmpty);
+    Assert.IsFalse(FileName2.IsEmpty);
+
+    Assert.AreNotEqual(FileName1, FileName2);
+
+    Assert.IsTrue(FileName1.StartsWith(TAppPaths.TempTestDir));
+    Assert.IsTrue(FileName2.StartsWith(TAppPaths.TempTestDir));
+
+  finally
+    DeleteFile(FileName1);
+    DeleteFile(FileName2);
+  end;
+end;
+
+procedure TAppPathsTests.CreateTempTestFile_Is_Empty_File;
+var
+  FileName: string;
+  Contents: string;
+begin
+  FileName := TAppPaths.CreateTempTestFile('txt');
+
+  try
+    Assert.IsTrue(
+      TFile.Exists(FileName),
+      'Temporary file should exist.');
+
+    Contents := TFile.ReadAllText(FileName);
+
+    Assert.AreEqual(
+      '',
+      Contents,
+      'Temporary file should initially be empty.');
+  finally
+    DeleteFile(FileName);
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TAppPathsTests);
+
+end.

--- a/Test/Persistence/Contests/Test.ArrlDx.Reader.pas
+++ b/Test/Persistence/Contests/Test.ArrlDx.Reader.pas
@@ -1,0 +1,332 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
+unit Test.ArrlDx.Reader;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Test.ContestReader.Base,
+  Test.ContestReader.Contracts,
+  ArrlDx.Types,
+  ArrlDx.Reader,
+  System.Classes;
+
+type
+  {
+    Derived Reader Verification...
+      Derived Reader Configuration
+        which fields are required
+        which are optional
+        which normalization rules apply
+        which filters apply
+        without duplicating infrastructure testing.
+
+      Contest Semantics
+        KeepRecord logic
+        official file counts
+        DX/local semantics
+        contest-specific normalization
+  }
+  [Category('ARRLDX')]
+  [TestFixture]
+  TArrlDxContestFileReaderTests = class(
+      TContestReaderContractTests<TArrlDxCallRec,TArrlDxContestFileReader>)
+  private
+    FLocalToContest: Boolean;
+
+  protected
+    function CreateReader: TArrlDxContestFileReader; override;
+
+  public
+    constructor Create;
+
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+
+    // tests...
+    [Test]
+    [Category('Schema')]
+    procedure Missing_Call_Field_Raises;
+
+    [Test]
+    [Category('Schema')]
+    procedure Reordered_Columns_Are_Supported;
+
+    [Test]
+    [Category('Normalization')]
+    procedure State_Field_Normalized_to_Uppercase;
+
+    [Test]
+    [Category('Normalization')]
+    procedure Power_Field_Normalized_to_Uppercase;
+
+    [Test]
+    [Category('Normalization')]
+    procedure UserText_Preserved;
+
+    [Category('Semantics')]
+    [TestCase('KeepRecord.1', 'True,     ,     ,False')]
+    [TestCase('KeepRecord.2', 'True,   MA,     ,False')]
+    [TestCase('KeepRecord.3', 'True,     ,  KW ,True')]
+    [TestCase('KeepRecord.4', 'True,   MA,  KW ,True')]
+
+    [TestCase('KeepRecord.5', 'False,    ,     ,False')]
+    [TestCase('KeepRecord.6', 'False,  MA,     ,True')]
+    [TestCase('KeepRecord.7', 'False,    ,  KW ,False')]
+    [TestCase('KeepRecord.8', 'False,  MA,  KW ,True')]
+    procedure KeepRecord_Matrix(
+      HomeCallLocal: Boolean;
+      State: string;
+      Power: string;
+      Expected: Boolean);
+
+    [Test]
+    [Category('File')]
+    procedure Load_N1MM_File_Local;
+
+    [Test]
+    [Category('File')]
+    procedure Load_N1MM_File_Dx;
+
+    [Category('File')]
+    [TestCase('Local', 'True,  3781')]
+    [TestCase('DX',    'False, 4576')]
+    procedure Count_Official_Contest_File(LocalToContest: boolean; Expected: integer);
+end;
+
+implementation
+
+uses
+  System.IOUtils,               // for TFile
+  System.SysUtils,
+  System.Generics.Collections,  // for TObjectList
+  ContestFileFormat,
+  AppPaths;
+
+constructor TArrlDxContestFileReaderTests.Create;
+begin
+  inherited Create('!!Order!!,Call,State,Power', 'K1ABC,MA,100');
+  FLocalToContest := True;
+end;
+
+function TArrlDxContestFileReaderTests.CreateReader: TArrlDxContestFileReader;
+begin
+  Result := TArrlDxContestFileReader.Create(FLocalToContest);
+end;
+
+procedure TArrlDxContestFileReaderTests.Setup;
+begin
+  inherited Setup;
+
+  FLocalToContest := True;
+end;
+
+
+procedure TArrlDxContestFileReaderTests.TearDown;
+begin
+  inherited;
+end;
+
+
+procedure TArrlDxContestFileReaderTests.Missing_Call_Field_Raises;
+begin
+  Self.FLocalToContest := False;
+
+  WriteTestFile('dx-missing-call.csv', [
+      '!!Order!!,State,Power',
+      'MA,KW'
+    ]);
+
+  AssertReadRaises(
+    TestFile('dx-missing-call.csv'),
+    Exception,
+    '.*missing required field "Call".*');
+end;
+
+
+procedure TArrlDxContestFileReaderTests.Reordered_Columns_Are_Supported;
+var
+  Results: TObjectList<TArrlDxCallRec>;
+begin
+  FLocalToContest := False;
+
+  WriteTestFile('reordered-columns.csv', [
+      '!!Order!!,Power,UserText,State,Call',
+      'KW,Big Gun,MA,K1ABC'
+    ]);
+
+  Results := ReadAllFromFile(
+    TestFile('reordered-columns.csv'));
+
+  try
+    Assert.AreEqual(1, Results.Count);
+    Assert.AreEqual('K1ABC', Results[0].Call);
+    Assert.AreEqual('MA', Results[0].State);
+    Assert.AreEqual('KW', Results[0].Power);
+    Assert.AreEqual('Big Gun', Results[0].UserText);
+  finally
+    Results.Free;
+  end;
+end;
+
+
+procedure TArrlDxContestFileReaderTests.State_Field_Normalized_to_Uppercase;
+var
+  Results: TObjectList<TArrlDxCallRec>;
+begin
+  // DX Station will work states. Set FLocalToContest to False.
+  Self.FLocalToContest := False;
+
+  WriteTestFile('dx-state-uppercase.csv', [
+      '!!Order!!,Call,State',
+      'K1ABC,ma'
+    ]);
+
+  Results := Self.ReadAllFromFile(TestFile('dx-state-uppercase.csv'));
+  try
+    Assert.AreEqual(1, Results.Count);
+    Assert.AreEqual('MA', Results[0].State);
+  finally
+    Results.Free;
+  end;
+end;
+
+
+procedure TArrlDxContestFileReaderTests.Power_Field_Normalized_to_Uppercase;
+var
+  Results: TObjectList<TArrlDxCallRec>;
+begin
+  WriteTestFile('dx-power-uppercase.csv', [
+      '!!Order!!,Call,Power',
+      'DL1ABC,kw'
+    ]);
+
+  Results := ReadAllFromFile(TestFile('dx-power-uppercase.csv'));
+  try
+    Assert.AreEqual(1, Results.Count);
+    Assert.AreEqual('KW', Results[0].Power);
+  finally
+    Results.Free;
+  end;
+end;
+
+
+procedure TArrlDxContestFileReaderTests.UserText_Preserved;
+var
+  Results: TObjectList<TArrlDxCallRec>;
+begin
+  // DX Station will work states. Set FLocalToContest to False.
+  Self.FLocalToContest := False;
+
+  WriteTestFile('dx-usertext.csv', [
+      '!!Order!!,Call,State,UserText',
+      'K1abc,Ma,Big Gun Station'
+    ]);
+
+  Results := ReadAllFromFile(TestFile('dx-usertext.csv'));
+  try
+    Assert.AreEqual(1, Results.Count);
+    Assert.AreEqual('K1ABC', Results[0].Call);
+    Assert.AreEqual('MA', Results[0].State);
+    Assert.IsEmpty(Results[0].Power);
+    Assert.AreEqual('Big Gun Station', Results[0].UserText);
+  finally
+    Results.Free;
+  end;
+end;
+
+
+procedure TArrlDxContestFileReaderTests.KeepRecord_Matrix(
+  HomeCallLocal: Boolean;
+  State: string;
+  Power: string;
+  Expected: Boolean);
+var
+  TempFile: string;
+  Count: Integer;
+begin
+  TempFile := TAppPaths.TempTestFile(
+    Format('keep-record.%s.%s.txt', [State.Trim, Power.Trim]));
+  TFile.WriteAllLines(TempFile, TArray<string>.Create(
+    '!!Order!!,Call,State,Power',
+    Format('K1ABC,%s,%s', [State.Trim, Power.Trim])
+  ));
+
+  FLocalToContest := HomeCallLocal;
+  Count := Self.ReadCountFromFile(TempFile);
+
+  Assert.AreEqual(Integer(Ord(Expected)), Count);
+end;
+
+
+procedure TArrlDxContestFileReaderTests.Load_N1MM_File_Local;
+var
+  Reader: TArrlDxContestFileReader;
+begin
+  Reader := TArrlDxContestFileReader.Create({HomeCallIsLocal=}True);
+
+  try
+    Reader.ReadFile(
+      TAppPaths.ContestDataFile('ARRLDXCW_USDX.txt'),
+      procedure(Rec: TArrlDxCallRec)
+      begin
+        // Local to contest (W/VE) will work DX
+        // DX sends Call,Power
+        // W/VE sends Call,State
+        Assert.IsNotEmpty(Rec.Call);
+        Assert.IsEmpty(Rec.State);
+        Assert.IsNotEmpty(Rec.Power);
+
+        Rec.Free;
+      end);
+
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TArrlDxContestFileReaderTests.Load_N1MM_File_Dx;
+var
+  Reader: TArrlDxContestFileReader;
+begin
+  Reader := TArrlDxContestFileReader.Create({HomeCallIsLocal=}False);
+
+  try
+    Reader.ReadFile(
+      TAppPaths.ContestDataFile('ARRLDXCW_USDX.txt'),
+      procedure(Rec: TArrlDxCallRec)
+      begin
+        // Not Local to contest (DX) will work W/VE
+        // DX sends Call,Power
+        // W/VE sends Call,State
+        Assert.IsNotEmpty(Rec.Call);
+        Assert.IsNotEmpty(Rec.State);
+        Assert.IsEmpty(Rec.Power);
+
+        Rec.Free;
+      end);
+
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TArrlDxContestFileReaderTests.Count_Official_Contest_File(
+  LocalToContest: boolean; Expected: integer);
+var
+  Count: Integer;
+begin
+  FLocalToContest := LocalToContest;
+  Count := ReadCountFromFile(TAppPaths.ContestDataFile('ARRLDXCW_USDX.txt'));
+  Assert.AreEqual(Expected, Count);
+end;
+
+end.

--- a/Test/Persistence/Test.ContestFileFormat.pas
+++ b/Test/Persistence/Test.ContestFileFormat.pas
@@ -1,0 +1,414 @@
+unit Test.ContestFileFormat;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Classes;
+
+type
+  [TestFixture]
+  TContestFileFormatTests = class
+  public
+
+    [Test]
+    procedure Detect_N1MM_Format;
+
+    [Test]
+    procedure Detect_ARRL_Format;
+
+    [Test]
+    procedure DetectFormat_Skips_BlankLines;
+
+    [Test]
+    procedure DetectFormat_Unknown;
+
+    [Test]
+    procedure Parse_CSV;
+
+    [Test]
+    procedure Parse_TSV;
+
+    [Test]
+    procedure ParseFields_Clears_Previous_Contents;
+
+    [Test]
+    procedure GetValue_ValidIndex;
+
+    [Test]
+    procedure GetValue_IndexPastEnd_ReturnsEmptyString;
+
+    [Test]
+    procedure GetValue_NegativeIndex_ReturnsEmptyString;
+
+    [Test]
+    procedure GetValue_TrimsWhitespace;
+
+    [Test]
+    procedure GetValue_EmptyField;
+
+    [Test]
+    procedure N1MM_Order_Is_Header_Directive;
+
+    [Test]
+    procedure Arrl_CabrilloId_Is_Header_Directive;
+
+    [Test]
+    procedure Data_Row_Is_Not_Header_Directive;
+
+    [Test]
+    procedure Empty_Fields_Is_Not_Header_Directive;
+
+    [Test]
+    procedure Whitespace_Field_Is_Not_Header_Directive;
+  end;
+
+implementation
+
+uses
+  ContestFileFormat;
+
+procedure TContestFileFormatTests.Detect_N1MM_Format;
+var
+  Lines: TStringList;
+  Info: TContestFileFormatInfo;
+begin
+  Lines := TStringList.Create;
+  try
+    Lines.Add('# comment');
+    Lines.Add('!!Order!!,Call,State');
+
+    Info := DetectFormat(Lines);
+
+    Assert.AreEqual(cffN1MMCsv, Info.Format);
+    Assert.AreEqual('N1MM Call HIstory', Info.Description);
+    Assert.AreEqual(',', Info.Delimiter);
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.Detect_ARRL_Format;
+var
+  Lines: TStringList;
+  Info: TContestFileFormatInfo;
+begin
+  Lines := TStringList.Create;
+  try
+    Lines.Add('# comment');
+    Lines.Add('cabrillo_id'#9'year'#9'call');
+
+    Info := DetectFormat(Lines);
+
+    Assert.AreEqual(cffArrlTsv, Info.Format);
+    Assert.AreEqual('ARRL Score Summary', Info.Description);
+    Assert.AreEqual(#9, Info.Delimiter);
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.DetectFormat_Skips_BlankLines;
+var
+  Lines: TStringList;
+  Info: TContestFileFormatInfo;
+begin
+  Lines := TStringList.Create;
+  try
+    Lines.Add('');
+    Lines.Add('   ');
+    Lines.Add(#9#9);
+    Lines.Add('!!Order!!,Call,State');
+
+    Info := DetectFormat(Lines);
+
+    Assert.AreEqual(cffN1MMCsv, Info.Format);
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.DetectFormat_Unknown;
+var
+  Lines: TStringList;
+  Info: TContestFileFormatInfo;
+begin
+  Lines := TStringList.Create;
+  try
+    Lines.Add('AA0A,MO');
+
+    Info := DetectFormat(Lines);
+
+    Assert.AreEqual(cffUnknown, Info.Format);
+    Assert.AreEqual('an Unknown', Info.Description);
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.Parse_CSV;
+var
+  Fields: TStringList;
+  FormatInfo: TContestFileFormatInfo;
+begin
+  Fields := TStringList.Create;
+  try
+    FormatInfo.Format := cffN1MMCsv;
+    FormatInfo.Description := 'N1MM Call History';
+    FormatInfo.Delimiter := ',';
+    FormatInfo.SupportsDynamicHeaders := True;
+
+    ParseFields(
+      'AA0A,MO,',
+      FormatInfo,
+      Fields);
+
+    Assert.AreEqual(3, Fields.Count);
+    Assert.AreEqual('AA0A', Fields[0]);
+    Assert.AreEqual('MO', Fields[1]);
+    Assert.AreEqual('', Fields[2]);
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.Parse_TSV;
+var
+  Fields: TStringList;
+  FormatInfo: TContestFileFormatInfo;
+begin
+  Fields := TStringList.Create;
+  try
+    FormatInfo.Format := cffArrlTsv;
+    FormatInfo.Description := 'ARRL Score Summary';
+    FormatInfo.Delimiter := #9;
+    FormatInfo.SupportsDynamicHeaders := False;
+
+    ParseFields(
+      'ARRL-10'#9'2025'#9'2E0CVN',
+      FormatInfo,
+      Fields);
+
+    Assert.AreEqual(3, Fields.Count);
+    Assert.AreEqual('ARRL-10', Fields[0]);
+    Assert.AreEqual('2025', Fields[1]);
+    Assert.AreEqual('2E0CVN', Fields[2]);
+
+    // add a trailing <tab>. should add an extra empty field value.
+    ParseFields(
+      'ARRL-10'#9'2025'#9'2E0CVN'#9,
+      FormatInfo,
+      Fields);
+
+    Assert.AreEqual(4, Fields.Count);
+    Assert.AreEqual('ARRL-10', Fields[0]);
+    Assert.AreEqual('2025', Fields[1]);
+    Assert.AreEqual('2E0CVN', Fields[2]);
+    Assert.AreEqual('', Fields[3]);
+
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.ParseFields_Clears_Previous_Contents;
+var
+  Fields: TStringList;
+  FormatInfo: TContestFileFormatInfo;
+begin
+  Fields := TStringList.Create;
+  try
+    FormatInfo.Format := cffN1MMCsv;
+    FormatInfo.Description := 'N1MM Call History';
+    FormatInfo.Delimiter := ',';
+
+    ParseFields(
+      'AA0A,MO,Club',
+      FormatInfo,
+      Fields);
+
+    Assert.AreEqual(3, Fields.Count);
+
+    ParseFields(
+      'AA0A',
+      FormatInfo,
+      Fields);
+
+    Assert.AreEqual(1, Fields.Count);
+    Assert.AreEqual('AA0A', Fields[0]);
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.GetValue_ValidIndex;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('AA0A');
+    Fields.Add('MO');
+
+    Assert.AreEqual('AA0A', GetValue(Fields, 0));
+    Assert.AreEqual('MO', GetValue(Fields, 1));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.GetValue_IndexPastEnd_ReturnsEmptyString;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('AA0A');
+
+    Assert.AreEqual('', GetValue(Fields, 1));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.GetValue_NegativeIndex_ReturnsEmptyString;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('AA0A');
+
+    Assert.AreEqual('', GetValue(Fields, -1));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.GetValue_TrimsWhitespace;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('  AA0A  ');
+
+    Assert.AreEqual('AA0A', GetValue(Fields, 0));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.GetValue_EmptyField;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('AA0A');
+    Fields.Add('');
+
+    Assert.AreEqual('', GetValue(Fields, 1));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.N1MM_Order_Is_Header_Directive;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('!!Order!!');
+
+    Assert.IsTrue(
+      IsFormatHeaderDirective(
+        cffN1MMCsv,
+        Fields));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.Arrl_CabrilloId_Is_Header_Directive;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('cabrillo_id');
+    Fields.Add('call');
+
+    Assert.IsTrue(
+      IsFormatHeaderDirective(
+        cffArrlTsv,
+        Fields));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.Data_Row_Is_Not_Header_Directive;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('AA0A');
+
+    Assert.IsFalse(
+      IsFormatHeaderDirective(
+        cffN1MMCsv,
+        Fields));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.Empty_Fields_Is_Not_Header_Directive;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Assert.IsFalse(
+      IsFormatHeaderDirective(
+        cffN1MMCsv,
+        Fields));
+
+    Assert.IsFalse(
+      IsFormatHeaderDirective(
+        cffArrlTsv,
+        Fields));
+  finally
+    Fields.Free;
+  end;
+end;
+
+procedure TContestFileFormatTests.Whitespace_Field_Is_Not_Header_Directive;
+var
+  Fields: TStringList;
+begin
+  Fields := TStringList.Create;
+  try
+    Fields.Add('   ');
+
+    Assert.IsFalse(
+      IsFormatHeaderDirective(
+        cffN1MMCsv,
+        Fields));
+
+    Assert.IsFalse(
+      IsFormatHeaderDirective(
+        cffArrlTsv,
+        Fields));
+  finally
+    Fields.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TContestFileFormatTests);
+
+end.

--- a/Test/Persistence/Test.ContestFileReader.pas
+++ b/Test/Persistence/Test.ContestFileReader.pas
@@ -1,0 +1,1594 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
+unit Test.ContestFileReader;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Classes,
+  ContestFileFormat,
+  ContestFileReader,
+  Test.ContestReader.Base;
+
+type
+  TFakeRec = class
+  public
+    Call: string;
+    State: string;
+    Power: string;
+    UserText: string;
+  end;
+
+  TColumnMap = record
+    CallInx: Integer;
+    StateInx: Integer;
+    PowerInx: Integer;
+    UserTextInx: Integer;
+  end;
+
+type
+  TFakeReader = class(TContestFileReader<TFakeRec>)
+  protected
+    FCols: TColumnMap;
+    FHeaderCount: Integer;
+
+    procedure ParseSectionHeader(
+      const Format: TContestFileFormat;
+      const Fields: TStrings); override;
+
+    procedure ParseRow(
+      const Fields: TStrings;
+      Rec: TFakeRec); override;
+
+    property HeaderCount: Integer read FHeaderCount;
+
+  public
+    constructor Create;
+    destructor Destroy; override;
+  end;
+
+type
+  TFakeBindingRow = class
+  public
+    Call: string;
+    Name: string;
+    Age: Integer;
+  end;
+
+  TFakeBindingReader = class(TContestFileReader<TFakeBindingRow>)
+  protected
+    function IsHeaderDirective(
+      const Format: TContestFileFormat;
+      const Fields: TStrings): Boolean; override;
+
+    procedure ConfigureBindings; override;
+  end;
+
+  [TestFixture]
+  TContestFileReaderTests = class(TContestReaderTestHelper)
+  public
+    [Test]
+    procedure Visits_All_Rows;
+
+    [Test]
+    procedure Skips_Blank_Lines;
+
+    [Test]
+    procedure Skips_Comment_Lines;
+
+    [Test]
+    procedure Header_Is_Not_Visited;
+
+    [Test]
+    procedure Reads_Multiple_Files;
+
+    [Test]
+    procedure KeepRow_Can_Filter_Rows;
+
+    [Test]
+    procedure Multiple_Headers_Are_Supported;
+
+    [Test]
+    procedure Reordered_Columns_Are_Supported;
+
+    [Test]
+    procedure Missing_Optional_Field_Returns_Empty_String;
+
+    [Test]
+    procedure Unknown_Columns_Are_Ignored;
+
+    [Test]
+    procedure Missing_Required_Field_Raises;
+
+    [Test]
+    procedure Unknown_Format_Raises_Exception;
+
+    [Test]
+    procedure Unsupported_Format_Raises_Exception;
+
+    [Test]
+    procedure Empty_File_Raises_Unknown_Format;
+
+    [Test]
+    procedure Default_CreateRecord_Is_Used;
+
+    [Test]
+    procedure NormalizeRecord_Is_Called;
+
+    [Test]
+    procedure NormalizeRecord_Before_KeepRow;
+
+    [Test]
+    procedure StopReading_Ends_Read_Loop;
+
+    [Test]
+    procedure HandleLine_Can_Consume_Line;
+
+    [Test]
+    procedure Consumer_Can_Apply_Correction_File;
+
+    [Test]
+    procedure Default_Bindings_Are_Applied;
+
+    [Test]
+    procedure Default_Bindings_Recompile_When_Header_Changes;
+
+    [Test]
+    procedure Consumer_Owns_Record;
+
+    [Test]
+    procedure Header_Only_File_Produces_No_Records;
+
+    [Test]
+    procedure FileName_Is_Available_During_Parsing;
+
+    [Test]
+    procedure LineNumber_Is_Available_During_Parsing;
+
+    [Test]
+    procedure ReadFiles_Preserves_Order;
+
+    [Test]
+    procedure ReadFiles_Continues_Across_Multiple_Files;
+  end;
+
+  [TestFixture]
+  TTestCallHistoryBindings = class(TContestReaderTestHelper)
+  public
+    [Test]
+    procedure Binds_Required_Field;
+
+    [Test]
+    procedure Binds_Optional_Field;
+
+    [Test]
+    procedure Missing_Optional_Field_Uses_Default;
+
+    [Test]
+    procedure Missing_Required_Field_Raises_Exception;
+
+    [Test]
+    procedure Recompiles_Bindings_When_Header_Changes;
+  end;
+
+  [TestFixture]
+  TTestCallHistoryHybrid = class(TContestReaderTestHelper)
+  public
+    [Test]
+    procedure Hybrid_ParseRow_Can_Extend_Bindings;
+  end;
+
+implementation
+
+uses
+  System.Generics.Collections,  // for TObjectDictionary
+  System.SysUtils;
+
+constructor TFakeReader.Create;
+begin
+  inherited Create([cffN1MMCsv]);
+  FCols.CallInx := -1;
+  FCols.StateInx := -1;
+  FCols.PowerInx := -1;
+  FCols.UserTextInx := -1;
+  FHeaderCount := 0;
+end;
+
+destructor TFakeReader.Destroy;
+begin
+  inherited;
+end;
+
+procedure TFakeReader.ParseSectionHeader(
+  const Format: TContestFileFormat;
+  const Fields: TStrings);
+begin
+  inherited;
+  Inc(FHeaderCount);
+
+  Assert.IsFalse(FColumnMap.Contains('!!Order!!'));
+
+  FCols.CallInx := RequireField('Call');
+  FCols.StateInx := OptionalField('State');
+  FCols.PowerInx := OptionalField('Power');
+  FCols.UserTextInx := OptionalField('UserText');
+end;
+
+procedure TFakeReader.ParseRow(
+  const Fields: TStrings;
+  Rec: TFakeRec);
+begin
+  Rec.Call := GetValue(Fields, FCols.CallInx);
+  Rec.State := GetValue(Fields, FCols.StateInx);
+  Rec.Power := GetValue(Fields, FCols.PowerInx);
+  Rec.UserText := GetValue(Fields, FCols.UserTextInx);
+end;
+
+function TFakeBindingReader.IsHeaderDirective(
+  const Format: TContestFileFormat;
+  const Fields: TStrings): Boolean;
+begin
+  Result := (Fields.Count > 0) and SameText(Fields[0], '!!Order!!');
+end;
+
+procedure TFakeBindingReader.ConfigureBindings;
+begin
+  AddBinding(
+    'CALL',
+    True,
+    procedure(const Value: string; Rec: TFakeBindingRow)
+    begin
+      Rec.Call := Value.ToUpper;
+    end);
+
+  AddBinding(
+    'NAME',
+    False,
+    procedure(const Value: string; Rec: TFakeBindingRow)
+    begin
+      Rec.Name := Value;
+    end);
+
+  AddBinding(
+    'AGE',
+    False,
+    procedure(const Value: string; Rec: TFakeBindingRow)
+    begin
+      Rec.Age := StrToIntDef(Value, 0);
+    end);
+end;
+
+procedure TContestFileReaderTests.Visits_All_Rows;
+var
+  Reader: TFakeReader;
+  Count: Integer;
+begin
+  WriteTestFile('multi-calls.txt', [
+    '!!Order!!,CALL',
+    'AA0A',
+    'AA0AA',
+    'AA0AW'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Count := 0;
+
+    Reader.ReadFile(
+      TestFile('multi-calls.txt'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(3, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+[Test]
+procedure TContestFileReaderTests.Skips_Blank_Lines;
+var
+  Reader: TFakeReader;
+  Count: Integer;
+begin
+  WriteTestFile('skip-blanks.txt', [
+    '!!Order!!,CALL',
+    '',
+    'AA0A',
+    '',
+    'AA0AA'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Count := 0;
+
+    Reader.ReadFile(
+      TestFile('skip-blanks.txt'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(2, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+[Test]
+procedure TContestFileReaderTests.Skips_Comment_Lines;
+var
+  Reader: TFakeReader;
+  Count: Integer;
+begin
+  WriteTestFile('skip-comments.txt', [
+    '# comment',
+    '!!Order!!,CALL',
+    '# another comment',
+    'AA0A'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Count := 0;
+
+    Reader.ReadFile(
+      TestFile('skip-comments.txt'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(1, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+[Test]
+procedure TContestFileReaderTests.Header_Is_Not_Visited;
+var
+  Reader: TFakeReader;
+  Calls: TStringList;
+begin
+  WriteTestFile('single.csv', [
+    '!!Order!!,CALL',
+    'AA0A'
+  ]);
+
+  Calls := TStringList.Create;
+  Reader := TFakeReader.Create;
+  try
+    Reader.ReadFile(
+      TestFile('single.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Calls.Add(Rec.Call);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(1, Calls.Count);
+    Assert.AreEqual('AA0A', Calls[0]);
+  finally
+    Reader.Free;
+    Calls.Free;
+  end;
+end;
+
+procedure TContestFileReaderTests.Multiple_Headers_Are_Supported;
+var
+  Reader: TFakeReader;
+  Count: Integer;
+begin
+  WriteTestFile('multiple-headers.csv', [
+    '!!Order!!,CALL',
+    'AA0A',
+    'AA0AA',
+    '!!Order!!,CALL',
+    'AA0AW'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Count := 0;
+
+    Reader.ReadFile(
+      TestFile('multiple-headers.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+
+  	Assert.AreEqual(2, Reader.HeaderCount);
+    Assert.AreEqual(3, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestFileReaderTests.Reordered_Columns_Are_Supported;
+var
+  Reader: TFakeReader;
+begin
+  WriteTestFile('reorder-columns.txt', [
+    '!!Order!!,State,Call,Power',
+    'MA,K1ABC,KW'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Reader.ReadFile(
+      TestFile('reorder-columns.txt'),
+      procedure(Rec: TFakeRec)
+      begin
+        Assert.AreEqual('K1ABC', Rec.Call);
+        Assert.AreEqual('MA', Rec.State);
+        Assert.AreEqual('KW', Rec.Power);
+        Rec.Free;
+      end);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestFileReaderTests.Missing_Optional_Field_Returns_Empty_String;
+var
+  Reader: TFakeReader;
+begin
+  WriteTestFile('opt-field.txt', [
+    '!!Order!!,Call',
+    'K1ABC'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Reader.ReadFile(
+      TestFile('opt-field.txt'),
+      procedure(Rec: TFakeRec)
+      begin
+        Assert.AreEqual('K1ABC', Rec.Call);
+        Assert.AreEqual('', Rec.State);
+        Assert.AreEqual('', Rec.Power);
+        Assert.AreEqual('', Rec.UserText);
+        Rec.Free;
+      end);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestFileReaderTests.Unknown_Columns_Are_Ignored;
+var
+  Reader: TFakeReader;
+  Records: TObjectList<TFakeRec>;
+begin
+  WriteTestFile('unknown-cols.txt', [
+    '!!Order!!,Foo,Call,Bar,State,Baz',
+    'XXX,AA0A,YYY,MA,ZZZ'
+  ]);
+
+  Reader := TFakeReader.Create;
+  Records := TObjectList<TFakeRec>.Create(True);
+
+  try
+    Reader.ReadFile(
+      TestFile('unknown-cols.txt'),
+      procedure(Rec: TFakeRec)
+      begin
+        Records.Add(Rec);
+      end);
+
+    Assert.AreEqual(1, Records.Count, 'expecting 1 record');
+
+    Assert.AreEqual('AA0A', Records[0].Call);
+    Assert.AreEqual('MA', Records[0].State);
+
+  finally
+    Records.Free;
+    Reader.Free;
+  end;
+end;
+
+procedure TContestFileReaderTests.Missing_Required_Field_Raises;
+var
+  Reader: TFakeReader;
+begin
+  WriteTestFile('missing-call.csv', [
+    '!!Order!!,State,Power',
+    'MA,KW'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Assert.WillRaiseWithMessageRegex(
+      procedure
+      begin
+        Reader.ReadFile(
+          TestFile('missing-call.csv'),
+          procedure(Rec: TFakeRec)
+          begin
+            Rec.Free;
+          end);
+      end,
+      Exception,
+      '.*missing required field "Call".*');
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestFileReaderTests.Reads_Multiple_Files;
+var
+  Reader: TFakeReader;
+  File1: string;
+  File2: string;
+  Count: Integer;
+begin
+  File1 := 'multi-files1.csv';
+  File2 := 'multi-files2.csv';
+
+  WriteTestFile(File1, [
+    '!!Order!!,CALL',
+    'AA0A'
+  ]);
+
+  WriteTestFile(File2, [
+    '!!Order!!,CALL',
+    'AA0AA'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Count := 0;
+
+    Reader.ReadFiles(
+      [TestFile(File1), TestFile(File2)],
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(2, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+type
+  TFilteringReader = class(TFakeReader)
+  protected
+    function KeepRecord(const Rec: TFakeRec): Boolean; override;
+  end;
+
+function TFilteringReader.KeepRecord(const Rec: TFakeRec): Boolean;
+begin
+  Result := Rec.Call <> 'AA0AA';
+end;
+
+[Test]
+procedure TContestFileReaderTests.KeepRow_Can_Filter_Rows;
+var
+  Reader: TFakeReader;
+  Count: Integer;
+begin
+  WriteTestFile('keep-row-filter.csv', [
+    '!!Order!!,CALL',
+    'AA0A',
+    'AA0AA',
+    'AA0AW'
+  ]);
+
+  Reader := TFilteringReader.Create;
+  try
+    Count := 0;
+
+    Reader.ReadFile(
+      TestFile('keep-row-filter.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(2, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestFileReaderTests.Unknown_Format_Raises_Exception;
+var
+  Reader: TFakeReader;
+begin
+  WriteTestFile('invalid-header.csv', [
+    'not a valid header'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Assert.WillRaiseWithMessageRegex(
+      procedure
+      begin
+        Reader.ReadFile(
+          TestFile('invalid-header.csv'),
+          procedure(Rec: TFakeRec)
+          begin
+            Rec.Free;
+          end);
+      end,
+      Exception,
+      'Unknown call history file format: ".*"');
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TContestFileReaderTests.Unsupported_Format_Raises_Exception;
+var
+  Reader: TFakeReader;
+begin
+  // TFakeReader is expecting N1MM-format files
+  Reader := TFakeReader.Create;
+
+  // Reading an ARRL-format file raises unsupported format exception
+  WriteTestFile('arrl-format.csv', [
+    'cabrillo_id'#9'CALL',
+    'AA0A',
+    'AA0AA',
+    'AA0AW'
+  ]);
+
+  Assert.WillRaiseWithMessageRegex(
+    procedure
+    begin
+      Reader.ReadFile(TestFile('arrl-format.csv'),
+          procedure(Rec: TFakeRec)
+          begin
+            Rec.Free;
+          end)
+    end,
+    Exception,
+    'File ".*" is in ARRL Score Summary format, which is not supported by TFakeReader.');
+end;
+
+[Test]
+procedure TContestFileReaderTests.Empty_File_Raises_Unknown_Format;
+var
+  Reader: TFakeReader;
+begin
+  // create an empty file
+  WriteTestFile('empty-file.csv', [
+    ''
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Assert.WillRaiseWithMessageRegex(
+      procedure
+      begin
+        Reader.ReadFile(
+          TestFile('empty-file.csv'),
+          procedure(Rec: TFakeRec)
+          begin
+            Rec.Free;
+          end);
+      end,
+      Exception,
+      'Unknown call history file format: ".*"');
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+type
+  TLineNumberReader = class(TFakeReader)
+  public
+    LastLineNumber: Integer;
+
+  protected
+    procedure ParseRow(
+      const Fields: TStrings;
+      Rec: TFakeRec); override;
+  end;
+
+procedure TLineNumberReader.ParseRow(
+  const Fields: TStrings;
+  Rec: TFakeRec);
+begin
+  inherited;
+
+  LastLineNumber := LineNumber;
+end;
+
+
+type
+  TFileNameReader = class(TFakeReader)
+  public
+    LastFileName: string;
+
+  protected
+    procedure ParseRow(
+      const Fields: TStrings;
+      Rec: TFakeRec); override;
+  end;
+
+procedure TFileNameReader.ParseRow(
+  const Fields: TStrings;
+  Rec: TFakeRec);
+begin
+  inherited;
+
+  LastFileName := FileName;
+end;
+
+
+procedure TContestFileReaderTests.Consumer_Owns_Record;
+var
+  Reader: TFakeReader;
+  Count: Integer;
+begin
+  Count := 0;
+
+  WriteTestFile(TestFile('simple.csv'), [
+    '!!Order!!,Call',
+    'K1ABC'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Reader.ReadFile(TestFile('simple.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Assert.IsNotNull(Rec);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(1, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+[Test]
+procedure TContestFileReaderTests.Header_Only_File_Produces_No_Records;
+var
+  Reader: TFakeReader;
+  Count: Integer;
+begin
+  Count := 0;
+
+  // create a header-only file
+  WriteTestFile('header-only.csv', [
+    '!!Order!!,Call,State'
+  ]);
+
+  Reader := TFakeReader.Create;
+  try
+    Reader.ReadFile(TestFile('header-only.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(0, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestFileReaderTests.FileName_Is_Available_During_Parsing;
+var
+  Reader: TFileNameReader;
+begin
+  WriteTestFile('simple.csv', [
+    '!!Order!!,Call',
+    'K1ABC'
+  ]);
+
+  Reader := TFileNameReader.Create;
+  try
+    Reader.ReadFile(TestFile('simple.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(TestFile('simple.csv'), Reader.LastFileName);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestFileReaderTests.LineNumber_Is_Available_During_Parsing;
+var
+  Reader: TLineNumberReader;
+begin
+  Reader := TLineNumberReader.Create;
+  try
+    WriteTestFile('simple.csv', [
+      '!!Order!!,Call',
+      'K1ABC'
+    ]);
+
+    Reader.ReadFile(TestFile('simple.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(2, Reader.LastLineNumber);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestFileReaderTests.ReadFiles_Preserves_Order;
+var
+  Reader: TFakeReader;
+  Calls: TStringList;
+  File1, File2: string;
+begin
+  Calls := TStringList.Create;
+  Reader := TFakeReader.Create;
+  try
+    File1 := 'simple1.csv';
+    WriteTestfile(File1, [
+      '!!Order!!,Call',
+      'K1AAA'
+    ]);
+
+    File2 := 'simple2.csv';
+    WriteTestfile(File2, [
+      '!!Order!!,Call',
+      'K1BBB'
+    ]);
+
+    Reader.ReadFiles(
+      [TestFile(File1), TestFile(File2)],
+      procedure(Rec: TFakeRec)
+      begin
+        Calls.Add(Rec.Call);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual('K1AAA', Calls[0]);
+    Assert.AreEqual('K1BBB', Calls[1]);
+  finally
+    Calls.Free;
+    Reader.Free;
+  end;
+end;
+
+
+[Test]
+procedure TContestFileReaderTests.ReadFiles_Continues_Across_Multiple_Files;
+var
+  Reader: TFakeReader;
+  Count: Integer;
+  File1, File2: string;
+begin
+  Count := 0;
+
+  Reader := TFakeReader.Create;
+  try
+    File1 := 'simple1.csv';
+    WriteTestfile(File1, [
+      '!!Order!!,Call',
+      'K1AAA'
+    ]);
+
+    File2 := 'simple2.csv';
+    WriteTestfile(File2, [
+      '!!Order!!,Call',
+      'K1BBB'
+    ]);
+
+    Reader.ReadFiles(
+      [TestFile(File1), TestFile(File2)],
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(2, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+type
+  TDefaultCreateRec = class
+  public
+    Call: string;
+  end;
+
+  TDefaultCreateReader = class(TContestFileReader<TDefaultCreateRec>)
+  protected
+    procedure ParseRow(
+      const Fields: TStrings;
+      Rec: TDefaultCreateRec); override;
+  end;
+
+procedure TDefaultCreateReader.ParseRow(
+  const Fields: TStrings;
+  Rec: TDefaultCreateRec);
+begin
+  Rec.Call := Fields[0];
+end;
+
+
+[Test]
+procedure TContestFileReaderTests.Default_CreateRecord_Is_Used;
+var
+  Reader: TDefaultCreateReader;
+begin
+  WriteTestFile('simple.csv', [
+    '!!Order!!,CALL',
+    'AA0A'
+  ]);
+
+  Reader := TDefaultCreateReader.Create([cffN1MMCsv]);
+  try
+    Reader.ReadFile(
+      TestFile('simple.csv'),
+      procedure(Rec: TDefaultCreateRec)
+      begin
+        Assert.IsNotNull(Rec);
+        Assert.AreEqual('AA0A', Rec.Call);
+        Rec.Free;
+      end);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+type
+  TNormalizingReader = class(TFakeReader)
+  protected
+    procedure NormalizeRecord(Rec: TFakeRec); override;
+  end;
+
+  procedure TNormalizingReader.NormalizeRecord(Rec: TFakeRec);
+  begin
+    inherited;
+    Rec.Call := UpperCase(Rec.Call);
+  end;
+
+[Test]
+procedure TContestFileReaderTests.NormalizeRecord_Is_Called;
+var
+  Reader: TNormalizingReader;
+begin
+  WriteTestFile('simple.csv', [
+    '!!Order!!,CALL',
+    'aa0a'
+  ]);
+
+  Reader := TNormalizingReader.Create;
+  try
+    Reader.ReadFile(
+      TestFile('simple.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Assert.AreEqual('AA0A', Rec.Call);
+        Rec.Free;
+      end);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+type
+  TNormalizeThenKeepReader = class(TFakeReader)
+  protected
+    procedure NormalizeRecord(Rec: TFakeRec); override;
+    function KeepRecord(const Rec: TFakeRec): Boolean; override;
+  end;
+
+procedure TNormalizeThenKeepReader.NormalizeRecord(Rec: TFakeRec);
+begin
+  Rec.Call := UpperCase(Rec.Call);
+end;
+
+function TNormalizeThenKeepReader.KeepRecord(const Rec: TFakeRec): Boolean;
+begin
+  Result := Rec.Call = 'AA0A';
+end;
+
+[Test]
+procedure TContestFileReaderTests.NormalizeRecord_Before_KeepRow;
+var
+  Reader: TNormalizeThenKeepReader;
+  Count: Integer;
+begin
+  WriteTestFile('simple.csv', [
+    '!!Order!!,CALL',
+    'aa0a'
+  ]);
+
+  Reader := TNormalizeThenKeepReader.Create;
+  try
+    Assert.IsTrue(Reader.SupportedFormats = [cffN1MMCsv]);
+
+    Count := 0;
+    Reader.ReadFile(
+      TestFile('simple.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+    Assert.AreEqual(1, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+type
+  THandleLineReader = class(TFakeReader)
+  protected
+    function HandleLine(const Line: string): Boolean; override;
+  end;
+
+function THandleLineReader.HandleLine(
+  const Line: string): Boolean;
+begin
+  Result := SameText(Line, 'SPECIAL');
+end;
+
+
+[Test]
+procedure TContestFileReaderTests.HandleLine_Can_Consume_Line;
+var
+  Reader: THandleLineReader;
+  Count: Integer;
+begin
+  WriteTestFile('special.csv', [
+    '!!Order!!,CALL',
+    'AA0A',
+    'SPECIAL',
+    'AA0AA'
+  ]);
+
+  Reader := THandleLineReader.Create;
+  try
+    Count := 0;
+    Reader.ReadFile(
+      TestFile('special.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+    Assert.AreEqual(2, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+[Test]
+{
+  This test is based on the need to apply corrections to an original data set.
+  This is true for the Arrl 10m Contest where the ARRL score data file
+  contains sections, not States. The ARRL 10m Contest requires States to be
+  sent from US/CA/XE stations. This data file uses 'MDC' for Maryland/DC
+  section, but the contest requires the state. Either 'MD' or 'DC', not 'MDC'
+
+  The idea of using a second correction file allows records from the first
+  file to be correct using data from the second file. This unit test
+  captures the basic idea of this proposed algorithm.
+
+  What this test proves:
+  - The reader produces records immediately.
+  - The consumer may store records.
+  - The consumer may later apply corrections.
+  - Unknown corrections are ignored.
+  - The reader itself performs no merge logic.
+}
+procedure TContestFileReaderTests.Consumer_Can_Apply_Correction_File;
+var
+  Reader: TFakeReader;
+  PrimaryFile: string;
+  CorrectionFile: string;
+  Dict: TObjectDictionary<string, TFakeRec>;
+  Rec: TFakeRec;
+begin
+  PrimaryFile := 'primary.txt';
+  CorrectionFile := 'corrections.txt';
+
+  WriteTestFile(PrimaryFile, [
+    '!!Order!!,CALL,STATE',
+    'AA0A,MD',
+    'AA0B,MD'
+  ]);
+
+  WriteTestFile(CorrectionFile, [
+    '!!Order!!,CALL,STATE',
+    'AA0B,DC',
+    'AA0C,DC'
+  ]);
+
+  Reader := TFakeReader.Create;
+  Dict := TObjectDictionary<string, TFakeRec>.Create([doOwnsValues]);
+  try
+
+    // Load primary records.
+    Reader.ReadFile(
+      TestFile(PrimaryFile),
+
+      procedure(Rec: TFakeRec)
+      begin
+        Dict.Add(Rec.Call, Rec);
+      end);
+
+    // Apply corrections.
+    Reader.ReadFile(
+      TestFile(CorrectionFile),
+
+      procedure(Rec: TFakeRec)
+      var
+        Existing: TFakeRec;
+      begin
+        if Dict.TryGetValue(Rec.Call, Existing) then
+          Existing.State := Rec.State;
+
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(2, Dict.Count);
+
+    Assert.IsTrue(Dict.TryGetValue('AA0A', Rec));
+    Assert.AreEqual('MD', Rec.State);
+
+    Assert.IsTrue(Dict.TryGetValue('AA0B', Rec));
+    Assert.AreEqual('DC', Rec.State);
+
+    Assert.IsFalse(Dict.ContainsKey('AA0C'));
+
+  finally
+    Dict.Free;
+    Reader.Free;
+  end;
+end;
+
+type
+  TSimpleRec = class
+  public
+    Call: string;
+    State: string;
+  end;
+
+type
+  TSimpleReader = class(TContestFileReader<TSimpleRec>)
+  end;
+
+[Test]
+procedure TContestFileReaderTests.Default_Bindings_Are_Applied;
+var
+  Reader: TSimpleReader;
+  Rec: TSimpleRec;
+begin
+  WriteTestFile('simple.csv', [
+    '!!Order!!,CALL,STATE',
+    'AA0A,TX'
+  ]);
+
+  Reader := TSimpleReader.Create([cffN1MMCsv]);
+  try
+    Reader.AddDefaultBinding('CALL', True,
+      procedure(const Value: string; Row: TSimpleRec) begin
+        Row.Call := Value;
+      end);
+
+    Reader.AddDefaultBinding('STATE', True,
+      procedure(const Value: string; Row: TSimpleRec) begin
+        Row.State := Value;
+      end);
+
+    Rec := nil;
+
+    Reader.ReadFile(
+      TestFile('simple.csv'),
+      procedure(Row: TSimpleRec)
+      begin
+        Rec := Row;
+      end);
+
+    Assert.IsNotNull(Rec);
+    Assert.AreEqual('AA0A', Rec.Call);
+    Assert.AreEqual('TX', Rec.State);
+
+    Rec.Free;
+  finally
+    Reader.Free;
+  end;
+end;
+
+[Test]
+procedure TContestFileReaderTests.Default_Bindings_Recompile_When_Header_Changes;
+var
+  Reader: TSimpleReader;
+  Count: Integer;
+begin
+  WriteTestFile('multiple-bindings.csv', [
+    '!!Order!!,CALL',
+    'AA0A',
+
+    '!!Order!!,CALL,STATE',
+    'AA0B,CA'
+  ]);
+
+  Reader := TSimpleReader.Create([cffN1MMCsv]);
+  try
+    Reader.AddDefaultBinding('CALL', True,
+      procedure(const Value: string; Row: TSimpleRec)
+      begin
+        Row.Call := Value;
+      end);
+
+    Reader.AddDefaultBinding('STATE', False,
+      procedure(const Value: string; Row: TSimpleRec)
+      begin
+        Row.State := Value;
+      end);
+
+    Count := 0;
+
+    Reader.ReadFile(
+      TestFile('multiple-bindings.csv'),
+      procedure(Row: TSimpleRec)
+      begin
+        Inc(Count);
+
+        if Count = 1 then
+        begin
+          Assert.AreEqual('AA0A', Row.Call);
+          Assert.AreEqual('', Row.State);
+        end;
+
+        if Count = 2 then
+        begin
+          Assert.AreEqual('AA0B', Row.Call);
+          Assert.AreEqual('CA', Row.State);
+        end;
+
+        Row.Free;
+      end);
+
+    Assert.AreEqual(2, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+type
+  TStopReader = class(TFakeReader)
+  protected
+    function HandleLine(const Line: string): Boolean; override;
+  end;
+
+function TStopReader.HandleLine(
+  const Line: string): Boolean;
+begin
+  Result := SameText(Line, 'BREAK');
+  if Result then
+    StopReading;
+end;
+
+
+[Test]
+procedure TContestFileReaderTests.StopReading_Ends_Read_Loop;
+var
+  Reader: TStopReader;
+  Count: Integer;
+begin
+  WriteTestFile('file-with-break.csv', [
+    '!!Order!!,CALL',
+    'AA0A',
+    'BREAK',
+    'AA0AA'
+  ]);
+
+  Reader := TStopReader.Create;
+  try
+    Count := 0;
+    Reader.ReadFile(
+      TestFile('file-with-break.csv'),
+      procedure(Rec: TFakeRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+    Assert.AreEqual(1, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TTestCallHistoryBindings.Binds_Required_Field;
+var
+  Reader: TFakeBindingReader;
+  Rec: TFakeBindingRow;
+begin
+  WriteTestFile('simple.csv', [
+    '!!Order!!,CALL',
+    'AA0A'
+  ]);
+
+  Reader := TFakeBindingReader.Create([cffN1MMCsv]);
+  try
+    Rec := nil;
+
+    Reader.ReadFile(
+      TestFile('simple.csv'),
+      procedure(R: TFakeBindingRow)
+      begin
+        Rec := R;
+      end);
+
+    Assert.IsNotNull(Rec);
+    Assert.AreEqual('AA0A', Rec.Call);
+
+    Rec.Free;
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TTestCallHistoryBindings.Binds_Optional_Field;
+var
+  Reader: TFakeBindingReader;
+  Rec: TFakeBindingRow;
+begin
+  WriteTestFile('name-age.txt', [
+    '!!Order!!,CALL,NAME,AGE',
+    'AA0A,Mike,42'
+  ]);
+
+  Reader := TFakeBindingReader.Create([cffN1MMCsv]);
+  try
+    Rec := nil;
+
+    Reader.ReadFile(
+      TestFile('name-age.txt'),
+      procedure(R: TFakeBindingRow)
+      begin
+        Rec := R;
+      end);
+
+    Assert.AreEqual('AA0A', Rec.Call);
+    Assert.AreEqual('Mike', Rec.Name);
+    Assert.AreEqual(42, Rec.Age);
+
+    Rec.Free;
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TTestCallHistoryBindings.Missing_Optional_Field_Uses_Default;
+var
+  Reader: TFakeBindingReader;
+  Rec: TFakeBindingRow;
+begin
+  WriteTestFile('simple.csv', [
+    '!!Order!!,CALL',
+    'AA0A'
+  ]);
+
+  Reader := TFakeBindingReader.Create([cffN1MMCsv]);
+  try
+    Rec := nil;
+
+    Reader.ReadFile(
+      TestFile('simple.csv'),
+      procedure(R: TFakeBindingRow)
+      begin
+        Rec := R;
+      end);
+
+    Assert.AreEqual('AA0A', Rec.Call);
+    Assert.AreEqual('', Rec.Name);
+    Assert.AreEqual(0, Rec.Age);
+
+    Rec.Free;
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TTestCallHistoryBindings.Missing_Required_Field_Raises_Exception;
+var
+  Reader: TFakeBindingReader;
+begin
+  WriteTestFile('missing-call.txt', [
+    '!!Order!!,NAME',
+    'Mike'
+  ]);
+
+  Reader := TFakeBindingReader.Create([cffN1MMCsv]);
+  try
+    Assert.WillRaiseWithMessageRegex(
+      procedure
+      begin
+        Reader.ReadFile(
+          TestFile('missing-call.txt'),
+          procedure(Rec: TFakeBindingRow)
+          begin
+            Rec.Free;
+          end);
+      end,
+      Exception,
+      'Missing required field "CALL". Line 1, File ".*"');
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TTestCallHistoryBindings.Recompiles_Bindings_When_Header_Changes;
+var
+  Reader: TFakeBindingReader;
+  Count: Integer;
+begin
+  WriteTestFile('header-change.txt', [
+    '!!Order!!,CALL',
+    'AA0A',
+
+    '!!Order!!,CALL,NAME',
+    'AA0B,Mike'
+  ]);
+
+  Reader := TFakeBindingReader.Create([cffN1MMCsv]);
+  try
+    Count := 0;
+
+    Reader.ReadFile(
+      TestFile('header-change.txt'),
+      procedure(Rec: TFakeBindingRow)
+      begin
+        Inc(Count);
+
+        if Count = 1 then
+        begin
+          Assert.AreEqual('AA0A', Rec.Call);
+          Assert.AreEqual('', Rec.Name);
+        end;
+
+        if Count = 2 then
+        begin
+          Assert.AreEqual('AA0B', Rec.Call);
+          Assert.AreEqual('Mike', Rec.Name);
+        end;
+
+        Rec.Free;
+      end);
+
+    Assert.AreEqual(2, Count);
+  finally
+    Reader.Free;
+  end;
+end;
+
+{ ---- Hybrid Reader ---- }
+
+type
+  THybridRow = class
+  public
+    Call: string;
+    State: string;
+    DisplayText: string;
+  end;
+
+  THybridReader = class(TContestFileReader<THybridRow>)
+  protected
+    function IsHeaderDirective(
+      const Format: TContestFileFormat;
+      const Fields: TStrings): Boolean; override;
+
+    procedure ConfigureBindings; override;
+
+    procedure ParseRow(
+      const Fields: TStrings;
+      Rec: THybridRow); override;
+  end;
+
+function THybridReader.IsHeaderDirective(
+  const Format: TContestFileFormat;
+  const Fields: TStrings): Boolean;
+begin
+  Result := inherited IsHeaderDirective(Format, Fields);
+end;
+
+procedure THybridReader.ConfigureBindings;
+begin
+  AddBinding(
+    'CALL',
+    True,
+    procedure(const Value: string; Rec: THybridRow)
+    begin
+      Rec.Call := Value.ToUpper;
+    end);
+
+  AddBinding(
+    'STATE',
+    False,
+    procedure(const Value: string; Rec: THybridRow)
+    begin
+      Rec.State := Value.ToUpper;
+    end);
+end;
+
+procedure THybridReader.ParseRow(
+  const Fields: TStrings;
+  Rec: THybridRow);
+begin
+  inherited;
+
+  Rec.DisplayText :=
+    Rec.Call + ' (' + Rec.State + ')';
+end;
+
+[Test]
+procedure TTestCallHistoryHybrid.Hybrid_ParseRow_Can_Extend_Bindings;
+var
+  Reader: THybridReader;
+begin
+  WriteTestFile('call-state.txt', [
+    '!!Order!!,CALL,STATE',
+    'aa0a,tx'
+  ]);
+
+  Reader := THybridReader.Create([cffN1MMCsv]);
+  try
+    Reader.ReadFile(
+      TestFile('call-state.txt'),
+      procedure(Rec: THybridRow)
+      begin
+        Assert.AreEqual('AA0A', Rec.Call);
+        Assert.AreEqual('TX', Rec.State);
+        Assert.AreEqual('AA0A (TX)', Rec.DisplayText);
+
+        Rec.Free;
+      end);
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+initialization
+  TDUnitX.RegisterTestFixture(TContestFileReaderTests);
+  TDUnitX.RegisterTestFixture(TTestCallHistoryBindings);
+  TDUnitX.RegisterTestFixture(TTestCallHistoryHybrid);
+
+end.

--- a/Test/Persistence/Test.ContestReader.Base.pas
+++ b/Test/Persistence/Test.ContestReader.Base.pas
@@ -1,0 +1,146 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
+unit Test.ContestReader.Base;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Classes,
+  System.IOUtils,
+  System.Generics.Collections;
+
+type
+  {
+    Base helper fixture for contest reader tests.
+
+    Responsibilities:
+      - Temporary file creation
+      - Test data path
+      - Writing test input files
+      - Reading all records into TObjectList<T>
+      - Common parsing helpers
+      - Shared assertions
+      - Cleanup
+
+    This class is intentionally NON-generic so helper methods remain
+    simple and reusable across all reader test fixtures.
+  }
+  TContestReaderTestHelper = class
+  protected
+    FTempFiles: TList<string>;
+
+    function TempTestFile(
+      const FileName: string = ''): string;
+
+    function CreateTempFileName(const FileName: string = ''): string;
+    function CreateTempTestFile(const Extension: string = ''): string;
+
+    procedure WriteTestFile(
+      const FileName: string;
+      const Lines: array of string);
+
+    function TestFile(const FileName: string): string;
+
+    function ContestDataFile(
+      const FileName: string): string;
+
+  public
+    [Setup]
+    procedure Setup;
+
+    [TearDown]
+    procedure TearDown;
+  end;
+
+implementation
+
+uses
+  AppPaths;
+
+{ ==================================================================== }
+{ TContestReaderTestHelper                                             }
+{ ==================================================================== }
+
+procedure TContestReaderTestHelper.Setup;
+begin
+  FTempFiles := TList<string>.Create;
+end;
+
+procedure TContestReaderTestHelper.TearDown;
+var
+  FileName: string;
+begin
+  for FileName in FTempFiles do
+  begin
+    if TFile.Exists(FileName) then
+      TFile.Delete(FileName);
+  end;
+
+  FTempFiles.Free;
+end;
+
+
+// generates path, does NOT create file, registers cleanup
+function TContestReaderTestHelper.CreateTempFileName(const FileName: string = ''): string;
+begin
+  Result := TAppPaths.TempTestFile(FileName);
+  FTempFiles.Add(Result);
+end;
+
+
+// generates path, creates the file, registers cleanup
+function TContestReaderTestHelper.CreateTempTestFile(
+  const Extension: string = ''): string;
+begin
+  Result := TAppPaths.CreateTempTestFile(Extension);
+  FTempFiles.Add(Result);
+end;
+
+
+function TContestReaderTestHelper.TempTestFile(
+  const FileName: string): string;
+begin
+  Result := TAppPaths.TempTestFile(FileName);
+end;
+
+
+function TContestReaderTestHelper.ContestDataFile(
+  const FileName: string): string;
+begin
+  Result := TAppPaths.ContestDataFile(FileName);
+end;
+
+
+procedure TContestReaderTestHelper.WriteTestFile(
+  const FileName: string;
+  const Lines: array of string);
+var
+  SL: TStringList;
+  Path: string;
+  S: string;
+begin
+  Path := CreateTempFileName(FileName);
+
+  SL := TStringList.Create;
+  try
+    for S in Lines do
+      SL.Add(S);
+
+    SL.SaveToFile(Path);
+
+  finally
+    SL.Free;
+  end;
+end;
+
+function TContestReaderTestHelper.TestFile(
+  const FileName: string): string;
+begin
+  Result := TAppPaths.TempTestFile(FileName);
+end;
+
+end.

--- a/Test/Persistence/Test.ContestReader.Contracts.pas
+++ b/Test/Persistence/Test.ContestReader.Contracts.pas
@@ -1,0 +1,381 @@
+//------------------------------------------------------------------------------
+//This Source Code Form is subject to the terms of the Mozilla Public
+//License, v. 2.0. If a copy of the MPL was not distributed with this
+//file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//------------------------------------------------------------------------------
+unit Test.ContestReader.Contracts;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Classes,
+  System.SysUtils,
+  System.IOUtils,
+  System.Generics.Collections,
+  Test.ContestReader.Base,
+  ContestFileReader;
+
+type
+  {
+    Generic reusable contract tests for contest readers.
+
+    Purpose:
+      Verify baseline TContestFileReader behavior shared by all
+      derived contest readers.
+
+    Derived fixtures provide:
+      - concrete reader type
+      - concrete record type
+      - minimal valid header
+      - reader construction
+
+    IMPORTANT:
+      This base fixture should test only generic reader behavior.
+
+      Contest-specific semantics such as:
+        - KeepRecord logic
+        - NormalizeRecord behavior
+        - field interpretation
+        - contest-specific filtering
+
+      should remain in the derived fixture.
+  }
+  TContestReaderContractTests<
+    TRec: class, constructor;
+    TReader: TContestFileReader<TRec>, constructor> =
+      class abstract(TContestReaderTestHelper)
+
+  private
+    FMinimalValidHeader: string;
+    FMinimalValidRow: string;
+
+    procedure CheckFixtureConfigured;
+
+  protected
+    property MinimalValidHeader: string read FMinimalValidHeader;
+    property MinimalValidRow: string read FMinimalValidRow;
+
+    {
+      Construct a new instance of ContestReaderContractTests<>.
+      Derived classes provide:
+      - AMinimalValidHeader - minimal valid header for the contest reader.
+      - AMinimalValidRow    - minimal valid row for the contest reader.
+
+      Example:
+        Create('!!Order!!,Call,State', 'K1ABC,MA');
+    }
+    constructor Create(
+      const AMinimalValidHeader: string;
+      const AMinimalValidRow: string);
+
+    {
+      Create a default valid reader instance.
+
+      Derived fixtures override this to provide any required
+      constructor arguments.
+    }
+    function CreateReader: TReader; virtual;
+
+    {
+      Reads all records from the supplied lines and returns
+      them in an owning TObjectList<TRec>.
+    }
+    function ReadAll(
+      const Lines: array of string): TObjectList<TRec>;
+
+    { Read all records from the specified file; return TObjectList<TRec>. }
+    function ReadAllFromFile(
+      const FileName: string): TObjectList<TRec>;
+
+    { Read all records from the specified file and return final count. }
+    function ReadCountFromFile(const FileName: string): Integer;
+
+    { Read from specified file and assert that an exception was raised. }
+    procedure AssertReadRaises(
+      const FileName: string;
+      const ExceptionClass: ExceptClass;
+      const MsgRegex: string = '');
+
+    public
+    {
+      Verifies a valid file produces exactly one record.
+    }
+    [Test]
+    procedure Reads_Single_Record;
+
+    {
+      Verifies blank lines are ignored.
+    }
+    [Test]
+    procedure Skips_Blank_Lines;
+
+    {
+      Verifies comment lines are ignored.
+    }
+    [Test]
+    procedure Skips_Comment_Lines;
+
+    {
+      Verifies a header-only file produces no records.
+    }
+    [Test]
+    procedure Header_Only_File_Produces_No_Records;
+
+    {
+      Verifies unknown file formats raise exceptions.
+    }
+    [Test]
+    procedure Unknown_Format_Raises_Exception;
+  end;
+
+implementation
+
+uses
+  AppPaths;
+
+{ TContestReaderContractTests<TRec,TReader> }
+
+constructor TContestReaderContractTests<TRec,TReader>.Create(
+  const AMinimalValidHeader: string;
+  const AMinimalValidRow: string);
+begin
+  FMinimalValidHeader := AMinimalValidHeader;
+  FMinimalValidRow := AMinimalValidRow;
+end;
+
+
+// Validate that minimal header and row fields have been set by derived class.
+procedure TContestReaderContractTests<TRec,TReader>.CheckFixtureConfigured;
+begin
+  Assert.IsFalse(FMinimalValidHeader.IsEmpty);
+  Assert.IsFalse(FMinimalValidRow.IsEmpty);
+end;
+
+
+function TContestReaderContractTests<TRec, TReader>.CreateReader: TReader;
+begin
+  Result := TReader.Create;
+end;
+
+
+function TContestReaderContractTests<TRec,TReader>.ReadAll(
+  const Lines: array of string): TObjectList<TRec>;
+var
+  Reader: TReader;
+  FileName: string;
+  Records: TObjectList<TRec>;
+begin
+  FileName := 'contest-reader-test.csv';
+
+  WriteTestFile(FileName, Lines);
+
+  Records := TObjectList<TRec>.Create(True);
+
+  Reader := CreateReader;
+  try
+    Reader.ReadFile(TestFile(FileName),
+      procedure(Rec: TRec)
+      begin
+        Records.Add(Rec);
+      end);
+  finally
+    Reader.Free;
+  end;
+
+  Result := Records;
+end;
+
+
+function TContestReaderContractTests<TRec, TReader>.ReadAllFromFile(
+    const FileName: string): TObjectList<TRec>;
+var
+  Reader: TReader;
+  Records: TObjectList<TRec>;
+begin
+  Records := TObjectList<TRec>.Create(True);
+
+  Reader := CreateReader;
+  try
+    Reader.ReadFile(FileName,
+      procedure(Rec: TRec)
+      begin
+        Records.Add(Rec);
+      end);
+  finally
+    Reader.Free;
+  end;
+
+  Result := Records;
+end;
+
+
+function TContestReaderContractTests<TRec,TReader>.ReadCountFromFile(
+    const FileName: string): Integer;
+var
+  Reader: TReader;
+  Count: integer;
+begin
+  Count := 0;
+
+  Reader := CreateReader;
+  try
+    Reader.ReadFile(FileName,
+      procedure(Rec: TRec)
+      begin
+        Inc(Count);
+        Rec.Free;
+      end);
+  finally
+    Reader.Free;
+  end;
+
+  Result := Count;
+end;
+
+
+procedure TContestReaderContractTests<TRec,TReader>.AssertReadRaises(
+  const FileName: string;
+  const ExceptionClass: ExceptClass;
+  const MsgRegex: string = '');
+var
+  Reader: TReader;
+begin
+  Reader := CreateReader;
+  try
+
+    if MsgRegex.IsEmpty then
+    begin
+      Assert.WillRaise(
+        procedure
+        begin
+          Reader.ReadFile(
+            FileName,
+            procedure(Rec: TRec)
+            begin
+              Rec.Free;
+            end);
+        end,
+        ExceptionClass);
+    end
+    else
+    begin
+      Assert.WillRaiseWithMessageRegex(
+        procedure
+        begin
+          Reader.ReadFile(
+            FileName,
+            procedure(Rec: TRec)
+            begin
+              Rec.Free;
+            end);
+        end,
+        ExceptionClass,
+        MsgRegex);
+    end;
+
+  finally
+    Reader.Free;
+  end;
+end;
+
+
+procedure TContestReaderContractTests<TRec,TReader>.Reads_Single_Record;
+var
+  Records: TObjectList<TRec>;
+begin
+  CheckFixtureConfigured;
+
+  Records := ReadAll([
+    MinimalValidHeader,
+    MinimalValidRow
+  ]);
+  try
+    Assert.AreEqual(1, Records.Count);
+  finally
+    Records.Free;
+  end;
+end;
+
+
+procedure TContestReaderContractTests<TRec,TReader>.Skips_Blank_Lines;
+var
+  Records: TObjectList<TRec>;
+begin
+  Records := ReadAll([
+    '',
+    '   ',
+    MinimalValidHeader,
+    '',
+    MinimalValidRow,
+    ''
+  ]);
+  try
+    Assert.AreEqual(1, Records.Count);
+  finally
+    Records.Free;
+  end;
+end;
+
+
+procedure TContestReaderContractTests<TRec,TReader>.Skips_Comment_Lines;
+var
+  Records: TObjectList<TRec>;
+begin
+  Records := ReadAll([
+    '# comment',
+    '# another comment',
+    MinimalValidHeader,
+    MinimalValidRow
+  ]);
+  try
+    Assert.AreEqual(1, Records.Count);
+  finally
+    Records.Free;
+  end;
+end;
+
+
+procedure TContestReaderContractTests<TRec,TReader>.Header_Only_File_Produces_No_Records;
+var
+  Records: TObjectList<TRec>;
+begin
+  Records := ReadAll([
+    MinimalValidHeader
+  ]);
+  try
+    Assert.AreEqual(0, Records.Count);
+  finally
+    Records.Free;
+  end;
+end;
+
+
+procedure TContestReaderContractTests<TRec,TReader>.Unknown_Format_Raises_Exception;
+var
+  Reader: TReader;
+begin
+  WriteTestFile('unknown-format.txt', [
+    'This is not a valid contest file'
+  ]);
+
+  Reader := CreateReader;
+  try
+    Assert.WillRaiseWithMessageRegex(
+      procedure
+      begin
+        Reader.ReadFile(
+          TestFile('unknown-format.txt'),
+          procedure(Rec: TRec)
+          begin
+            Rec.Free;
+          end);
+      end,
+      Exception,
+      'Unknown call history file format: ".*"');
+  finally
+    Reader.Free;
+  end;
+end;
+
+end.

--- a/Test/UnitTests.dpr
+++ b/Test/UnitTests.dpr
@@ -28,12 +28,16 @@ uses
   SSExchParserTest in 'SSExchParserTest.pas',
   DxccListTest in 'DxccListTest.pas',
   AppPaths in '..\Src\Core\AppPaths.pas',
+  ArrlDx.Types in '..\Src\Domain\Contests\ArrlDx.Types.pas',
   ContestFileFormat in '..\Src\Persistence\ContestFileFormat.pas',
   ContestFileReader in '..\Src\Persistence\ContestFileReader.pas',
+  ArrlDx.Reader in '..\Src\Persistence\Contests\ArrlDx.Reader.pas',
   Test.AppPaths in 'Core\Test.AppPaths.pas',
   Test.ContestFileFormat in 'Persistence\Test.ContestFileFormat.pas',
   Test.ContestFileReader in 'Persistence\Test.ContestFileReader.pas',
   Test.ContestReader.Base in 'Persistence\Test.ContestReader.Base.pas',
+  Test.ContestReader.Contracts in 'Persistence\Test.ContestReader.Contracts.pas',
+  Test.ArrlDx.Reader in 'Persistence\Contests\Test.ArrlDx.Reader.pas',
   DxOperTest in 'DxOperTest.pas';
 
 {$IFNDEF TESTINSIGHT}

--- a/Test/UnitTests.dpr
+++ b/Test/UnitTests.dpr
@@ -27,6 +27,8 @@ uses
   MySSExchTest in 'MySSExchTest.pas',
   SSExchParserTest in 'SSExchParserTest.pas',
   DxccListTest in 'DxccListTest.pas',
+  AppPaths in '..\Src\Core\AppPaths.pas',
+  Test.AppPaths in 'Core\Test.AppPaths.pas',
   DxOperTest in 'DxOperTest.pas';
 
 {$IFNDEF TESTINSIGHT}

--- a/Test/UnitTests.dpr
+++ b/Test/UnitTests.dpr
@@ -28,7 +28,9 @@ uses
   SSExchParserTest in 'SSExchParserTest.pas',
   DxccListTest in 'DxccListTest.pas',
   AppPaths in '..\Src\Core\AppPaths.pas',
+  ContestFileFormat in '..\Src\Persistence\ContestFileFormat.pas',
   Test.AppPaths in 'Core\Test.AppPaths.pas',
+  Test.ContestFileFormat in 'Persistence\Test.ContestFileFormat.pas',
   DxOperTest in 'DxOperTest.pas';
 
 {$IFNDEF TESTINSIGHT}

--- a/Test/UnitTests.dpr
+++ b/Test/UnitTests.dpr
@@ -29,8 +29,11 @@ uses
   DxccListTest in 'DxccListTest.pas',
   AppPaths in '..\Src\Core\AppPaths.pas',
   ContestFileFormat in '..\Src\Persistence\ContestFileFormat.pas',
+  ContestFileReader in '..\Src\Persistence\ContestFileReader.pas',
   Test.AppPaths in 'Core\Test.AppPaths.pas',
   Test.ContestFileFormat in 'Persistence\Test.ContestFileFormat.pas',
+  Test.ContestFileReader in 'Persistence\Test.ContestFileReader.pas',
+  Test.ContestReader.Base in 'Persistence\Test.ContestReader.Base.pas',
   DxOperTest in 'DxOperTest.pas';
 
 {$IFNDEF TESTINSIGHT}

--- a/Test/UnitTests.dproj
+++ b/Test/UnitTests.dproj
@@ -109,8 +109,11 @@
         <DCCReference Include="DxccListTest.pas"/>
         <DCCReference Include="..\Src\Core\AppPaths.pas"/>
         <DCCReference Include="..\Src\Persistence\ContestFileFormat.pas"/>
+        <DCCReference Include="..\Src\Persistence\ContestFileReader.pas"/>
         <DCCReference Include="Core\Test.AppPaths.pas"/>
         <DCCReference Include="Persistence\Test.ContestFileFormat.pas"/>
+        <DCCReference Include="Persistence\Test.ContestFileReader.pas"/>
+        <DCCReference Include="Persistence\Test.ContestReader.Base.pas"/>
         <DCCReference Include="DxOperTest.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/Test/UnitTests.dproj
+++ b/Test/UnitTests.dproj
@@ -107,8 +107,10 @@
         <DCCReference Include="MySSExchTest.pas"/>
         <DCCReference Include="SSExchParserTest.pas"/>
         <DCCReference Include="DxccListTest.pas"/>
-        <DCCReference Include="Core\Test.AppPaths.pas"/>
         <DCCReference Include="..\Src\Core\AppPaths.pas"/>
+        <DCCReference Include="..\Src\Persistence\ContestFileFormat.pas"/>
+        <DCCReference Include="Core\Test.AppPaths.pas"/>
+        <DCCReference Include="Persistence\Test.ContestFileFormat.pas"/>
         <DCCReference Include="DxOperTest.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
@@ -157,13 +159,7 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="Win32\Debug\UnitTests.exe" Configuration="Debug" Class="ProjectOutput">
-                    <Platform Name="Win32">
-                        <RemoteName>UnitTests.exe</RemoteName>
-                        <Overwrite>true</Overwrite>
-                    </Platform>
-                </DeployFile>
-                <DeployFile LocalName="Win32\Release\UnitTests.exe" Configuration="Release" Class="ProjectOutput">
+                <DeployFile LocalName="..\UnitTests.exe" Configuration="Release" Class="ProjectOutput">
                     <Platform Name="Win32">
                         <RemoteName>UnitTests.exe</RemoteName>
                         <Overwrite>true</Overwrite>

--- a/Test/UnitTests.dproj
+++ b/Test/UnitTests.dproj
@@ -107,6 +107,8 @@
         <DCCReference Include="MySSExchTest.pas"/>
         <DCCReference Include="SSExchParserTest.pas"/>
         <DCCReference Include="DxccListTest.pas"/>
+        <DCCReference Include="Core\Test.AppPaths.pas"/>
+        <DCCReference Include="..\Src\Core\AppPaths.pas"/>
         <DCCReference Include="DxOperTest.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>

--- a/Test/UnitTests.dproj
+++ b/Test/UnitTests.dproj
@@ -108,12 +108,16 @@
         <DCCReference Include="SSExchParserTest.pas"/>
         <DCCReference Include="DxccListTest.pas"/>
         <DCCReference Include="..\Src\Core\AppPaths.pas"/>
+        <DCCReference Include="..\Src\Domain\Contests\ArrlDx.Types.pas"/>
         <DCCReference Include="..\Src\Persistence\ContestFileFormat.pas"/>
         <DCCReference Include="..\Src\Persistence\ContestFileReader.pas"/>
+        <DCCReference Include="..\Src\Persistence\Contests\ArrlDx.Reader.pas"/>
         <DCCReference Include="Core\Test.AppPaths.pas"/>
         <DCCReference Include="Persistence\Test.ContestFileFormat.pas"/>
         <DCCReference Include="Persistence\Test.ContestFileReader.pas"/>
         <DCCReference Include="Persistence\Test.ContestReader.Base.pas"/>
+        <DCCReference Include="Persistence\Test.ContestReader.Contracts.pas"/>
+        <DCCReference Include="Persistence\Contests\Test.ArrlDx.Reader.pas"/>
         <DCCReference Include="DxOperTest.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>


### PR DESCRIPTION
The motivation behind this refactoring is to combine the common code found in each reader. The existing implementation have had some bugs, including one release that had no valid callsigns loaded for one contest. So this change introduces a common base class reader  and support UnitTest'ing files. Each contest will then derive the reader and override new contest-specific methods. The goal is for each contest is to have a derived reader and corresponding unit testing. This change only refactors the ARRL DX Contest. The other contests will be provided as time permits.

There are 5 commits in this review.
1. The first is repeated from PR #457 and is being reviewed separately.
2. ArrlDx - refactor & introduce Src/Domain/Contests/ArrlDx.Types.pas.
3. Add ContestFileFormat and associated unit test
    - Use by the new generic ContestFileReader to detect file types
    - Supports:
      - N1MM files call history files, and
      - ARRL Contest score summary files
    - Files:
      - Src/Persistence/ContestFileFormat.pas
      - Test/Persistence/Test.ContestFileFormat.pas
4. Introduce ContestFileReader
    Implements the common behaviors for reading either
    - N1MM Call History files, or
    - ARRL Contest Summary Score files
    - refactor validation
    - Arrl10m.Policy is used for common code between ArrlDx.Contest and ArrlDx.Reader
5. ARRL DX Contest - refactor call history reader
    - Add Src/Persistence/Contests/ArrlDx.Reader.pas
    - Add unit testing at Test/Persistence/Contests/Test.ArrlDx.Reader.pas
    - Add generic testing support (in the form of testing the implied
      contracts for all derived readers) at:
      Test/Persistence/Test.ContestReader.Contracts.pas
    - The motivation behind this refactoring is to address the issue
      that the 1.84 release did not load the ARRL DX Contest files correctly.
      By adding unit tests for each contest, we can guarantee that the files
      will load correctly.