### PR TITLE
433 improve invalid callsign error check

### DIFF
--- a/ArrlSS.pas
+++ b/ArrlSS.pas
@@ -58,7 +58,7 @@ public
     out AExchSummary: string; out AExchError: string) : Boolean; override;
   procedure OnExchangeEditComplete; override;
   procedure SetHisCall(const ACall: string); override;
-  function CheckEnteredCallLength(const ACall: string;
+  function ValidateEnteredCall(const ACall: string;
     out AExchError: String) : boolean; override;
   function ValidateEnteredExchange(const ACall, AExch1, AExch2: string;
     out AExchError: String) : boolean; override;
@@ -347,16 +347,16 @@ end;
 
 
 {
-  Verify callsign using length-based check.
+  Verify callsign using RegExp-based check.
   For ARRL SS, if Call has been parsed, it is assumed valid; otherwise
   call the base class implementation.
 }
-function TSweepstakes.CheckEnteredCallLength(const ACall: string;
+function TSweepstakes.ValidateEnteredCall(const ACall: string;
   out AExchError: String) : boolean;
 begin
   AExchError := '';
   if ExchValidator.Call.IsEmpty then
-    Result := inherited CheckEnteredCallLength(ACall, AExchError)
+    Result := inherited ValidateEnteredCall(ACall, AExchError)
   else
     Result := True;
 end;

--- a/Contest.pas
+++ b/Contest.pas
@@ -87,7 +87,7 @@ type
     procedure OnExchangeEditComplete; virtual;
     procedure SetHisCall(const ACall: string); virtual;
 
-    function CheckEnteredCallLength(const ACall: string;
+    function ValidateEnteredCall(const ACall: string;
       out AExchError: String) : boolean; virtual;
     function ValidateEnteredExchange(const ACall, AExch1, AExch2: string;
       out AExchError: String) : boolean; virtual;
@@ -113,6 +113,7 @@ implementation
 uses
   SysUtils, RndFunc, Math, DxOper,
   PerlRegEx,
+  CallsignUtils,
   VCL.Graphics,       // clDefault
   Main, CallLst, DXCC;
 
@@ -586,14 +587,14 @@ end;
 
 
 {
-  Performs simple length check on a callsign.
-  Returns true for callsigns with 3 or more characters; false otherwise.
+  Performs RegEx-based validity check on a callsign.
+  Returns true for valid callsigns; false otherwise.
   Upon error, AExchError will contain a simple error message.
 }
-function TContest.CheckEnteredCallLength(const ACall: string;
+function TContest.ValidateEnteredCall(const ACall: string;
   out AExchError: String) : boolean;
 begin
-  Result := StringReplace(ACall, '?', '', [rfReplaceAll]).Length >= 3;
+  Result := CallsignUtils.IsValidCall(StringReplace(ACall, '?', '', [rfReplaceAll]));
   if not Result then
     AExchError := 'Invalid callsign';
 end;
@@ -647,7 +648,9 @@ function TContest.ValidateEnteredExchange(const ACall, AExch1, AExch2: string;
   end;
 
 begin
-  if not ValidateExchField1(AExch1) then
+  if not CallsignUtils.IsValidCall(ACall) then
+    AExchError := 'Invalid callsign'
+  else if not ValidateExchField1(AExch1) then
     AExchError := format('Missing/Invalid %s',
       [Exchange1Settings[Mainform.RecvExchTypes.Exch1].C])
   else if not ValidateExchField2(AExch2) then

--- a/Log.pas
+++ b/Log.pas
@@ -694,7 +694,7 @@ begin
     Call := StringReplace(Edit1.Text, '?', '', [rfReplaceAll]);
 
     // Verify callsign (simple length-based check); virtual
-    if not Tst.CheckEnteredCallLength(Call, ExchError) then
+    if not Tst.ValidateEnteredCall(Call, ExchError) then
       begin
         {Beep;}
         DisplayError(ExchError);

--- a/Main.pas
+++ b/Main.pas
@@ -415,6 +415,7 @@ uses
   DXCC, ARRLFD, NAQP, CWOPS, CQWW, CQWPX, ARRLDX, CWSST, ALLJA, ACAG,
   IARUHF, ARRLSS,
   MorseKey, FarnsKeyer, CallLst,
+  CallsignUtils,
   SysUtils, ShellApi, Crc32, Idhttp, Math, IniFiles,
   Dialogs, Vcl.FileCtrl, System.UITypes, TypInfo, ScoreDlg, Log, PerlRegEx, StrUtils,
   DateUtils, ShlObj;
@@ -889,9 +890,9 @@ begin
 
     '.', '+', '[', ',': //TU & Save
       begin
-        // verify callsign using simple length-based check
+        // verify callsign using a RegEx-based check
         var ExchError: string;
-        if not Tst.CheckEnteredCallLength(Edit1.Text, ExchError) then
+        if not Tst.ValidateEnteredCall(Edit1.Text, ExchError) then
           begin
             DisplayError(ExchError);
             Exit;
@@ -1128,7 +1129,7 @@ begin
   if (GetKeyState(VK_CONTROL) or GetKeyState(VK_SHIFT) or GetKeyState(VK_MENU)) < 0 then
   begin
     // verify callsign before calling SaveQSO
-    if not Tst.CheckEnteredCallLength(Edit1.Text, ExchError) then
+    if not Tst.ValidateEnteredCall(Edit1.Text, ExchError) then
       begin
         DisplayError(ExchError);
         Exit;
@@ -1162,9 +1163,9 @@ begin
   // Update CallSent (HisCall has been sent)
   Tst.OnExchangeEditComplete;
 
-  // Has user entered a complete callsign (3 or more characters)?
+  // Has user entered a complete callsign?
   ValidCall := (Pos('?', Edit1.Text) = 0) and
-               Tst.CheckEnteredCallLength(Edit1.Text, ExchError);
+                Tst.ValidateEnteredCall(Edit1.Text, ExchError);
   ExchError := '';
 
   // clear prior error string
@@ -1208,7 +1209,7 @@ begin
     Log.SaveQso;
   end
   else
-    MustAdvance := true;
+    MustAdvance := ValidCall;
 end;
 
 

--- a/Src/Persistence/ContestFileReader.pas
+++ b/Src/Persistence/ContestFileReader.pas
@@ -239,6 +239,14 @@ TContestFileReader<TCallRec: class, constructor> = class
 
       Derived readers typically override ConfigureBindings and use
       AddBinding instead.
+
+      Example usage:
+        Reader := TContestFileReader<TCallOnlyRec>.Create([cffN1MMCsv, cffArrlTsv]);
+        Reader.AddDefaultBinding('Call', True,
+          procedure(const Value: string; Rec: TCallOnlyRec)
+          begin
+            Rec.Call := Value.ToUpper;
+          end);
     }
     procedure AddDefaultBinding(
       const ColumnName: string;

--- a/Test/CallsignUtilsTest.pas
+++ b/Test/CallsignUtilsTest.pas
@@ -39,6 +39,16 @@ type
     [TestCase('No Valid Prefix',      '123ABC,')]   // Invalid callsign format
     [TestCase('Invalid Characters',   '@#CALL,')]   // Callsign contains invalid characters
     [TestCase('Incomplete Portable',  'F6/,')]      // Invalid callsign without proper format
+    [TestCase('Incomplete Portable2', 'F6/W,')]     // Invalid callsign without proper format
+    [TestCase('Incomplete Portable3', 'F6/W7,')]    // Invalid callsign without proper format
+    [TestCase('Invalid_Short1',       'W,')]
+    [TestCase('Invalid_Short2',       'W7,')]
+    [TestCase('Invalid_Short3',       'KD7,')]
+    [TestCase('Invalid_Short4',       'DL,')]
+    [TestCase('Invalid_OnlyDigit',    '43,')]
+    [TestCase('Invalid_LeadingDigit1','43T,')]
+    [TestCase('Invalid_LeadingDigit2','7QCU,')]
+    [TestCase('Invalid_LeadingDigit3','7Q3,')]
     procedure TestExtractCallsign(const AFullCall, AExpected: string);
 
     // --- ExtractPrefix Tests (w/ WPX Contest Rules) ---
@@ -216,6 +226,10 @@ type
     [TestCase('W7SST/W',          'W7SST/W,W7')]  // should be 'W0'
     [TestCase('F6FVY/W7',         'F6FVY/W7,F6')] // should be 'W7'
     procedure TestExtractPrefix0(const AFullCall, AExpected: String);
+
+    [Test(True)]
+    [Category('IsValidCallsign')]
+    procedure IsValidCallsign_Across_Multiple_Files;
   end;
 
 implementation
@@ -224,6 +238,10 @@ uses
   //TypInfo,          // for typeInfo
   PerlRegEx,
   CallsignUtils,
+  ContestFileReader,
+  ContestFileFormat,
+  AppPaths,
+  System.Generics.Collections,
   System.SysUtils;
 
 procedure TestCallsignUtils.SetupFixture;
@@ -236,6 +254,7 @@ end;
 procedure TestCallsignUtils.TestExtractCallsign(const AFullCall, AExpected: string);
 var
   FullCall, Expected: String;
+  IsValid: Boolean;
   S: string;
 
   procedure RunAlgo(var S: String; const AFullcall, AExpected: String);
@@ -259,6 +278,19 @@ begin
 
   RunAlgo(S, FullCall, Expected);
   if S <> '' then Assert.Fail(S);
+
+  {
+    The following IsValidCall(callsign) test is added into this existing unit
+    test function.
+    The expected argument indicates callsign validity:
+      Expected.IsEmpty=True  --> Callsign should be invalid
+      Expected.IsEmpty=False --> Callsign should be valid
+  }
+  IsValid := CallsignUtils.IsValidCall(AFullCall);
+  if Expected.IsEmpty then
+    Assert.IsFalse(IsValid, 'IsValidCall(%s) = True; should be False')
+  else
+    Assert.IsTrue(IsValid, 'IsValidCall(%s) = False; should be True');
 end;
 
 procedure TestCallsignUtils.TestExtractPrefixWpx(const ACallsign, AExpected: string);
@@ -338,6 +370,61 @@ procedure TestCallsignUtils.TestExtractPrefix0(const AFullCall, AExpected: Strin
 begin
   Assert.AreEqual(ExtractPrefix0(AFullCall.Trim), AExpected.Trim);
 end;
+
+type TCallOnlyRec = class
+public
+  Call: string;
+end;
+
+procedure TestCallsignUtils.IsValidCallsign_Across_Multiple_Files;
+var
+  Reader: TContestFileReader<TCallOnlyRec>;
+  UniqueCalls: TDictionary<string,byte>;
+  InvalidCalls: TList<string>;
+begin
+  Reader := TContestFileReader<TCallOnlyRec>.Create([cffN1MMCsv, cffArrlTsv]);
+  UniqueCalls := TDictionary<string,byte>.Create;
+  InvalidCalls := TList<string>.Create;
+
+  try
+    Reader.AddDefaultBinding('Call', True,
+      procedure(const Value: string; Rec: TCallOnlyRec)
+      begin
+        Rec.Call := Value.ToUpper;
+      end);
+
+    Reader.ReadFiles(
+      [
+        // TAppPaths.ContestDataFile('arrl-10-2025.tsv'),
+        // TAppPaths.ContestDataFile('ARRL10M.txt'),
+        TAppPaths.ContestDataFile('ARRLDXCW_USDX.txt'),
+        TAppPaths.ContestDataFile('CQWWCW.txt'),
+        TAppPaths.ContestDataFile('FDGOTA.txt'),
+        TAppPaths.ContestDataFile('IARU_HF.txt'),
+        TAppPaths.ContestDataFile('K1USNSST.txt'),
+        TAppPaths.ContestDataFile('NAQPCW.txt'),
+        TAppPaths.ContestDataFile('SSCW.txt')
+      ],
+      procedure(Rec: TCallOnlyRec)
+      begin
+        if UniqueCalls.TryAdd(Rec.Call,0) then
+          if not CallsignUtils.IsValidCall(Rec.Call) then
+            InvalidCalls.Add(Rec.Call);
+        Rec.Free;
+      end);
+
+    if InvalidCalls.Count > 0 then
+      Assert.Fail(format(
+        'Found %d invalid callsigns: [%s] --> Please remove from call history files.',
+        [InvalidCalls.Count, string.join(', ', InvalidCalls.ToArray)]));
+
+  finally
+    Reader.Free;
+    UniqueCalls.Free;
+    InvalidCalls.Free;
+  end;
+end;
+
 
 initialization
   TDUnitX.RegisterTestFixture(TestCallsignUtils);

--- a/Util/CallsignUtils.pas
+++ b/Util/CallsignUtils.pas
@@ -9,6 +9,8 @@ interface
 
 function ExtractCallsign(Call: string): string;
 function ExtractPrefix(Call: string; DeleteTrailingLetters: boolean = True): string;
+function IsValidCall(Call: string): boolean;
+
 
 implementation
 
@@ -18,6 +20,7 @@ uses
 
 var
   CallsignRegex: TPerlRegEx;    // Compile the regex ONCE at initialization
+  ValidCallRegex: TPerlRegEx;   // Compile the regex ONCE at initialization
 
 // Code by BG4FQD
 function ExtractCallsign(Call: string):string;
@@ -132,13 +135,26 @@ begin
   Result := Copy(Result, 1, 5);
 end;
 
+
+function IsValidCall(Call: string): boolean;
+begin
+  ValidCallRegEx.Subject := UTF8Encode(Call);
+  Result := ValidCallRegEx.Match;
+end;
+
+
 initialization
   // Compile callsign regex only once at startup; free automatically.
   CallsignRegEx := TPerlRegEx.Create();
   CallsignRegEx.RegEx:= '(([0-9][A-Z])|([A-Z]{1,2}))[0-9][A-Z0-9]*[A-Z]';
   CallsignRegEx.Study;
 
+  ValidCallRegEx := TPerlRegEx.Create();
+  ValidCallRegEx.RegEx:= '(([0-9][A-Z])|([A-Z]{1,2}))[0-9][A-Z0-9]*[A-Z]';
+  ValidCallRegEx.Study;
+
 finalization
   CallsignRegEx.Free;
+  ValidCallRegEx.Free;
 
 end.


### PR DESCRIPTION
I decided to fix this using a regular expression representing common callsigns.

Here is the checkin note for this change:
#### Improve callsign validation when using Enter key

- Prior behavior was identifying valid callsigns by using a length-based
  check (3 or more characters).
- This is often invalid if the user only enters 'KD7' as a partial call.
- Pressing Enter would send this partial call and the report. The report
  should not be sent.
- With this fix, the callsign field is checked for validity against
  regular callsign rules.
- Now, after entering 'KD7', KD7 will be sent only without sending the
  user's report and the cursor will stay in the Callsign entry box.
- Once the user enters a complete callsign, the exchange report will be
  sent and the cursor advances to the next entry field.

#### Testing Results
I have updated the unit testing to confirm that this approach will work for all callsigns in the existing call history files. This approach in fact worked pretty well and found 5 invalid callsigns out of ~7000 calls. Here is the output of the updated unit testing:

```
Failing Tests

  CallsignUtilsTest.TestCallsignUtils.IsValidCallsign_Across_Multiple_Files
  Message: Found 7 invalid callsigns: [K400, KG20, KSOAT, KW20, VC1933, KI30, VYIJA] --> Please remove from call history files.
```

I will download new call history files to correct the above problems.

[Here is a build](https://1drv.ms/u/c/353d3bde42947823/IQBnIPvKak9gT4xKBjgs4J9VAQeVPp_nhwOmtTTJsJgWSWM?e=cjp44P) with the above fix.