### PR TITLE
P29sx hotfix

### DIFF
--- a/CallLst.pas
+++ b/CallLst.pas
@@ -58,7 +58,7 @@ var
 begin
   Calls.Clear;
 
-  FileName := ExtractFilePath(TAppPaths.ContestDataFile('Master.dta'));
+  FileName := TAppPaths.ContestDataFile('Master.dta');
   if not FileExists(FileName) then Exit;
 
   with TFileStream.Create(FileName, fmOpenRead) do

--- a/Src/Core/AppPaths.pas
+++ b/Src/Core/AppPaths.pas
@@ -114,18 +114,18 @@ begin
     TAppPaths.FRepositoryRootDir := '';
 
   // Detect installed layout
+{$IFDEF FUTURE_CONTEST_DATA_SUBDIR}
   if TDirectory.Exists(TPath.Combine(FExecutableDir, 'ContestData')) then
     TAppPaths.FIsInstalledLayout := True
-{$IFDEF FUTURE_CONTEST_DATA_SUBDIR}
   else if TDirectory.Exists(
     TPath.Combine([FRepositoryRootDir, 'Src', 'Domain', 'Contests', 'Data'])) then
     TAppPaths.FIsInstalledLayout := False
-{$ELSE}
-  else if not FRepositoryRootDir.IsEmpty then
-    TAppPaths.FIsInstalledLayout := False
-{$ENDIF}
   else
     raise Exception.Create('Invalid configuration');
+{$ELSE}
+  // current release still needs contest data besid the exe
+  TAppPaths.FIsInstalledLayout := TAppPaths.FRepositoryRootDir.IsEmpty;
+{$ENDIF}
 
   // location of contest history files
 {$IFDEF FUTURE_CONTEST_DATA_SUBDIR}


### PR DESCRIPTION
While test-building master, I ran into an interesting little regression: four logged calls, all four from `P29SX`. The attached debug-build screenshot records this remarkably loyal pile-up.

<img width="731" height="558" alt="image" src="https://github.com/user-attachments/assets/7ac9288c-9381-4fbe-9087-7b0b27b2cc07" />

TAppPaths.ContestDataFile('Master.dta') already returns the pathname. Passing it through ExtractFilePath removed master.dta leaving the call list empty and invoking the old `P29SX` fallback. This PR uses the returned pathname directly.

I also tested the build in a clean temporary folder, copying the executable and contest files beside it as in the current release. It failed at startup with a warning "Invalid configuration"". Creating an empty ContestData directory made it start: that directory was being used as an installation marker, although the current build still reads the actual data from beside the executable.

The source tree concealed this because .git, VCL, Util and main.pas identify it as a dev's worktree. This PR keeps the proposed ContestData layout behind `FUTURE_CONTEST_DATA_SUBDIR` and restores the present flat release layout.

