### PR TITLE
Display number of callsigns loaded when starting a contest

### DIFF
--- a/ACAG.pas
+++ b/ACAG.pas
@@ -25,6 +25,9 @@ type
     CallList: TObjectList<TAcagCallRec>;
     Comparer: IComparer<TAcagCallRec>;
 
+  protected
+    function GetCallHistoryCount: Integer; override;
+
   public
     constructor Create;
     destructor Destroy; override;
@@ -100,6 +103,12 @@ begin
     tl.Free;
     if rec <> nil then rec.Free;
   end;
+end;
+
+
+function TACAG.GetCallHistoryCount: Integer;
+begin
+  Result := CallList.Count;
 end;
 
 

--- a/ALLJA.pas
+++ b/ALLJA.pas
@@ -25,6 +25,9 @@ type
     CallList: TObjectList<TAllJaCallRec>;
     Comparer: IComparer<TAllJaCallRec>;
 
+  protected
+    function GetCallHistoryCount: Integer; override;
+
   public
     constructor Create;
     destructor Destroy; override;
@@ -46,6 +49,7 @@ implementation
 
 uses
   SysUtils, Classes;
+
 
 function TALLJA.LoadCallHistory(const AUserCallsign : string) : boolean;
 const
@@ -100,6 +104,12 @@ begin
     tl.Free;
     if rec <> nil then rec.Free;
   end;
+end;
+
+
+function TALLJA.GetCallHistoryCount: Integer;
+begin
+  Result := CallList.Count;
 end;
 
 

--- a/ArrlDx.pas
+++ b/ArrlDx.pas
@@ -26,6 +26,9 @@ type
     ArrlDxCallList: TObjectList<TArrlDxCallRec>;
     Comparer: IComparer<TArrlDxCallRec>;
 
+  protected
+    function GetCallHistoryCount: Integer; override;
+
   public
     constructor Create;
     destructor Destroy; override;
@@ -170,6 +173,12 @@ begin
     tl.Free;
 
   end;
+end;
+
+
+function TArrlDx.GetCallHistoryCount: Integer;
+begin
+  Result := Self.ArrlDxCallList.Count;
 end;
 
 

--- a/ArrlFd.pas
+++ b/ArrlFd.pas
@@ -57,6 +57,9 @@ private
   FdCallList: TObjectList<TFdCallRec>;
   Comparer: IComparer<TFdCallRec>;
 
+protected
+  function GetCallHistoryCount: Integer; override;
+
 public
   constructor Create;
   destructor Destroy; override;
@@ -360,6 +363,12 @@ begin
     PendingStations.Free;
     if rec <> nil then rec.Free;
   end;
+end;
+
+
+function TArrlFieldDay.GetCallHistoryCount: Integer;
+begin
+  Result := FdCallList.Count;
 end;
 
 

--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -34,6 +34,9 @@ private
 
   function GetAlternateSection(const ASection: string): string;
 
+protected
+  function GetCallHistoryCount: Integer; override;
+
 public
   constructor Create;
   destructor Destroy; override;
@@ -130,6 +133,12 @@ begin
     tl.Free;
     if rec <> nil then rec.Free;
   end;
+end;
+
+
+function TSweepstakes.GetCallHistoryCount: Integer;
+begin
+  Result := SweepstakesCallList.Count;
 end;
 
 

--- a/CWOPS.pas
+++ b/CWOPS.pas
@@ -24,6 +24,9 @@ type
     Comparer: IComparer<TCWOPSRec>;
     procedure Delimit(var AStringList: TStringList; const AText: string);
 
+  protected
+    function GetCallHistoryCount: Integer; override;
+
   public
     constructor Create;
     destructor Destroy; override;
@@ -109,6 +112,12 @@ begin
 
 
 end;
+
+function TCWOPS.GetCallHistoryCount: Integer;
+begin
+  Result := CWOPSList.Count;
+end;
+
 
 constructor TCWOPS.Create;
 begin

--- a/CWSST.pas
+++ b/CWSST.pas
@@ -23,6 +23,9 @@ type
     Comparer: IComparer<TCWSSTRec>;
     procedure Delimit(var AStringList: TStringList; const AText: string);
 
+  protected
+    function GetCallHistoryCount: Integer; override;
+
   public
     constructor Create;
     destructor Destroy; override;
@@ -108,9 +111,14 @@ begin
         tl.Free;
         if SST <> nil then SST.Free;
     end;
-
-
 end;
+
+
+function TCWSST.GetCallHistoryCount: Integer;
+begin
+  Result := CWSSTList.Count;
+end;
+
 
 constructor TCWSST.Create;
 begin

--- a/CallLst.pas
+++ b/CallLst.pas
@@ -20,6 +20,7 @@ type
     constructor Create;
     destructor Destroy; override;
     procedure LoadCallList;
+    function Count : Integer;
     function IsEmpty : Boolean;
     procedure Clear();
     function PickCall : string;
@@ -102,6 +103,12 @@ begin
   finally
     L.Free;
   end;
+end;
+
+
+function TCallList.Count : Integer;
+begin
+  Result := Calls.Count;
 end;
 
 

--- a/Contest.pas
+++ b/Contest.pas
@@ -32,6 +32,7 @@ type
     constructor Create;
     function IsReloadRequired(const AUserCallsign : String) : boolean;
     procedure SetLastLoadCallsign(const AUserCallsign : String);
+    function GetCallHistoryCount: Integer; virtual; abstract;
     function ValidateExchField(const FieldDef: PFieldDefinition;
       const Avalue: string) : Boolean;
 
@@ -99,6 +100,8 @@ type
     procedure OnMeStartedSending;
     procedure OnSaveQsoComplete;
     procedure OnStationIDSent;
+
+    property CallHistoryCount: Integer read GetCallHistoryCount;
   end;
 
 var

--- a/Contest.pas
+++ b/Contest.pas
@@ -223,11 +223,15 @@ end;
   user's home callsign is required when loading some contests
   (don't load if user callsign is empty or is the same as last time).
 
+  If RunMode=rmHST, always reload the CallList. This is done because
+  calls are deleted as they are used.
+
   return whether the call history file is valid. This varies by contest.
 }
 function TContest.IsReloadRequired(const AUserCallsign : string) : boolean;
 begin
-  Result := not (AUserCallsign.IsEmpty or (LastLoadCallsign = AUserCallsign));
+  Result := (Ini.RunMode = rmHST) or
+            not (AUserCallsign.IsEmpty or (LastLoadCallsign = AUserCallsign));
 end;
 
 

--- a/CqWW.pas
+++ b/CqWW.pas
@@ -26,6 +26,9 @@ private
   MyContinent : string;
   MyEntity : string;
 
+protected
+  function GetCallHistoryCount: Integer; override;
+
 public
   constructor Create;
   destructor Destroy; override;
@@ -120,6 +123,12 @@ begin
     tl.Free;
     if rec <> nil then rec.Free;
   end;
+end;
+
+
+function TCqWw.GetCallHistoryCount: Integer;
+begin
+  Result := CqWwCallList.Count;
 end;
 
 

--- a/CqWpx.pas
+++ b/CqWpx.pas
@@ -22,6 +22,9 @@ private
 
   function GetNR(const station : TDxStation) : integer;
 
+protected
+  function GetCallHistoryCount: Integer; override;
+
 public
   constructor Create;
   destructor Destroy; override;
@@ -94,6 +97,12 @@ begin
   CallLst.LoadCallList;
 
   Result := True;
+end;
+
+
+function TCqWpx.GetCallHistoryCount: Integer;
+begin
+  Result := CallLst.Count;
 end;
 
 

--- a/IaruHf.pas
+++ b/IaruHf.pas
@@ -26,6 +26,9 @@ type
     Comparer: IComparer<TIaruHfCallRec>;
     MyContinent: string;  // set by OnSetMyCall
 
+  protected
+    function GetCallHistoryCount: Integer; override;
+
   public
     constructor Create;
     destructor Destroy; override;
@@ -162,6 +165,12 @@ begin
     tl.Free;
     dupList.Free;
   end;
+end;
+
+
+function TIaruHf.GetCallHistoryCount: Integer;
+begin
+  Result := IaruHfCallList.Count;
 end;
 
 

--- a/Main.pas
+++ b/Main.pas
@@ -2055,11 +2055,19 @@ begin
     Log.SBarUpdateStationInfo('');
     Log.SBarUpdateStatusMsg('');
     Log.SBarUpdateDebugMsg('');
+{$ifdef DEBUG}
+    Log.SBarUpdateStatusMsg('Loading call history...');
+{$endif}
     Application.ProcessMessages;  // Force UI update
 
     // load call history and other contest-specific setup before starting
     if not Tst.OnContestPrepareToStart(Ini.Call, ExchangeEdit.Text) then
       Exit;
+
+{$ifdef DEBUG}
+    // display number of callsigns loaded
+    Log.SBarUpdateStatusMsg(format('%d callsigns loaded', [Tst.CallHistoryCount]));
+{$endif}
   end;
 
   BStop := Value = rmStop;

--- a/Main.pas
+++ b/Main.pas
@@ -2055,19 +2055,15 @@ begin
     Log.SBarUpdateStationInfo('');
     Log.SBarUpdateStatusMsg('');
     Log.SBarUpdateDebugMsg('');
-{$ifdef DEBUG}
     Log.SBarUpdateStatusMsg('Loading call history...');
-{$endif}
     Application.ProcessMessages;  // Force UI update
 
     // load call history and other contest-specific setup before starting
     if not Tst.OnContestPrepareToStart(Ini.Call, ExchangeEdit.Text) then
       Exit;
 
-{$ifdef DEBUG}
     // display number of callsigns loaded
     Log.SBarUpdateStatusMsg(format('%d callsigns loaded', [Tst.CallHistoryCount]));
-{$endif}
   end;
 
   BStop := Value = rmStop;

--- a/NaQp.pas
+++ b/NaQp.pas
@@ -24,6 +24,9 @@ private
   FIsCallLocalLastCall: String;     // used to optimize IsCallLocalToContest
   FIsCallLocalLastResult: Boolean;  // used to optimize IsCallLocalToContest
 
+protected
+  function GetCallHistoryCount: Integer; override;
+
 public
   constructor Create;
   destructor Destroy; override;
@@ -165,6 +168,12 @@ begin
     tl.Free;
     if rec <> nil then rec.Free;
   end;
+end;
+
+
+function TNcjNaQp.GetCallHistoryCount: Integer;
+begin
+  Result := NaQpCallList.Count;
 end;
 
 


### PR DESCRIPTION
Several changes:
- Added virtual function to allow each contest returns number of available callsigns
- Add TContest.CallHistoryCount as a public property
- value is returned using a virtual/abstract function
- returns number of callsigns loaded in the callhistory file
- used/printed by Main.pas
- TContest.GetCallHistoryCount is now an abstract function
- this was done to prevent a release with a broken call history file reader. The case in point was release 1.85.3 where the ArrlDx file was only reading a dozen or so callsigns and was reported back to the developers by our users.