### PR TITLE
fix audio recording status and folder selection

### DIFF
--- a/Main.pas
+++ b/Main.pas
@@ -2301,8 +2301,8 @@ begin
       AlWavFile1.Close;
       Log.ClearError;
       Log.SbarUpdateStationInfo('');
-      Log.SBarUpdateStatusMsg('Audio recording saved: ' +
-        AlWavFile1.FileName);
+      Log.SBarUpdateStatusMsg('Saved: ' +
+        ExtractFileName(AlWavFile1.FileName));
       sbar.Hint := 'Audio recording saved: ' + AlWavFile1.FileName;
       sbar.ShowHint := True;
       sbar.Visible := True;
@@ -2762,7 +2762,6 @@ begin
     begin
       Windows.DeleteFile(PChar(@TempFile[0]));
       Ini.RecordingFolder := InitialFolder;
-      Ini.SaveWav := True;
       Exit;
     end;
     Application.MessageBox(PChar(Format(


### PR DESCRIPTION
Two small follow-ups to #456:

- status bar reports `Saved: <filename>`; the tooltip has the full path
- choosing a folder now preserves whether recording is enabled
- cancel still does nothing