### PR TITLE
Send 5NN faster than the rest of the exchange

### DIFF
--- a/Ini.pas
+++ b/Ini.pas
@@ -272,6 +272,8 @@ var
   AllStationsWpmS: integer = 0;      // force all stations to this Wpm
   CallsFromKeyer: boolean = false;
   F8: string = '';
+  Faster5nn: integer = 0;
+  Faster5nnMem: integer = 20;
 
   { display parsed Exchange field settings; calls/exchanges (in rmSingle mode) }
   DebugExchSettings: boolean = false;
@@ -456,6 +458,8 @@ begin
       StationIdRate := ReadInteger(SEC_SET, 'StationIdRate', StationIdRate);
       SingleCallStartDelay := ReadInteger(SEC_SET, 'SingleCallStartDelay', SingleCallStartDelay);
       SingleCallStartDelay := Max(0, Min(SingleCallStartDelay, 2500));
+      Faster5nn := Max(0, Min(100, ReadInteger(SEC_SET, 'Faster5nn', Faster5nn)));
+      if Faster5nn > 0 then Faster5nnMem := Faster5nn;
 
       // [Debug]
       DebugExchSettings := ReadBool(SEC_DBG, 'DebugExchSettings', DebugExchSettings);
@@ -540,6 +544,7 @@ begin
       WriteInteger(SEC_SET, 'ShowExchangeSummary', ShowExchangeSummary);
       WriteInteger(SEC_SET, 'StationIdRate', StationIdRate);
       WriteInteger(SEC_SET, 'SingleCallStartDelay', SingleCallStartDelay);
+      WriteInteger(SEC_SET, 'Faster5nn', Faster5nn);
 
     finally
       Free;

--- a/Main.dfm
+++ b/Main.dfm
@@ -1478,10 +1478,10 @@ object MainForm: TMainForm
           Caption = '9'
           OnClick = Activity1Click
         end
-        object Faster5nn1: TMenuItem
-          Caption = 'Faster 5NN'
-          OnClick = Faster5nn1Click
-        end
+      end
+      object Faster5nn1: TMenuItem
+        Caption = 'Faster 5NN'
+        OnClick = Faster5nn1Click
       end
       object N7: TMenuItem
         Caption = '-'

--- a/Main.dfm
+++ b/Main.dfm
@@ -1470,6 +1470,10 @@ object MainForm: TMainForm
           Caption = '9'
           OnClick = Activity1Click
         end
+        object Faster5nn1: TMenuItem
+          Caption = 'Faster 5NN'
+          OnClick = Faster5nn1Click
+        end
       end
       object N7: TMenuItem
         Caption = '-'

--- a/Main.dfm
+++ b/Main.dfm
@@ -1479,10 +1479,6 @@ object MainForm: TMainForm
           OnClick = Activity1Click
         end
       end
-      object Faster5nn1: TMenuItem
-        Caption = 'Faster 5NN'
-        OnClick = Faster5nn1Click
-      end
       object N7: TMenuItem
         Caption = '-'
       end
@@ -1532,6 +1528,10 @@ object MainForm: TMainForm
         Caption = 'NIL Instantly Removes Caller'
         Checked = True
         OnClick = NilInstantRemove1Click
+      end
+      object Faster5nn1: TMenuItem
+        Caption = 'Faster 5NN'
+        OnClick = Faster5nn1Click
       end
       object mnuShowCallsignInfo: TMenuItem
         Caption = 'Show Callsign Info'

--- a/Main.pas
+++ b/Main.pas
@@ -177,6 +177,7 @@ type
     QSB1: TMenuItem;
     Flutter1: TMenuItem;
     LIDS1: TMenuItem;
+    Faster5nn1: TMenuItem;
     Activity1: TMenuItem;
     N11: TMenuItem;
     N21: TMenuItem;
@@ -291,6 +292,7 @@ type
     procedure SelfMonClick(Sender: TObject);
     procedure Settings1Click(Sender: TObject);
     procedure LIDS1Click(Sender: TObject);
+    procedure Faster5nn1Click(Sender: TObject);
     procedure CWMaxRxSpeedClick(Sender: TObject);
     procedure CWMinRxSpeedClick(Sender: TObject);
     procedure NRDigitsClick(Sender: TObject);
@@ -2553,6 +2555,7 @@ begin
   QSB1.Checked := Ini.Qsb;
   Flutter1.Checked := Ini.Flutter;
   LIDS1.Checked := Ini.Lids;
+  Faster5nn1.Checked := Ini.Faster5nn > 0;
 end;
 
 
@@ -2700,6 +2703,20 @@ begin
   CheckBox6.Checked := LIDS1.Checked;
 
   ReadCheckboxes;
+end;
+
+
+procedure TMainForm.Faster5nn1Click(Sender: TObject);
+begin
+  if Ini.Faster5nn = 0 then
+    Ini.Faster5nn := Ini.Faster5nnMem
+  else
+    begin
+    Ini.Faster5nnMem := Ini.Faster5nn;
+    Ini.Faster5nn := 0;
+    end;
+
+  Faster5nn1.Checked := Ini.Faster5nn > 0;
 end;
 
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -83,6 +83,8 @@ CONFIGURATION
             over.
      Activity - band activity, determines how many stations on average
                 reply to your CQ.
+     Faster 5NN - some stations send 5NN or 599 faster than the rest of
+                  the message.
 
   The Run Button
     This starts and stops the competition or contest.

--- a/Station.pas
+++ b/Station.pas
@@ -314,11 +314,12 @@ begin
     Nr2 := NrAsText;
     FastSteps := 0;
     if (IsFastReport(Nr) or IsFastReport(Nr2)) and
-      (Ini.Faster5nn > 0) and not Tst.IsFarnsworthAllowed then
+      (Ini.Faster5nn > 0) and not Tst.IsFarnsworthAllowed and
+      not (Ini.SimContest in [scWpx, scHst]) then
       if Self = Tst.Me then
         FastSteps := 5
-      else if Random(100) < Ini.Faster5nn then
-        FastSteps := 3 + Random(3);
+      else if 100 * Frac(100 * R1) < Ini.Faster5nn then
+        FastSteps := 3 + Floor(3 * Frac(10000 * R1));
 
     //with error
     AMsg := StringReplace(AMsg, '<#>', MarkReport(Nr), []);

--- a/Station.pas
+++ b/Station.pas
@@ -241,7 +241,8 @@ end;
 }
 procedure TStation.SendText(AMsg: string);
 var
-  P : integer;
+  P, FastSteps: integer;
+  Nr, Nr2, DebugMsg: string;
 
   // Modifies AMsg by replacing AToken at position P with ANewText and
   // advances the token offset P to the start of the next token.
@@ -265,20 +266,37 @@ var
     Result := (P = 0);
   end;
 
-begin
-  if Pos('<#>', AMsg) > 0 then
-    begin
-    //with error
-    AMsg := StringReplace(AMsg, '<#>', NrAsText, []);
-    //error cleared
-    AMsg := StringReplace(AMsg, '<#>', NrAsText, [rfReplaceAll]);
-    end;
+  function IsFastReport(const AExchange: string): boolean;
+  var
+    Report: string;
+  begin
+    Report := Copy(AExchange, 1, 3);
+    Result := (SentExchTypes.Exch1 = etRST) and
+      ((Report = '5NN') or (Report = '599'));
+  end;
 
+  function MarkReport(const AExchange: string): string;
+  begin
+    Result := AExchange;
+    if (FastSteps = 0) or not IsFastReport(AExchange) then Exit;
+
+    Result := StringOfChar(CW_SPEED_UP, FastSteps) + Copy(AExchange, 1, 3) +
+      StringOfChar(CW_SPEED_DOWN, FastSteps) + Copy(AExchange, 4, MaxInt);
+  end;
+
+begin
   // replace tokens with actual values
   P := Pos('<', AMsg);
   while (P > 0) do
     begin
       var Q: Integer := P;
+      // Leave <#> until the other tokens have been expanded.
+      if PosEx('<#>', AMsg, P) = P then
+        begin
+        P := PosEx('<', AMsg, P + 1);
+        Continue;
+        end;
+
       if ReplaceTokenAt(AMsg, P, '<my>', MyCall) then Break;
       if ReplaceTokenAt(AMsg, P, '<exch1>', Exch1) then Break;
       if ReplaceTokenAt(AMsg, P, '<exch2>', Exch2) then Break;
@@ -288,6 +306,24 @@ begin
         raise Exception.CreateFmt(
           'Internal error: TStation.SendText: unrecognized token in msg: "%s"',
           [AMsg]);
+    end;
+
+  if Pos('<#>', AMsg) > 0 then
+    begin
+    Nr := NrAsText;
+    Nr2 := NrAsText;
+    FastSteps := 0;
+    if (IsFastReport(Nr) or IsFastReport(Nr2)) and
+      (Ini.Faster5nn > 0) and not Tst.IsFarnsworthAllowed then
+      if Self = Tst.Me then
+        FastSteps := 5
+      else if Random(100) < Ini.Faster5nn then
+        FastSteps := 3 + Random(3);
+
+    //with error
+    AMsg := StringReplace(AMsg, '<#>', MarkReport(Nr), []);
+    //error cleared
+    AMsg := StringReplace(AMsg, '<#>', MarkReport(Nr2), [rfReplaceAll]);
     end;
 
 {
@@ -302,7 +338,11 @@ begin
 
   // during debug, use status bar to show CW stream
   if BDebugCwDecoder and not (self is TQrmStation) then
-    Log.SBarUpdateDebugMsg(MsgText);
+    begin
+    DebugMsg := StringReplace(MsgText, CW_SPEED_UP, '', [rfReplaceAll]);
+    DebugMsg := StringReplace(DebugMsg, CW_SPEED_DOWN, '', [rfReplaceAll]);
+    Log.SBarUpdateDebugMsg(DebugMsg);
+    end;
 
   SendMorse(Keyer.Encode(MsgText));
 end;

--- a/VCL/MorseKey.pas
+++ b/VCL/MorseKey.pas
@@ -10,6 +10,10 @@ interface
 uses
   SndTypes;
 
+const
+  CW_SPEED_UP = '<';
+  CW_SPEED_DOWN = '>';
+
 
 type
   TKeyer = class
@@ -161,12 +165,18 @@ var
 begin
   Result := '';
   for i:=1 to Length(Txt) do
-    if CharInSet(Txt[i], [' ', '_']) then
-        Result := Result + ' '
-    else
-        Result := Result + Morse[Txt[i]];
-  if Result <> '' then
-    Result[Length(Result)] := '~';  // EOM has ~5U spacing
+    case Txt[i] of
+      CW_SPEED_UP, CW_SPEED_DOWN: Result := Result + Txt[i];
+      ' ', '_': Result := Result + ' ';
+      else Result := Result + Morse[Txt[i]];
+    end;
+
+  for i:=Length(Result) downto 1 do
+    if not CharInSet(Result[i], [CW_SPEED_UP, CW_SPEED_DOWN]) then
+      begin
+      Result[i] := '~';  // EOM has ~5U spacing
+      Break;
+      end;
 end;
 
 
@@ -181,8 +191,14 @@ end;
 }
 function TKeyer.GetEnvelope: TSingleArray;
 var
-  UnitCnt, Len, i, p: integer;
-  SamplesInUnit: integer;
+  Len, i, p: integer;
+  CurrentWpm, SamplesInUnit: integer;
+
+  procedure SetSpeed(AWpm: integer);
+  begin
+    CurrentWpm := Max(1, AWpm);
+    SamplesInUnit := Round(60/48 * Rate / CurrentWpm);
+  end;
 
   procedure AddRampOn;
   begin
@@ -233,29 +249,31 @@ var
 begin
   assert(WpmS > 0, 'must init using SetWpm()');
 
-  //count units
-  UnitCnt := 0;
-
+  SetSpeed(WpmS);
+  TrueEnvelopeLen := 0;
   for i:=1 to Length(MorseMsg) do
     case MorseMsg[i] of
-      '.': Inc(UnitCnt, 2);   // 1 unit dit followed by 1 unit spacing
-      '-': Inc(UnitCnt, 4);   // 3 unit dash followed by 1 unit spacing
-      ' ': Inc(UnitCnt, 2);   // 3U inter-char space (2U + prior 1U)
+      CW_SPEED_UP: SetSpeed(CurrentWpm + 2);
+      CW_SPEED_DOWN: SetSpeed(CurrentWpm - 2);
+      '.': Inc(TrueEnvelopeLen, 2 * SamplesInUnit); // dit and spacing
+      '-': Inc(TrueEnvelopeLen, 4 * SamplesInUnit); // dash and spacing
+      ' ': Inc(TrueEnvelopeLen, 2 * SamplesInUnit); // inter-char space
     { ' ': subsequent space } // 5U inter-word space (2U + prior 3U)
-      '~': Inc(UnitCnt, 3);   // 4U inter-msg space (3U + prior 1U + loop time)
+      '~': Inc(TrueEnvelopeLen, 3 * SamplesInUnit); // inter-msg space
     end;
 
   //calc buffer size
-  SamplesInUnit := Round(60/48 * Rate / WpmS);  // 48U = 1 word w/ 5U inter-word space
-  TrueEnvelopeLen := UnitCnt * SamplesInUnit;
   Len := BufSize * Ceil(TrueEnvelopeLen / BufSize);
   Result := nil;
   SetLength(Result, Len);
 
   //fill buffer
   p := 0;
+  SetSpeed(WpmS);
   for i:=1 to Length(MorseMsg) do
     case MorseMsg[i] of
+      CW_SPEED_UP: SetSpeed(CurrentWpm + 2);
+      CW_SPEED_DOWN: SetSpeed(CurrentWpm - 2);
       '.': begin AddRampOn; AddOn(1); AddRampOff; AddOff(1, RampLen); end;
       '-': begin AddRampOn; AddOn(3); AddRampOff; AddOff(1, RampLen); end;
       ' ': AddOff(2, 0);      // 3U inter-char spacing (2U + prior 1U)

--- a/VCL/MorseKey.pas
+++ b/VCL/MorseKey.pas
@@ -249,17 +249,18 @@ var
 begin
   assert(WpmS > 0, 'must init using SetWpm()');
 
+  // Count samples directly - faster 5NN can put several WPMs in one message.
   SetSpeed(WpmS);
   TrueEnvelopeLen := 0;
   for i:=1 to Length(MorseMsg) do
     case MorseMsg[i] of
       CW_SPEED_UP: SetSpeed(CurrentWpm + 2);
       CW_SPEED_DOWN: SetSpeed(CurrentWpm - 2);
-      '.': Inc(TrueEnvelopeLen, 2 * SamplesInUnit); // dit and spacing
-      '-': Inc(TrueEnvelopeLen, 4 * SamplesInUnit); // dash and spacing
-      ' ': Inc(TrueEnvelopeLen, 2 * SamplesInUnit); // inter-char space
+      '.': Inc(TrueEnvelopeLen, 2 * SamplesInUnit); // 1 unit dit followed by 1 unit spacing
+      '-': Inc(TrueEnvelopeLen, 4 * SamplesInUnit); // 3 unit dash followed by 1 unit spacing
+      ' ': Inc(TrueEnvelopeLen, 2 * SamplesInUnit); // 3U inter-char space (2U + prior 1U)
     { ' ': subsequent space } // 5U inter-word space (2U + prior 3U)
-      '~': Inc(TrueEnvelopeLen, 3 * SamplesInUnit); // inter-msg space
+      '~': Inc(TrueEnvelopeLen, 3 * SamplesInUnit); // 4U inter-msg space (3U + prior 1U + loop time)
     end;
 
   //calc buffer size


### PR DESCRIPTION
During contests, some operators often send 5NN or 599 a little faster than the rest of an exchange. This PR lets MRCE reproduce that behaviour. It may catch the student out the first time, which is precisely the teaching value.

This is an older feature I had set aside on a private branch. The behaviour is small, although implementing it properly reaches into the core wpm and audio generator: internally, < and > adjust speed in the same style as N1MM, then restore it immediately after the report. Nothing except 5NN and 599 is affected.

I've tested it quite a bit, but a review is warranted.

I added an RC archive on my fork [here](https://github.com/yo3gnd/MorseRunner/releases/tag/faster-5nn-1) that is built on cb6c4c4c. Checksum `bccfc9f6a8d10309efb628c4bcd8b91fb85a32276d91eccaa5d24e0ea01d6b57` 