### PR TITLE
Dev improve status messages

### DIFF
--- a/Contest.pas
+++ b/Contest.pas
@@ -1008,10 +1008,7 @@ begin
     begin
       if Stations.DropCallerForNil(Call, Active) then
         if Active or (RunMode = rmSingle) then
-          begin
-            MainForm.sbar.Font.Color := clDefault;
-            MainForm.sbar.Caption := 'Skipped ' + Call;
-          end;
+          Log.SBarUpdateStatusMsg('Skipped ' + Call);
       Msg := Me.Msg;
       Me.Msg := [msgGarbage];
     end;

--- a/DxStn.pas
+++ b/DxStn.pas
@@ -132,9 +132,7 @@ begin
         if Oper.State = osFailed then begin
           // during debug, use status bar to show CW stream
           if BDebugCwDecoder or BDebugGhosting then
-            Mainform.sbar.Caption :=
-              (Format('[%s-osFailed], Stn deleted',[MyCall]) + '; ' +
-              Mainform.sbar.Caption).Substring(0, 80);
+            SBarUpdateStatusMsg(Format('[%s-osFailed], Stn deleted',[MyCall]));
           Free;
           Exit;
           end;
@@ -176,9 +174,7 @@ begin
             begin
               // during debug, use status bar to show CW stream
               if BDebugCwDecoder or BDebugGhosting then
-                Mainform.sbar.Caption :=
-                  (Format('[%s-osFailed, Stn deleted]',[MyCall]) + '; ' +
-                  Mainform.sbar.Caption).Substring(0, 80);
+                SBarUpdateStatusMsg(Format('[%s-osFailed], Stn deleted',[MyCall]));
               Free;
               Exit;
             end;

--- a/Log.pas
+++ b/Log.pas
@@ -30,6 +30,7 @@ procedure UpdateSbar;
 procedure UpdateExchangeSummaryLabel;
 procedure SbarUpdateStationInfo(const ACallsign: string);
 procedure SetExchangeSummaryText(const AExchSummary: String);
+procedure SBarUpdateStatusMsg(const AMsg: string);
 procedure SBarUpdateDebugMsg(const AMsgText: string);
 procedure ClearError;
 procedure DisplayError(const AExchError: string; const AColor: TColor = clRed);
@@ -121,8 +122,8 @@ var
   NrSent: boolean;   // msgNR has been sent; cleared after qso is completed.
   ShowCorrections: boolean;   // show exchange correction column.
   SBarDebugMsg: String;         // sbar debug message
-  SBarStationInfo: String;    // sbar station info (UserText from call history file)
   ExchangeSummaryText: String;  // exchange summary (ARRL SS)
+  SBarStatusMsg: String;      // sbar status message (e.g. # callsigns loaded)
   SBarErrorMsg: String;       // sbar exchange error
   SBarErrorColor: TColor;     // sbar exchange error color
   Histo: THisto;
@@ -399,7 +400,7 @@ begin
   MainForm.ListView2.Perform(WM_VSCROLL, SB_BOTTOM, 0);
 end;
 
-//Update Callsign info
+//Update Callsign info for the given callsign
 procedure SbarUpdateStationInfo(const ACallsign: string);
 var
   s: string;
@@ -412,13 +413,9 @@ begin
   begin
     // Adding a contest: SbarUpdateStationInfo - update status bar with station info (e.g. FD shows UserText)
     s := Tst.GetStationInfo(ACallsign);
-
-    // '&' are suppressed in this control; replace with '&&'
-    s:= StringReplace(s, '&', '&&', [rfReplaceAll]);
   end;
 
-  SBarStationInfo := s;
-  UpdateSbar;
+  SBarUpdateStatusMsg(s);
 end;
 
 
@@ -443,6 +440,15 @@ begin
 end;
 
 
+procedure SBarUpdateStatusMsg(const AMsg: string);
+begin
+  if SBarStatusMsg = AMsg then Exit;
+
+  SBarStatusMsg := AMsg;
+  UpdateSbar;
+end;
+
+
 procedure SBarUpdateDebugMsg(const AMsgText: string);
 begin
   if SBarDebugMsg = AMsgText then Exit;
@@ -455,35 +461,31 @@ begin
 end;
 
 // Refresh Status Bar
-// [(Error | UserText)] [>> Debug stream]
+// [(Error | (Status | UserText))] [>> Debug stream]
 procedure UpdateSbar;
 var
   S: String;
 begin
-  // error or UserText...
   if not SBarErrorMsg.IsEmpty then
-    begin
-      if not S.IsEmpty then
-        S := S + ' -- ';
-      S := S + SBarErrorMsg;
-    end
-  else if not SBarStationInfo.IsEmpty then
-    begin
-      if not S.IsEmpty then
-        S := S + ' -- ';
-      S := S + SBarStationInfo;
-    end;
+    S := SBarErrorMsg
+  else if not SBarStatusMsg.IsEmpty then
+    S := SBarStatusMsg
+  else
+    S := '';
 
   // during debug, use status bar to show CW stream
   if not SBarDebugMsg.IsEmpty then
-    S := format('  %-45s >> %-40s', [S, SBarDebugMsg]);
+    S := format('%-45s >> %-40s', [S, SBarDebugMsg]);
 
   if SBarErrorMsg.IsEmpty then
     Mainform.sbar.Font.Color := clDefault
   else
     Mainform.sbar.Font.Color := SBarErrorColor;
 
-  MainForm.sbar.Caption := S;
+  // the '&' character is suppressed in this control; replace with '&&'
+  S:= StringReplace(S, '&', '&&', [rfReplaceAll]);
+
+  MainForm.sbar.Caption := '  ' + S;
 end;
 
 

--- a/Main.pas
+++ b/Main.pas
@@ -2052,6 +2052,9 @@ begin
 
     // clear existing status messages
     Log.ClearError;
+    Log.SBarUpdateStationInfo('');
+    Log.SBarUpdateStatusMsg('');
+    Log.SBarUpdateDebugMsg('');
     Application.ProcessMessages;  // Force UI update
 
     // load call history and other contest-specific setup before starting

--- a/Main.pas
+++ b/Main.pas
@@ -2184,6 +2184,8 @@ begin
       }
     if AlWavFile1.IsOpen then
       AlWavFile1.Close;
+
+    SBarUpdateStatusMsg('');
   end
   else begin
     AlWavFile1.FileName := ChangeFileExt(ParamStr(0), '.wav');

--- a/Station.pas
+++ b/Station.pas
@@ -134,7 +134,7 @@ function ToStr(const val : TStationEvent) : string; overload;
 implementation
 
 uses
-  Main,     // for Mainform.sbar.Caption, BDebugCwDecoder
+  Main,     // for Mainform.Edit2.Text, BDebugCwDecoder
   QrmStn,   // for TQrmStation.ClassType
   Contest,  // for Tst (TContest), Tst.Me.OpName
   Log,      // for SBarUpdateDebugMsg


### PR DESCRIPTION
Add SBarUpdateStatusMsg()

1. Add SBarUpdateStatusMsg() to Log.pas
  - the status bar now displays either error or status message.
  - used to print station info and other status strings (# of callsigns loaded)
  - clear existing status messages before starting a new contest
  - cleaned up SBarUpdateStationInfo.

2. Use SBarUpdateStatusMsg to update existing status messages